### PR TITLE
fix(build): correct Wire sourcePath for protobufs submodule

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -74,7 +74,12 @@ kotlin {
 
 wire {
     sourcePath {
-        srcDir("../../protobufs")
+        srcDir("../protobufs")
+        include("meshtastic/*.proto")
+    }
+    protoPath {
+        srcDir("../protobufs")
+        include("nanopb.proto")
     }
     kotlin {
         makeImmutableCopies = false


### PR DESCRIPTION
## Problem

After switching from vendored proto files to the `protobufs` submodule (#15), the Wire `sourcePath` was misconfigured, breaking compilation for **all targets** (wasmJs was the most visible in CI since it finished first).

Three issues:
1. **Wrong relative path** — `../../protobufs` resolved outside the repo (should be `../protobufs`)
2. **Unparseable `.options` files** — the submodule contains nanopb `.options` files that Wire tries to read as proto definitions
3. **Missing link dependency** — `nanopb.proto` (imported by some meshtastic protos) needs to be available for schema linking but shouldn't generate code

## Fix

- Fix path to `../protobufs`
- Filter `sourcePath` to `meshtastic/*.proto` only
- Add `nanopb.proto` on `protoPath` (link-only; Wire's built-in well-known types handle its `descriptor.proto` import)

## Verification

Full CI baseline passes locally: `spotlessCheck`, `detekt`, `allTests`, `apiCheck` ✅