### PR TITLE
fix(ci): fix CodeQL build cache + add release concurrency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,7 @@ jobs:
         if: matrix.language == 'java-kotlin'
         run: |
           chmod +x gradlew
-          ./gradlew :library:compileKotlinJvm --no-daemon --stacktrace
+          ./gradlew :library:compileKotlinJvm --no-daemon --no-build-cache --stacktrace
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx2048M"
 


### PR DESCRIPTION
## What changed

- **CodeQL fix:** Added `--no-build-cache` to the Gradle build step in `codeql.yml`. The `compileKotlinJvm` task was served `FROM-CACHE`, so CodeQL's tracer never intercepted any compilation — causing the `java-kotlin` analysis to fail with *"no source code seen during build"*.

- **Release concurrency:** Added a `concurrency` block to `release.yml` with `cancel-in-progress: true`. This was the only workflow missing one. Each tag gets its own group via `github.ref`, so different version releases won't interfere.

Fixes #2 (unblocks the Renovate PR by fixing the pre-existing CodeQL failure)