### PR TITLE
feat(build): add remote build cache and Develocity build scans

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -1,0 +1,32 @@
+name: Gradle Setup
+description: Setup Java and Gradle for KMP builds
+inputs:
+  cache_read_only:
+    description: 'Whether Gradle cache is read-only'
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Copy CI Gradle properties
+      shell: bash
+      run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+    - name: Validate Gradle Wrapper
+      uses: gradle/actions/wrapper-validation@v6
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Make gradlew executable
+      shell: bash
+      run: chmod +x gradlew
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-read-only: ${{ inputs.cache_read_only }}
+        cache-cleanup: on-success
+        add-job-summary: always

--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,39 @@
+#
+# CI-specific Gradle properties.
+#
+# This file is copied to ~/.gradle/gradle.properties by the gradle-setup
+# composite action, overriding the dev-oriented values in the repo-root
+# gradle.properties.
+#
+
+# ── Daemon ────────────────────────────────────────────────────────────
+# Single-use CI runners never reuse a daemon, so the startup cost is pure
+# overhead. Disabling it also avoids "daemon disappeared" warnings.
+org.gradle.daemon=false
+
+# ── Memory ────────────────────────────────────────────────────────────
+# Standard GitHub runners have 7 GB RAM. Keep Gradle + Kotlin daemon
+# within budget (4g Gradle + 2g Kotlin daemon + 1g OS/tooling headroom).
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+kotlin.daemon.jvm.options=-Xmx2g -XX:+UseParallelGC
+
+# ── Parallelism ───────────────────────────────────────────────────────
+org.gradle.parallel=true
+org.gradle.workers.max=4
+
+# ── Caching & Configuration ──────────────────────────────────────────
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configureondemand=false
+org.gradle.vfs.watch=false
+
+# ── Kotlin ────────────────────────────────────────────────────────────
+# Incremental compilation is wasted on fresh CI checkouts (no prior build
+# state to diff against). Disabling avoids the overhead of maintaining
+# incremental state that will never be reused.
+kotlin.incremental=false
+kotlin.code.style=official
+kotlin.parallel.tasks.in.project=true
+
+# ── Misc ─────────────────────────────────────────────────────────────
+org.gradle.welcome=never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx2048M"
+  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
 jobs:
-  validate-wrapper:
-    name: Validate Gradle Wrapper
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: gradle/actions/wrapper-validation@v6
-
   lint:
-    needs: [validate-wrapper]
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -32,58 +25,31 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run spotlessCheck and detekt
-        run: ./gradlew spotlessCheck detekt --no-daemon --stacktrace
+        run: ./gradlew spotlessCheck detekt --stacktrace
 
   test-jvm:
     name: Test JVM
-    needs: [validate-wrapper]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run JVM tests and verify coverage
-        run: ./gradlew jvmTest koverVerify --no-daemon --stacktrace
+        run: ./gradlew jvmTest koverVerify --stacktrace
 
       - name: Generate coverage report
         if: always()
-        run: ./gradlew koverXmlReport --no-daemon --stacktrace
+        run: ./gradlew koverXmlReport --stacktrace
 
       - name: Upload coverage to Codecov
         if: always()
@@ -96,145 +62,79 @@ jobs:
 
   test-native-linux:
     name: Test Native Linux
-    needs: [validate-wrapper]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run Linux native tests
-        run: ./gradlew :library:linuxX64Test --no-daemon --stacktrace
+        run: ./gradlew :library:linuxX64Test --stacktrace
 
   test-native-macos:
     name: Test Native macOS
-    needs: [validate-wrapper]
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run macOS and iOS simulator tests
-        run: ./gradlew :library:macosArm64Test :library:iosSimulatorArm64Test --no-daemon --stacktrace
+        run: ./gradlew :library:macosArm64Test :library:iosSimulatorArm64Test --stacktrace
 
   test-wasm:
     name: Test wasmJs
-    needs: [validate-wrapper]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run wasmJs browser tests
-        run: ./gradlew wasmJsBrowserTest --no-daemon --stacktrace
+        run: ./gradlew wasmJsBrowserTest --stacktrace
 
   test-windows:
     name: Test Windows
-    needs: [validate-wrapper]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run Windows native tests
-        run: .\gradlew.bat :library:mingwX64Test --no-daemon --stacktrace
+        shell: bash
+        run: ./gradlew :library:mingwX64Test --stacktrace
 
   api-check:
     name: API Check
-    needs: [validate-wrapper]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Run API compatibility check
-        run: ./gradlew apiCheck --no-daemon --stacktrace
+        run: ./gradlew apiCheck --stacktrace
 
   build:
     name: Build
@@ -245,22 +145,9 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: ${{ github.event_name == 'pull_request' }}
 
       - name: Build
-        run: ./gradlew build --no-daemon --stacktrace
+        run: ./gradlew build --stacktrace

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx2048M"
+  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
 jobs:
   build-docs:
@@ -24,15 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: gradle/actions/setup-gradle@v6
+          cache_read_only: 'false'
 
       - name: Generate API documentation
-        run: ./gradlew dokkaGeneratePublicationHtml --no-daemon --stacktrace
+        run: ./gradlew dokkaGeneratePublicationHtml --stacktrace
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx2048M"
+  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
 permissions:
   contents: write
@@ -24,28 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+          cache_read_only: 'false'
 
       - name: Validate before publish
-        run: ./gradlew spotlessCheck detekt allTests apiCheck build --no-daemon --stacktrace
+        run: ./gradlew spotlessCheck detekt allTests apiCheck build --stacktrace
 
       - name: Publish to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-daemon --stacktrace
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
@@ -80,7 +69,7 @@ jobs:
             artifact_glob: |
               sample/build/compose/binaries/main-release/deb/*.deb
             web_zip: false
-          - os: macos-14
+          - os: macos-15
             label: macos-arm64
             tasks: :sample:packageReleaseDistributionForCurrentOS
             artifact_glob: |
@@ -96,27 +85,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: ./.github/actions/gradle-setup
         with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Make gradlew executable
-        if: runner.os != 'Windows'
-        run: chmod +x gradlew
+          cache_read_only: 'false'
 
       - name: Build sample artifacts
         shell: bash
-        run: ./gradlew ${{ matrix.tasks }} --no-daemon --stacktrace
+        run: ./gradlew ${{ matrix.tasks }} --stacktrace
 
       - name: Zip wasmJs browser distribution
         if: matrix.web_zip == true
@@ -185,4 +160,3 @@ jobs:
           subject-path: |
             sbom.cdx.json
             sbom.spdx.json
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.parallel=true
+org.gradle.vfs.watch=true
+org.gradle.welcome=never
 #Kotlin
 kotlin.code.style=official
 #MPP

--- a/gradle/develocity.settings.gradle
+++ b/gradle/develocity.settings.gradle
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+def getMeshProperty(String key) {
+    def env = System.getenv(key)
+    if (env) return env
+
+    def currentDir = settingsDir
+    while (currentDir != null) {
+        def localFile = new File(currentDir, "local.properties")
+        if (localFile.exists()) {
+            def props = new Properties()
+            localFile.withInputStream { props.load(it) }
+            if (props.containsKey(key)) return props.getProperty(key)
+        }
+        def configFile = new File(currentDir, "config.properties")
+        if (configFile.exists()) {
+            def props = new Properties()
+            configFile.withInputStream { props.load(it) }
+            if (props.containsKey(key)) return props.getProperty(key)
+        }
+        currentDir = currentDir.parentFile
+    }
+    return null
+}
+
+develocity {
+    buildScan {
+        capture {
+            fileFingerprints = true
+        }
+        // Publish scans in CI for build failure debugging and performance profiling.
+        // Uses scans.gradle.com free tier (public scans). Disabled locally.
+        def isCi = System.getenv("CI") != null
+        publishing.onlyIf { isCi }
+        uploadInBackground = !isCi
+        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+        termsOfUseAgree = "yes"
+    }
+    buildCache {
+        local {
+            enabled = true
+        }
+        remote(HttpBuildCache) {
+            // Some servers have issues with Expect: 100-continue and return 403.
+            useExpectContinue = false
+            def cacheUrl = getMeshProperty("GRADLE_CACHE_URL")?.trim()
+            def cacheUsername = getMeshProperty("GRADLE_CACHE_USERNAME")?.trim()
+            def cachePassword = getMeshProperty("GRADLE_CACHE_PASSWORD")?.trim()
+
+            if (cacheUrl) {
+                println "MQTTastic: Remote cache URL found."
+
+                // Ensure trailing slash for Develocity/GE servers
+                url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
+
+                if (cacheUsername && cachePassword) {
+                    credentials {
+                        username = cacheUsername
+                        password = cachePassword
+                    }
+                }
+
+                allowInsecureProtocol = true
+                allowUntrustedServer = true
+
+                // Keep push enabled if credentials are provided.
+                // This naturally disables push for fork PRs which don't have access to secrets.
+                push = (cacheUsername && cachePassword)
+
+                enabled = true
+            } else {
+                enabled = false
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,12 @@ pluginManagement {
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+    id("com.gradle.develocity") version "4.4.0"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
 }
+
+// Shared Develocity and Build Cache configuration
+apply(from = "gradle/develocity.settings.gradle")
 
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
## Summary

Add hosted remote build cache and Develocity build scans, matching the pattern established in meshtastic/Meshtastic-Android.

## Changes

### Remote Build Cache
- **Develocity 4.4.0** plugin with build scans (CI-only, free tier at scans.gradle.com)
- **HTTP remote cache** at `gradle.hiddentemple.xyz` — shared with Meshtastic-Android
  - Push on main/merge-queue, read-only on PRs, auto-disabled for forks (no secrets)
  - Credentials via env vars (CI) or `local.properties` (local dev)

### CI Infrastructure
- **`.github/actions/gradle-setup`** composite action centralizing Java 21 + Gradle + wrapper validation + CI-tuned properties
- **`.github/ci-gradle.properties`** with CI-specific JVM tuning (4g heap, parallel GC, no daemon, no incremental compilation)
- Removed standalone `validate-wrapper` job (absorbed into composite action — all CI jobs now start in parallel immediately)

### Local Dev Improvements
- `org.gradle.parallel=true` — parallel task execution
- `org.gradle.vfs.watch=true` — file system watching for faster incremental builds

## Setup Required

Add 4 GitHub repository secrets:
- `GRADLE_CACHE_URL` — `https://gradle.hiddentemple.xyz/cache`
- `GRADLE_CACHE_USERNAME` / `GRADLE_CACHE_PASSWORD`
- `GRADLE_ENCRYPTION_KEY` — any random string (encrypts Gradle home cache in Actions)