### PR TITLE
fix(test): resolve Kotlin compiler warnings in test sources

### DIFF
--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.mqtt
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import org.meshtastic.mqtt.packet.MqttPacket
 import org.meshtastic.mqtt.packet.decodePacket
@@ -57,6 +58,7 @@ internal class FakeTransport : MqttTransport {
     override suspend fun connect(endpoint: MqttEndpoint) {
         connectError?.let { throw it }
         // Recreate receive channel if it was closed (supports reconnect testing)
+        @OptIn(ExperimentalCoroutinesApi::class)
         if (receiveChannel.isClosedForSend) {
             receiveChannel = Channel(Channel.UNLIMITED)
         }

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttClientTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttClientTest.kt
@@ -520,7 +520,7 @@ class MqttClientTest {
                             if (publish != null && publish.packetIdentifier != null) {
                                 transport.enqueuePacket(
                                     org.meshtastic.mqtt.packet.PubAck(
-                                        packetIdentifier = publish.packetIdentifier!!,
+                                        packetIdentifier = publish.packetIdentifier,
                                     ),
                                 )
                                 break

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttConnectionTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttConnectionTest.kt
@@ -160,7 +160,7 @@ class MqttConnectionTest {
             assertIs<Connect>(sent)
             assertEquals("last-will/topic", sent.willTopic)
             assertNotNull(sent.willPayload)
-            assertEquals("goodbye", sent.willPayload?.decodeToString())
+            assertEquals("goodbye", sent.willPayload.decodeToString())
             assertEquals(QoS.AT_LEAST_ONCE, sent.willQos)
             assertEquals(true, sent.willRetain)
             assertEquals(60L, sent.willProperties.willDelayInterval)


### PR DESCRIPTION
## Summary

Fixes 3 Kotlin compiler warnings that appear on every CI target (JVM, wasmJs, native, build):

- **`FakeTransport.kt:60`** — `Channel.isClosedForSend` is a delicate API; added `@OptIn(ExperimentalCoroutinesApi::class)`
- **`MqttClientTest.kt:523`** — removed unnecessary `            {                 echo ___BEGIN___COMMAND_OUTPUT_MARKER___;                 PS1=;PS2=;unset HISTFILE;                 EC=0;                 echo ___BEGIN___COMMAND_DONE_MARKER___0;             }` on a non-null receiver (already smart-cast by `!= null` check)
- **`MqttConnectionTest.kt:163`** — removed unnecessary `?.` safe call on a non-null receiver (already smart-cast by `assertNotNull`)

## Verification

- `jvmTest` passes with zero compiler warnings
- `spotlessCheck` passes