### PR TITLE
chore(ci): configure Maven Central publishing with build attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,35 @@ jobs:
       - name: Validate before publish
         run: ./gradlew spotlessCheck detekt allTests apiCheck build --stacktrace
 
+      - name: Stage signed artifacts locally
+        run: ./gradlew publishToMavenLocal --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: Collect Maven artifacts for attestation
+        shell: bash
+        run: |
+          mkdir -p maven-staging
+          cd ~/.m2/repository
+          find org/meshtastic -type f \
+            -not -name "maven-metadata*" \
+            -not -name "*.md5" \
+            -not -name "*.sha1" \
+            -not -name "*.sha256" \
+            -not -name "*.sha512" \
+            | while IFS= read -r f; do
+              mkdir -p "${{ github.workspace }}/maven-staging/$(dirname "$f")"
+              cp "$f" "${{ github.workspace }}/maven-staging/$f"
+            done
+          echo "Staged $(find "${{ github.workspace }}/maven-staging" -type f | wc -l) files for attestation"
+
+      - name: Attest Maven artifacts
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: maven-staging/**/*
+
       - name: Publish to Maven Central
         run: ./gradlew publishAllPublicationsToMavenCentralRepository --stacktrace
         env:
@@ -127,6 +156,12 @@ jobs:
         with:
           files: release-assets/*
           fail_on_unmatched_files: false
+
+      - name: Attest sample artifacts
+        if: steps.collect.outputs.count != '0'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: release-assets/*
 
   sbom:
     name: SBOM & Provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
 


### PR DESCRIPTION
## What changed

- Add `signingInMemoryKeyId` to release workflow for reliable in-memory GPG signing
- Add Sigstore build attestation for **Maven artifacts** (stage → attest → publish flow)
- Add Sigstore build attestation for **sample binaries** (APK, DMG, MSI, DEB, wasm)

## Why

Maven Central requires GPG signatures (signer identity), but Sigstore attestation adds **CI provenance** — proving artifacts were built by this repo's GitHub Actions workflow. These are complementary trust layers.

## Setup completed (not in this PR)

- GPG key `E7CC2A92` generated and uploaded to `keys.openpgp.org`
- GitHub secrets configured: `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `SIGNING_KEY`, `SIGNING_KEY_ID`, `SIGNING_PASSWORD`
- Local signed publish verified (`publishToMavenLocal` — all 10 targets with `.asc` signatures)

## Release flow

```
git tag v0.1.0 && git push origin v0.1.0
```

Pipeline: validate → stage locally → attest (Sigstore) → publish to Central → GitHub Release → attest sample binaries → SBOMs