### PR TITLE
fix(ci): resolve CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttPacket.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttPacket.kt
@@ -299,17 +299,21 @@ internal data class UnsubAck(
 // --- §3.12 PINGREQ ---
 
 /** PINGREQ packet — client keepalive ping (§3.12). No variable header or payload. */
-internal data object PingReq : MqttPacket {
+internal object PingReq : MqttPacket {
     override val packetType: PacketType get() = PacketType.PINGREQ
     override val properties: MqttProperties get() = MqttProperties.EMPTY
+
+    override fun toString(): String = "PingReq"
 }
 
 // --- §3.13 PINGRESP ---
 
 /** PINGRESP packet — server keepalive ping response (§3.13). No variable header or payload. */
-internal data object PingResp : MqttPacket {
+internal object PingResp : MqttPacket {
     override val packetType: PacketType get() = PacketType.PINGRESP
     override val properties: MqttProperties get() = MqttProperties.EMPTY
+
+    override fun toString(): String = "PingResp"
 }
 
 // --- §3.14 DISCONNECT ---


### PR DESCRIPTION
## Summary

Resolves 9 of the 12 open CodeQL code-scanning alerts. The remaining 3 (unpinned action tags) will be closed separately.

### Changes

- **`ci.yml`** — Add top-level `permissions: contents: read` to satisfy all 8 `actions/missing-workflow-permissions` alerts (#43–#50)
- **`MqttPacket.kt`** — Change `PingReq`/`PingResp` from `data object` to `object` with explicit `toString()` to eliminate the unread local variable bytecode artifact flagged by CodeQL (#22). These are propertyless singletons — `data object` added no value.

### Verification

- `spotlessCheck`, `detekt`, `jvmTest`, and `apiCheck` all pass locally.