### PR TITLE
feat(client)!: ConnectionState carries disconnect reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+- **`ConnectionState` is now a `sealed class`** (was an `enum`) so disconnect / reconnect events
+  carry diagnostic context. Pattern-match with `is` instead of `==`:
+  - `Connecting` (object)
+  - `Connected` (object)
+  - `Reconnecting(attempt, lastError)` — current attempt count and last failure observed
+  - `Disconnected(reason)` — `reason: MqttException?`. Use `Disconnected.Idle` for the
+    no-reason singleton (idle/initial/intentional-close states).
+- **Migration:** `state == ConnectionState.CONNECTED` → `state is ConnectionState.Connected`,
+  `state == ConnectionState.DISCONNECTED` → `state is ConnectionState.Disconnected`.
+
+### Added
+- `ConnectionState.Disconnected.reason`: surfaces the failure that caused an unexpected
+  disconnect — `MqttException.ConnectionRejected` for broker rejections,
+  `MqttException.ConnectionLost` for transport-side / protocol-violation tear-downs,
+  including the server's `ReasonCode` from a server-initiated DISCONNECT (§4.13).
+- `ConnectionState.Reconnecting.lastError`: the most recent reconnect attempt failure,
+  enabling consumers to render meaningful "retrying — DNS failed (3/10)" UX.
+
 ## [0.1.0] - 2026-04-16
 
 ### Added

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -13,14 +13,49 @@ public final class org/meshtastic/mqtt/AuthChallenge {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/meshtastic/mqtt/ConnectionState : java/lang/Enum {
-	public static final field CONNECTED Lorg/meshtastic/mqtt/ConnectionState;
-	public static final field CONNECTING Lorg/meshtastic/mqtt/ConnectionState;
-	public static final field DISCONNECTED Lorg/meshtastic/mqtt/ConnectionState;
-	public static final field RECONNECTING Lorg/meshtastic/mqtt/ConnectionState;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lorg/meshtastic/mqtt/ConnectionState;
-	public static fun values ()[Lorg/meshtastic/mqtt/ConnectionState;
+public abstract class org/meshtastic/mqtt/ConnectionState {
+}
+
+public final class org/meshtastic/mqtt/ConnectionState$Connected : org/meshtastic/mqtt/ConnectionState {
+	public static final field INSTANCE Lorg/meshtastic/mqtt/ConnectionState$Connected;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/meshtastic/mqtt/ConnectionState$Connecting : org/meshtastic/mqtt/ConnectionState {
+	public static final field INSTANCE Lorg/meshtastic/mqtt/ConnectionState$Connecting;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/meshtastic/mqtt/ConnectionState$Disconnected : org/meshtastic/mqtt/ConnectionState {
+	public static final field Companion Lorg/meshtastic/mqtt/ConnectionState$Disconnected$Companion;
+	public fun <init> ()V
+	public fun <init> (Lorg/meshtastic/mqtt/MqttException;)V
+	public synthetic fun <init> (Lorg/meshtastic/mqtt/MqttException;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/meshtastic/mqtt/MqttException;
+	public final fun copy (Lorg/meshtastic/mqtt/MqttException;)Lorg/meshtastic/mqtt/ConnectionState$Disconnected;
+	public static synthetic fun copy$default (Lorg/meshtastic/mqtt/ConnectionState$Disconnected;Lorg/meshtastic/mqtt/MqttException;ILjava/lang/Object;)Lorg/meshtastic/mqtt/ConnectionState$Disconnected;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Lorg/meshtastic/mqtt/MqttException;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/meshtastic/mqtt/ConnectionState$Disconnected$Companion {
+	public final fun getIdle ()Lorg/meshtastic/mqtt/ConnectionState$Disconnected;
+}
+
+public final class org/meshtastic/mqtt/ConnectionState$Reconnecting : org/meshtastic/mqtt/ConnectionState {
+	public fun <init> (ILorg/meshtastic/mqtt/MqttException;)V
+	public synthetic fun <init> (ILorg/meshtastic/mqtt/MqttException;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Lorg/meshtastic/mqtt/MqttException;
+	public final fun copy (ILorg/meshtastic/mqtt/MqttException;)Lorg/meshtastic/mqtt/ConnectionState$Reconnecting;
+	public static synthetic fun copy$default (Lorg/meshtastic/mqtt/ConnectionState$Reconnecting;ILorg/meshtastic/mqtt/MqttException;ILjava/lang/Object;)Lorg/meshtastic/mqtt/ConnectionState$Reconnecting;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttempt ()I
+	public final fun getLastError ()Lorg/meshtastic/mqtt/MqttException;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/meshtastic/mqtt/MqttClient {

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/ConnectionState.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/ConnectionState.kt
@@ -17,23 +17,46 @@
 package org.meshtastic.mqtt
 
 /**
- * Observable connection lifecycle states for [MqttClient].
+ * Observable connection lifecycle state for [MqttClient].
  *
  * Collect [MqttClient.connectionState] as a [kotlinx.coroutines.flow.StateFlow] to
- * observe state transitions and react to connectivity changes in your application.
+ * observe state transitions and react to connectivity changes — including the
+ * underlying cause when a connection drops or a reconnect attempt fails.
  *
- * Typical lifecycle: [DISCONNECTED] → [CONNECTING] → [CONNECTED] → [DISCONNECTED].
+ * Typical lifecycle: [Disconnected] → [Connecting] → [Connected] → [Disconnected].
  * When auto-reconnect is enabled and a connection drops unexpectedly:
- * [CONNECTED] → [RECONNECTING] → [CONNECTED] (or [DISCONNECTED] on permanent failure).
+ * [Connected] → [Reconnecting] → [Connected] (or [Disconnected] on permanent failure).
+ *
+ * ## Example — react to disconnect reasons
+ * ```kotlin
+ * client.connectionState.collect { state ->
+ *     when (state) {
+ *         is ConnectionState.Connected -> println("Online")
+ *         is ConnectionState.Connecting -> println("Connecting...")
+ *         is ConnectionState.Reconnecting -> println("Reconnecting (attempt ${state.attempt})")
+ *         is ConnectionState.Disconnected -> when (val reason = state.reason) {
+ *             null -> println("Offline")
+ *             else -> println("Offline: ${reason.reasonCode} — ${reason.message}")
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * ## Migration from 0.1.x
+ * In 0.1.x `ConnectionState` was an enum with `CONNECTING`/`CONNECTED`/`DISCONNECTED`/
+ * `RECONNECTING` constants. Replace equality checks (`state == ConnectionState.CONNECTED`)
+ * with `is` checks (`state is ConnectionState.Connected`).
  */
-public enum class ConnectionState {
+public sealed class ConnectionState {
     /**
      * Actively establishing a connection to the broker.
      *
      * The CONNECT packet has been (or is about to be) sent and the client
      * is awaiting a CONNACK response.
      */
-    CONNECTING,
+    public object Connecting : ConnectionState() {
+        override fun toString(): String = "Connecting"
+    }
 
     /**
      * Successfully connected to the broker and ready for publish/subscribe operations.
@@ -41,25 +64,48 @@ public enum class ConnectionState {
      * The CONNECT/CONNACK handshake completed with [org.meshtastic.mqtt.packet.ReasonCode.SUCCESS].
      * The background read loop and keepalive timer are active.
      */
-    CONNECTED,
-
-    /**
-     * Not connected to any broker.
-     *
-     * Either no connection has been attempted, or the last connection was
-     * closed — either by [MqttClient.disconnect]/[MqttClient.close] or
-     * due to a broker-initiated DISCONNECT.
-     */
-    DISCONNECTED,
+    public object Connected : ConnectionState() {
+        override fun toString(): String = "Connected"
+    }
 
     /**
      * Attempting to re-establish a lost connection.
      *
      * Entered automatically when the connection drops unexpectedly and
-     * [MqttConfig.autoReconnect] is `true`. Uses exponential backoff
-     * between attempts (configurable via [MqttConfig.reconnectBaseDelayMs]
-     * and [MqttConfig.reconnectMaxDelayMs]). Subscriptions are automatically
+     * [MqttConfig.autoReconnect] is `true`. Uses exponential backoff between
+     * attempts (configurable via [MqttConfig.reconnectBaseDelayMs] and
+     * [MqttConfig.reconnectMaxDelayMs]). Subscriptions are automatically
      * re-established on successful reconnection.
+     *
+     * @property attempt 1-based count of reconnect attempts performed so far.
+     *   `0` indicates the reconnect loop has just started and no attempt has
+     *   been made yet.
+     * @property lastError The most recent failure that triggered or extended
+     *   reconnection, or `null` if reconnect was triggered by a graceful
+     *   transport drop with no exception.
      */
-    RECONNECTING,
+    public data class Reconnecting(
+        val attempt: Int,
+        val lastError: MqttException? = null,
+    ) : ConnectionState()
+
+    /**
+     * Not connected to any broker.
+     *
+     * Either no connection has been attempted, the last connection was closed
+     * by [MqttClient.disconnect]/[MqttClient.close], or it was lost due to a
+     * broker-initiated DISCONNECT or transport failure.
+     *
+     * @property reason The error that caused the disconnect, or `null` for an
+     *   intentional disconnect via [MqttClient.disconnect]/[MqttClient.close]
+     *   and for the initial state before any connection has been attempted.
+     */
+    public data class Disconnected(
+        val reason: MqttException? = null,
+    ) : ConnectionState() {
+        public companion object {
+            /** Stable singleton for the initial idle / "no reason" state. */
+            public val Idle: Disconnected = Disconnected(reason = null)
+        }
+    }
 }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
@@ -147,9 +147,9 @@ import kotlin.concurrent.Volatile
  * ```kotlin
  * client.connectionState.collect { state ->
  *     when (state) {
- *         ConnectionState.CONNECTED -> println("Online")
- *         ConnectionState.RECONNECTING -> println("Reconnecting...")
- *         ConnectionState.DISCONNECTED -> println("Offline")
+ *         is ConnectionState.Connected -> println("Online")
+ *         is ConnectionState.Reconnecting -> println("Reconnecting...")
+ *         is ConnectionState.Disconnected -> println("Offline")
  *         else -> { /* CONNECTING */ }
  *     }
  * }
@@ -257,13 +257,13 @@ public class MqttClient
 
         private val scope = CoroutineScope(SupervisorJob(scope.coroutineContext[Job]) + scope.coroutineContext.minusKey(Job))
 
-        private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+        private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected.Idle)
 
         /**
          * Observable connection lifecycle state.
          *
          * Emits [ConnectionState] transitions as the client connects, disconnects,
-         * and reconnects. Starts as [ConnectionState.DISCONNECTED].
+         * and reconnects. Starts as [ConnectionState.Disconnected.Idle].
          *
          * @see ConnectionState
          */
@@ -364,12 +364,16 @@ public class MqttClient
                     connectWithRedirect(endpoint, redirectsRemaining = MAX_REDIRECTS)
                 }
             } catch (e: MqttConnectionException) {
-                throw MqttException.ConnectionRejected(
-                    reasonCode = e.reasonCode,
-                    message = e.message ?: "Connection failed",
-                    cause = e.cause,
-                    serverReference = e.serverReference,
-                )
+                val rejected =
+                    MqttException.ConnectionRejected(
+                        reasonCode = e.reasonCode,
+                        message = e.message ?: "Connection failed",
+                        cause = e.cause,
+                        serverReference = e.serverReference,
+                    )
+                // Forwarding hasn't started yet (connection==null on failure), so we own the state.
+                _connectionState.value = ConnectionState.Disconnected(reason = rejected)
+                throw rejected
             }
         }
 
@@ -396,7 +400,7 @@ public class MqttClient
                 } finally {
                     stopForwardJobs()
                     connection = null
-                    _connectionState.value = ConnectionState.DISCONNECTED
+                    _connectionState.value = ConnectionState.Disconnected.Idle
                     log.info(TAG) { "Disconnected" }
                 }
             }
@@ -635,7 +639,7 @@ public class MqttClient
                 } finally {
                     stopForwardJobs()
                     connection = null
-                    _connectionState.value = ConnectionState.DISCONNECTED
+                    _connectionState.value = ConnectionState.Disconnected.Idle
                 }
             }
             scope.coroutineContext[Job]?.cancel()
@@ -667,7 +671,7 @@ public class MqttClient
                 } finally {
                     stopForwardJobs()
                     connection = null
-                    _connectionState.value = ConnectionState.DISCONNECTED
+                    _connectionState.value = ConnectionState.Disconnected.Idle
                 }
             }
             scope.coroutineContext[Job]?.cancel()
@@ -731,7 +735,7 @@ public class MqttClient
                 scope.launch {
                     conn.connectionState.collect { state ->
                         _connectionState.value = state
-                        if (state == ConnectionState.DISCONNECTED &&
+                        if (state is ConnectionState.Disconnected &&
                             config.autoReconnect &&
                             !intentionalDisconnect
                         ) {
@@ -778,9 +782,13 @@ public class MqttClient
                 if (reconnectJob?.isActive == true) return
                 reconnectJob =
                     scope.launch {
-                        _connectionState.value = ConnectionState.RECONNECTING
+                        // Carry forward the cause from the just-observed Disconnected state, if any.
+                        var lastError: MqttException? =
+                            (_connectionState.value as? ConnectionState.Disconnected)?.reason
                         var delayMs = config.reconnectBaseDelayMs
                         var attempts = 0
+                        _connectionState.value =
+                            ConnectionState.Reconnecting(attempt = attempts, lastError = lastError)
 
                         log.warn(TAG) { "Connection lost, starting reconnect" }
 
@@ -790,7 +798,8 @@ public class MqttClient
                                 log.error(TAG) {
                                     "Max reconnect attempts ($attempts) exhausted — giving up"
                                 }
-                                _connectionState.value = ConnectionState.DISCONNECTED
+                                _connectionState.value =
+                                    ConnectionState.Disconnected(reason = lastError)
                                 return@launch
                             }
 
@@ -816,8 +825,10 @@ public class MqttClient
                                 @Suppress("TooGenericExceptionCaught") e: Exception,
                             ) {
                                 attempts++
+                                lastError = e.toMqttException()
                                 log.warn(TAG, throwable = e) { "Reconnect attempt $attempts failed" }
-                                _connectionState.value = ConnectionState.RECONNECTING
+                                _connectionState.value =
+                                    ConnectionState.Reconnecting(attempt = attempts, lastError = lastError)
                                 delayMs = (delayMs * 2).coerceAtMost(config.reconnectMaxDelayMs)
                             }
                         }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -101,7 +101,7 @@ internal class MqttConnection(
     private val log: MqttLoggerInternal = MqttLoggerInternal.NOOP,
     private val timeSource: TimeSource = TimeSource.Monotonic,
 ) {
-    private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+    private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected.Idle)
 
     /** Observable connection state. */
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
@@ -187,7 +187,7 @@ internal class MqttConnection(
      * @throws MqttConnectionException if the broker rejects the connection.
      */
     suspend fun connect(endpoint: MqttEndpoint): ConnAck {
-        _connectionState.value = ConnectionState.CONNECTING
+        _connectionState.value = ConnectionState.Connecting
 
         if (!config.cleanStart) {
             log.warn(TAG) {
@@ -210,7 +210,7 @@ internal class MqttConnection(
             if (connAck.reasonCode != ReasonCode.SUCCESS) {
                 log.error(TAG) { "Connection refused: ${connAck.reasonCode}" }
                 transport.close()
-                _connectionState.value = ConnectionState.DISCONNECTED
+                _connectionState.value = ConnectionState.Disconnected.Idle
                 val serverRef = connAck.properties.serverReference
                 throw MqttConnectionException(
                     connAck.reasonCode,
@@ -265,7 +265,7 @@ internal class MqttConnection(
                     (assignedClientId?.let { ", assignedClientId=$it" } ?: "")
             }
 
-            _connectionState.value = ConnectionState.CONNECTED
+            _connectionState.value = ConnectionState.Connected
             startReadLoop()
             startKeepAlive()
 
@@ -282,7 +282,7 @@ internal class MqttConnection(
             ) {
                 // Best-effort transport close
             }
-            _connectionState.value = ConnectionState.DISCONNECTED
+            _connectionState.value = ConnectionState.Disconnected.Idle
             throw MqttConnectionException(
                 ReasonCode.UNSPECIFIED_ERROR,
                 "Connection timed out: no CONNACK received within ${ACK_TIMEOUT_MS}ms",
@@ -301,7 +301,7 @@ internal class MqttConnection(
             ) {
                 // Best-effort transport close on handshake failure
             }
-            _connectionState.value = ConnectionState.DISCONNECTED
+            _connectionState.value = ConnectionState.Disconnected.Idle
             throw MqttConnectionException(ReasonCode.UNSPECIFIED_ERROR, "Connection failed: ${e.message}", e)
         }
     }
@@ -386,7 +386,8 @@ internal class MqttConnection(
     }
 
     private suspend fun resetConnectionState() {
-        _connectionState.value = ConnectionState.DISCONNECTED
+        // Caller-initiated graceful disconnect — no failure reason.
+        _connectionState.value = ConnectionState.Disconnected.Idle
         if (config.cleanStart) {
             packetIdAllocator.reset()
         }
@@ -423,7 +424,7 @@ internal class MqttConnection(
      * @return Reason code from the acknowledgement, or `null` for QoS 0.
      */
     suspend fun publish(message: MqttMessage): ReasonCode? {
-        check(_connectionState.value == ConnectionState.CONNECTED) { "Not connected" }
+        check(_connectionState.value is ConnectionState.Connected) { "Not connected" }
 
         // Enforce server Maximum QoS (§3.2.2.3.4)
         require(message.qos <= serverMaximumQos) {
@@ -478,7 +479,7 @@ internal class MqttConnection(
         subscriptions: List<Subscription>,
         properties: MqttProperties = MqttProperties.EMPTY,
     ): SubAck {
-        check(_connectionState.value == ConnectionState.CONNECTED) { "Not connected" }
+        check(_connectionState.value is ConnectionState.Connected) { "Not connected" }
 
         // Enforce shared subscription availability (§4.8.2)
         if (!serverSharedSubscriptionAvailable) {
@@ -546,7 +547,7 @@ internal class MqttConnection(
         topicFilters: List<String>,
         properties: MqttProperties = MqttProperties.EMPTY,
     ): UnsubAck {
-        check(_connectionState.value == ConnectionState.CONNECTED) { "Not connected" }
+        check(_connectionState.value is ConnectionState.Connected) { "Not connected" }
 
         val packetId = packetIdAllocator.allocate()
         val deferred = CompletableDeferred<MqttPacket>()
@@ -783,7 +784,7 @@ internal class MqttConnection(
                 ) {
                     if (isActive) {
                         log.error(TAG, throwable = e) { "Read loop error: ${e.message}" }
-                        handleFatalError()
+                        handleFatalError(cause = e)
                     }
                 }
                 log.debug(TAG) { "Read loop stopped" }
@@ -791,17 +792,30 @@ internal class MqttConnection(
     }
 
     /** Centralized fatal error handler: tear down resources and fail all pending waiters. */
-    private suspend fun handleFatalError(reasonCode: ReasonCode = ReasonCode.UNSPECIFIED_ERROR) {
+    private suspend fun handleFatalError(
+        reasonCode: ReasonCode = ReasonCode.UNSPECIFIED_ERROR,
+        cause: Throwable? = null,
+    ) {
         // Guard against re-entrant calls (e.g., handlePacket → handleFatalError → sendPacket fails)
         if (handlingFatalError) return
         handlingFatalError = true
+
+        // Coerce the cause to a public MqttException to derive the reason code and reason value.
+        val mappedReason: MqttException? = cause?.toMqttException(defaultReasonCode = reasonCode)
+        // Prefer the explicit reasonCode argument; fall back to the cause's reasonCode if present.
+        val effectiveReasonCode =
+            if (reasonCode == ReasonCode.UNSPECIFIED_ERROR && mappedReason != null) {
+                mappedReason.reasonCode
+            } else {
+                reasonCode
+            }
 
         log.error(TAG) { "Fatal error — tearing down connection" }
         stopBackgroundJobs()
         try {
             // §4.13: Send DISCONNECT with appropriate reason code before closing
             if (transport.isConnected) {
-                sendPacket(Disconnect(reasonCode = reasonCode))
+                sendPacket(Disconnect(reasonCode = effectiveReasonCode))
             }
         } catch (
             @Suppress("SwallowedException") _: kotlin.coroutines.cancellation.CancellationException,
@@ -827,7 +841,13 @@ internal class MqttConnection(
         // (read loop or keepalive) was cancelled by stopBackgroundJobs() above.
         withContext(NonCancellable) {
             failAllPendingAcks()
-            _connectionState.value = ConnectionState.DISCONNECTED
+            val reason =
+                mappedReason
+                    ?: MqttException.ConnectionLost(
+                        reasonCode = effectiveReasonCode,
+                        message = "Connection lost (${effectiveReasonCode.name})",
+                    )
+            _connectionState.value = ConnectionState.Disconnected(reason = reason)
         }
     }
 
@@ -929,7 +949,14 @@ internal class MqttConnection(
                 stopBackgroundJobs()
                 transport.close()
                 failAllPendingAcks()
-                _connectionState.value = ConnectionState.DISCONNECTED
+                _connectionState.value =
+                    ConnectionState.Disconnected(
+                        reason =
+                            MqttException.ConnectionLost(
+                                reasonCode = packet.reasonCode,
+                                message = "Server initiated disconnect (${packet.reasonCode})",
+                            ),
+                    )
             }
 
             is ConnAck, is Connect, is Subscribe, is Unsubscribe -> {

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttException.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttException.kt
@@ -80,3 +80,37 @@ public sealed class MqttException(
         cause: Throwable? = null,
     ) : MqttException(reasonCode, message, cause)
 }
+
+/**
+ * Coerce an arbitrary [Throwable] into a public [MqttException] for inclusion in
+ * [ConnectionState.Disconnected.reason] or [ConnectionState.Reconnecting.lastError].
+ *
+ * Pass-through for existing [MqttException] instances. Maps internal
+ * `MqttConnectionException` to its public counterpart. All other throwables become
+ * [MqttException.ConnectionLost] with [defaultReasonCode].
+ *
+ * Cancellation must be re-thrown by callers before reaching this helper —
+ * structured concurrency must be preserved.
+ */
+internal fun Throwable.toMqttException(defaultReasonCode: ReasonCode = ReasonCode.UNSPECIFIED_ERROR): MqttException =
+    when (this) {
+        is MqttException -> {
+            this
+        }
+
+        is MqttConnectionException -> {
+            MqttException.ConnectionLost(
+                reasonCode = this.reasonCode,
+                message = this.message ?: "Connection error",
+                cause = this.cause,
+            )
+        }
+
+        else -> {
+            MqttException.ConnectionLost(
+                reasonCode = defaultReasonCode,
+                message = this.message ?: this::class.simpleName ?: "Unknown error",
+                cause = this,
+            )
+        }
+    }

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/AdvancedFeaturesTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/AdvancedFeaturesTest.kt
@@ -30,6 +30,7 @@ import org.meshtastic.mqtt.packet.Subscribe
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -212,7 +213,11 @@ class AdvancedFeaturesTest {
             advanceUntilIdle()
 
             // The connection should be torn down due to TOPIC_ALIAS_INVALID
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            val state = connection.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            val reason = state.reason
+            assertIs<MqttException.ConnectionLost>(reason)
+            assertEquals(ReasonCode.TOPIC_ALIAS_INVALID, reason.reasonCode)
         }
 
     @Test
@@ -243,7 +248,7 @@ class AdvancedFeaturesTest {
 
             assertEquals(1, receivedMessages.size)
             assertEquals("sensor/temp", receivedMessages[0].topic)
-            assertEquals(ConnectionState.CONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Connected, connection.connectionState.value)
 
             job.cancel()
             connection.disconnect()

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/ConnectionStateTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/ConnectionStateTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Shape contract tests for [ConnectionState] sealed hierarchy. Behavioural assertions
+ * (state transitions, reason population during connect/disconnect/reconnect) live in
+ * MqttClientTest and MqttConnectionTest.
+ */
+class ConnectionStateTest {
+    @Test
+    fun connectedAndConnecting_areObjectSingletons() {
+        assertSame(ConnectionState.Connected, ConnectionState.Connected)
+        assertSame(ConnectionState.Connecting, ConnectionState.Connecting)
+        assertNotEquals<ConnectionState>(ConnectionState.Connected, ConnectionState.Connecting)
+    }
+
+    @Test
+    fun disconnectedIdle_isStableSingletonWithNullReason() {
+        val a = ConnectionState.Disconnected.Idle
+        val b = ConnectionState.Disconnected.Idle
+        assertSame(a, b)
+        assertNull(a.reason)
+        // Default constructor matches the Idle singleton by value
+        assertEquals(ConnectionState.Disconnected.Idle, ConnectionState.Disconnected())
+    }
+
+    @Test
+    fun disconnectedWithReason_carriesPublicException() {
+        val reason =
+            MqttException.ConnectionLost(
+                reasonCode = ReasonCode.SERVER_SHUTTING_DOWN,
+                message = "bye",
+            )
+        val state = ConnectionState.Disconnected(reason = reason)
+        assertNotNull(state.reason)
+        assertEquals(ReasonCode.SERVER_SHUTTING_DOWN, state.reason?.reasonCode)
+        // Two Disconnected instances with the same reason are value-equal
+        assertEquals(ConnectionState.Disconnected(reason = reason), state)
+        // But not equal to Idle once a reason is present
+        assertNotEquals<ConnectionState>(ConnectionState.Disconnected.Idle, state)
+    }
+
+    @Test
+    fun reconnecting_isDataClassWithAttemptAndLastError() {
+        val r1 = ConnectionState.Reconnecting(attempt = 1)
+        val r2 = ConnectionState.Reconnecting(attempt = 1)
+        assertEquals(r1, r2)
+        assertNull(r1.lastError)
+
+        val err = MqttException.ConnectionLost(ReasonCode.UNSPECIFIED_ERROR, "boom")
+        val withErr = ConnectionState.Reconnecting(attempt = 3, lastError = err)
+        assertEquals(3, withErr.attempt)
+        assertEquals(err, withErr.lastError)
+        assertNotEquals(r1, withErr)
+    }
+
+    @Test
+    fun sealedHierarchy_isExhaustiveOnIs() {
+        val cases: List<ConnectionState> =
+            listOf(
+                ConnectionState.Connecting,
+                ConnectionState.Connected,
+                ConnectionState.Reconnecting(attempt = 0),
+                ConnectionState.Disconnected.Idle,
+            )
+        for (state in cases) {
+            // If a new subclass is added to the sealed hierarchy, exhaustiveness will force
+            // a compile error in callers that pattern-match — this test just confirms each
+            // current arm is reachable at runtime.
+            val label =
+                when (state) {
+                    is ConnectionState.Connecting -> "connecting"
+                    is ConnectionState.Connected -> "connected"
+                    is ConnectionState.Reconnecting -> "reconnecting"
+                    is ConnectionState.Disconnected -> "disconnected"
+                }
+            assertTrue(label.isNotEmpty())
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/ConvenienceApiTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/ConvenienceApiTest.kt
@@ -220,7 +220,7 @@ class ConvenienceApiTest {
                 autoReconnect = false
             }
         // Just verify it constructs without error — can't introspect config from outside
-        assertEquals(ConnectionState.DISCONNECTED, client.connectionState.value)
+        assertEquals(ConnectionState.Disconnected.Idle, client.connectionState.value)
     }
 
     // --- MqttConfig.build {} ---

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttClientTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttClientTest.kt
@@ -75,7 +75,7 @@ class MqttClientTest {
             client.connect(endpoint)
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.CONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
 
             val sentConnect = transport.decodeSentPackets().first()
             assertIs<Connect>(sentConnect)
@@ -84,7 +84,7 @@ class MqttClientTest {
             client.disconnect()
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.DISCONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, client.connectionState.value)
 
             val sentDisconnect = transport.decodeSentPackets().last()
             assertIs<Disconnect>(sentDisconnect)
@@ -308,12 +308,12 @@ class MqttClientTest {
             client.connect(endpoint)
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.CONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
 
             client.close()
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.DISCONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, client.connectionState.value)
             // close() should have sent DISCONNECT and closed the transport
             val sentDisconnect = transport.decodeSentPackets().last()
             assertIs<Disconnect>(sentDisconnect)
@@ -355,17 +355,17 @@ class MqttClientTest {
             client.connect(endpoint)
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.CONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
 
             // Manual disconnect should NOT trigger reconnect even with autoReconnect=true
             client.disconnect()
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.DISCONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, client.connectionState.value)
 
             // Give time for a reconnect to potentially trigger (it shouldn't)
             advanceUntilIdle()
-            assertEquals(ConnectionState.DISCONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, client.connectionState.value)
 
             client.close()
         }
@@ -582,7 +582,7 @@ class MqttClientTest {
             // Initial connect
             client.connect(endpoint)
             advanceUntilIdle()
-            assertEquals(ConnectionState.CONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
 
             // Subscribe so we can verify resubscription after reconnect
             transport.enqueuePacket(
@@ -609,7 +609,7 @@ class MqttClientTest {
             advanceTimeBy(200)
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.CONNECTED, client.connectionState.value)
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
 
             // Verify reconnect sent a new CONNECT
             val connectPackets = transport.decodeSentPackets().filterIsInstance<Connect>()

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttConnectionTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttConnectionTest.kt
@@ -82,7 +82,7 @@ class MqttConnectionTest {
             advanceUntilIdle()
 
             assertEquals(ReasonCode.SUCCESS, connAck.reasonCode)
-            assertEquals(ConnectionState.CONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Connected, connection.connectionState.value)
 
             val sentPacket = transport.decodeSentPackets().first()
             assertIs<Connect>(sentPacket)
@@ -186,7 +186,7 @@ class MqttConnectionTest {
                     connection.connect(endpoint)
                 }
             assertEquals(ReasonCode.BAD_USER_NAME_OR_PASSWORD, ex.reasonCode)
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, connection.connectionState.value)
         }
 
     @Test
@@ -201,7 +201,7 @@ class MqttConnectionTest {
             connection.connect(endpoint)
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.CONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Connected, connection.connectionState.value)
 
             connection.disconnect()
             advanceUntilIdle()
@@ -222,7 +222,7 @@ class MqttConnectionTest {
             connection.disconnect()
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, connection.connectionState.value)
 
             val disconnectPackets = transport.decodeSentPackets().filterIsInstance<Disconnect>()
             assertEquals(1, disconnectPackets.size)
@@ -543,7 +543,11 @@ class MqttConnectionTest {
             transport.enqueuePacket(Disconnect(reasonCode = ReasonCode.SERVER_SHUTTING_DOWN))
             advanceUntilIdle()
 
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            val state = connection.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            val reason = state.reason
+            assertIs<MqttException.ConnectionLost>(reason)
+            assertEquals(ReasonCode.SERVER_SHUTTING_DOWN, reason.reasonCode)
         }
 
     // --- PubRel from server (incoming QoS 2) ---
@@ -803,7 +807,9 @@ class MqttConnectionTest {
             advanceUntilIdle()
 
             // The connection should be in DISCONNECTED state due to the protocol error
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            val state = connection.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            assertIs<MqttException.ConnectionLost>(state.reason)
         }
 
     // --- Safe ACK casts — wrong packet type for pending ACK ---
@@ -871,8 +877,12 @@ class MqttConnectionTest {
             )
             advanceUntilIdle()
 
-            // Connection should be torn down
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            // Connection should be torn down with PROTOCOL_ERROR reason
+            val state = connection.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            val reason = state.reason
+            assertIs<MqttException.ConnectionLost>(reason)
+            assertEquals(ReasonCode.PROTOCOL_ERROR, reason.reasonCode)
 
             // Verify a DISCONNECT was sent with PROTOCOL_ERROR reason code
             val disconnects = transport.decodeSentPackets().filterIsInstance<Disconnect>()
@@ -1014,7 +1024,7 @@ class MqttConnectionTest {
                 exception.message?.contains("timed out") == true,
                 "Expected timeout message, got: ${exception.message}",
             )
-            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Disconnected.Idle, connection.connectionState.value)
         }
 
     // --- Stray PUBREL (session resumption) ---
@@ -1102,7 +1112,7 @@ class MqttConnectionTest {
             advanceTimeBy(100)
 
             // Connection should still be alive
-            assertEquals(ConnectionState.CONNECTED, connection.connectionState.value)
+            assertEquals(ConnectionState.Connected, connection.connectionState.value)
 
             connection.disconnect()
             advanceUntilIdle()
@@ -1124,11 +1134,12 @@ class MqttConnectionTest {
             //   t=22500 → elapsed=15000 >= deadline=10000 → TIMEOUT
             advanceTimeBy(23_000)
 
-            assertEquals(
-                ConnectionState.DISCONNECTED,
-                connection.connectionState.value,
+            val state = connection.connectionState.value
+            assertIs<ConnectionState.Disconnected>(
+                state,
                 "Connection should be DISCONNECTED after PINGRESP timeout",
             )
+            assertIs<MqttException.ConnectionLost>(state.reason)
         }
 
     companion object {

--- a/library/src/jvmTest/kotlin/org/meshtastic/mqtt/MqttIntegrationTest.kt
+++ b/library/src/jvmTest/kotlin/org/meshtastic/mqtt/MqttIntegrationTest.kt
@@ -83,14 +83,14 @@ class MqttIntegrationTest {
             try {
                 client.connect(endpoint)
                 withTimeout(5_000) {
-                    while (client.connectionState.value != ConnectionState.CONNECTED) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
-                assertEquals(ConnectionState.CONNECTED, client.connectionState.value)
+                assertEquals(ConnectionState.Connected, client.connectionState.value)
 
                 client.disconnect()
-                assertEquals(ConnectionState.DISCONNECTED, client.connectionState.value)
+                assertEquals(ConnectionState.Disconnected.Idle, client.connectionState.value)
             } finally {
                 client.close()
             }
@@ -106,7 +106,7 @@ class MqttIntegrationTest {
             try {
                 client.connect(endpoint)
                 withTimeout(5_000) {
-                    while (client.connectionState.value != ConnectionState.CONNECTED) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -134,7 +134,7 @@ class MqttIntegrationTest {
                 // Connect subscriber and subscribe
                 subscriber.connect(endpoint)
                 withTimeout(5_000) {
-                    while (subscriber.connectionState.value != ConnectionState.CONNECTED) {
+                    while (subscriber.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -151,7 +151,7 @@ class MqttIntegrationTest {
                 // Connect publisher and publish
                 publisher.connect(endpoint)
                 withTimeout(5_000) {
-                    while (publisher.connectionState.value != ConnectionState.CONNECTED) {
+                    while (publisher.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -184,7 +184,7 @@ class MqttIntegrationTest {
             try {
                 subscriber.connect(endpoint)
                 withTimeout(5_000) {
-                    while (subscriber.connectionState.value != ConnectionState.CONNECTED) {
+                    while (subscriber.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -199,7 +199,7 @@ class MqttIntegrationTest {
 
                 publisher.connect(endpoint)
                 withTimeout(5_000) {
-                    while (publisher.connectionState.value != ConnectionState.CONNECTED) {
+                    while (publisher.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -230,7 +230,7 @@ class MqttIntegrationTest {
             try {
                 client.connect(endpoint)
                 withTimeout(5_000) {
-                    while (client.connectionState.value != ConnectionState.CONNECTED) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -275,7 +275,7 @@ class MqttIntegrationTest {
                 // Publish a retained message
                 publisher.connect(endpoint)
                 withTimeout(5_000) {
-                    while (publisher.connectionState.value != ConnectionState.CONNECTED) {
+                    while (publisher.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -291,7 +291,7 @@ class MqttIntegrationTest {
             try {
                 subscriber.connect(endpoint)
                 withTimeout(5_000) {
-                    while (subscriber.connectionState.value != ConnectionState.CONNECTED) {
+                    while (subscriber.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -318,7 +318,7 @@ class MqttIntegrationTest {
                 try {
                     cleaner.connect(endpoint)
                     withTimeout(5_000) {
-                        while (cleaner.connectionState.value != ConnectionState.CONNECTED) {
+                        while (cleaner.connectionState.value != ConnectionState.Connected) {
                             delay(50)
                         }
                     }
@@ -351,7 +351,7 @@ class MqttIntegrationTest {
                 // Subscribe to the will topic
                 subscriber.connect(endpoint)
                 withTimeout(5_000) {
-                    while (subscriber.connectionState.value != ConnectionState.CONNECTED) {
+                    while (subscriber.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -384,7 +384,7 @@ class MqttIntegrationTest {
                 try {
                     willClient.connect(endpoint)
                     withTimeout(5_000) {
-                        while (willClient.connectionState.value != ConnectionState.CONNECTED) {
+                        while (willClient.connectionState.value != ConnectionState.Connected) {
                             delay(50)
                         }
                     }
@@ -420,7 +420,7 @@ class MqttIntegrationTest {
             try {
                 subscriber.connect(endpoint)
                 withTimeout(5_000) {
-                    while (subscriber.connectionState.value != ConnectionState.CONNECTED) {
+                    while (subscriber.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }
@@ -441,7 +441,7 @@ class MqttIntegrationTest {
 
                 publisher.connect(endpoint)
                 withTimeout(5_000) {
-                    while (publisher.connectionState.value != ConnectionState.CONNECTED) {
+                    while (publisher.connectionState.value != ConnectionState.Connected) {
                         delay(50)
                     }
                 }

--- a/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/App.kt
+++ b/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/App.kt
@@ -328,9 +328,9 @@ private typealias ColumnScope = androidx.compose.foundation.layout.ColumnScope
 
 @Composable
 private fun ConnectionCard(state: MqttSampleState, viewModel: MqttSampleViewModel) {
-    val connected = state.connectionState == ConnectionState.CONNECTED
-    val connecting = state.connectionState == ConnectionState.CONNECTING ||
-        state.connectionState == ConnectionState.RECONNECTING
+    val connected = state.connectionState is ConnectionState.Connected
+    val connecting = state.connectionState is ConnectionState.Connecting ||
+        state.connectionState is ConnectionState.Reconnecting
     SectionCard(title = "Connection") {
         OutlinedTextField(
             value = state.brokerUri,
@@ -383,10 +383,10 @@ private fun ConnectionCard(state: MqttSampleState, viewModel: MqttSampleViewMode
             }
             Text(
                 when (state.connectionState) {
-                    ConnectionState.CONNECTED -> "Disconnect"
-                    ConnectionState.CONNECTING -> "Connecting…"
-                    ConnectionState.RECONNECTING -> "Reconnecting…"
-                    ConnectionState.DISCONNECTED -> "Connect"
+                    is ConnectionState.Connected -> "Disconnect"
+                    is ConnectionState.Connecting -> "Connecting…"
+                    is ConnectionState.Reconnecting -> "Reconnecting…"
+                    is ConnectionState.Disconnected -> "Connect"
                 },
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
@@ -416,7 +416,7 @@ private fun SubscribeCard(state: MqttSampleState, viewModel: MqttSampleViewModel
         QosChipRow(state.subscribeQos, viewModel::updateSubscribeQos)
         FilledTonalButton(
             onClick = viewModel::subscribe,
-            enabled = state.connectionState == ConnectionState.CONNECTED,
+            enabled = state.connectionState is ConnectionState.Connected,
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.large,
         ) { Text("Subscribe", fontWeight = FontWeight.SemiBold) }
@@ -470,7 +470,7 @@ private fun PublishCard(state: MqttSampleState, viewModel: MqttSampleViewModel) 
         }
         FilledTonalButton(
             onClick = viewModel::publish,
-            enabled = state.connectionState == ConnectionState.CONNECTED,
+            enabled = state.connectionState is ConnectionState.Connected,
             modifier = Modifier.fillMaxWidth(),
             shape = MaterialTheme.shapes.large,
         ) { Text("Send", fontWeight = FontWeight.SemiBold) }
@@ -521,8 +521,8 @@ private fun MessagesPane(
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
             if (state.receivedMessages.isEmpty()) {
                 EmptyMessages(
-                    connecting = state.connectionState == ConnectionState.CONNECTING ||
-                        state.connectionState == ConnectionState.RECONNECTING,
+                    connecting = state.connectionState is ConnectionState.Connecting ||
+                        state.connectionState is ConnectionState.Reconnecting,
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {
@@ -789,10 +789,10 @@ private fun QosRetainBadges(msg: DisplayMessage) {
 @Composable
 private fun ConnectionChip(connectionState: ConnectionState) {
     val (label, color) = when (connectionState) {
-        ConnectionState.CONNECTED -> "Connected" to MeshGreen
-        ConnectionState.CONNECTING -> "Connecting" to MeshWarning
-        ConnectionState.RECONNECTING -> "Reconnecting" to MeshWarning
-        ConnectionState.DISCONNECTED -> "Offline" to MaterialTheme.colorScheme.outline
+        is ConnectionState.Connected -> "Connected" to MeshGreen
+        is ConnectionState.Connecting -> "Connecting" to MeshWarning
+        is ConnectionState.Reconnecting -> "Reconnecting" to MeshWarning
+        is ConnectionState.Disconnected -> "Offline" to MaterialTheme.colorScheme.outline
     }
     Surface(
         shape = MaterialTheme.shapes.small,
@@ -878,7 +878,7 @@ fun MqttTopBarPreview() {
     MaterialExpressiveTheme(colorScheme = MeshDarkColors) {
         Surface {
             MqttTopBar(
-                connectionState = ConnectionState.CONNECTED,
+                connectionState = ConnectionState.Connected,
                 scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
             )
         }

--- a/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/MqttSampleViewModel.kt
+++ b/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/MqttSampleViewModel.kt
@@ -74,7 +74,7 @@ data class MqttSampleState(
     val clientId: String = "mqtttastic-sample",
     val username: String = "meshdev",
     val password: String = "large4cats",
-    val connectionState: ConnectionState = ConnectionState.DISCONNECTED,
+    val connectionState: ConnectionState = ConnectionState.Disconnected.Idle,
     // subscribe
     val subscribeTopic: String = "msh/US/2/e/LongFast/#",
     val subscribeQos: QoS = QoS.AT_MOST_ONCE,
@@ -175,7 +175,7 @@ class MqttSampleViewModel : ViewModel() {
 
     fun connect() {
         val s = _state.value
-        if (s.connectionState != ConnectionState.DISCONNECTED) return
+        if (s.connectionState !is ConnectionState.Disconnected) return
         viewModelScope.launch(exceptionHandler) {
             try {
                 val endpoint = MqttEndpoint.parse(s.brokerUri)
@@ -236,7 +236,7 @@ class MqttSampleViewModel : ViewModel() {
                 client = null
                 _state.update {
                     it.copy(
-                        connectionState = ConnectionState.DISCONNECTED,
+                        connectionState = ConnectionState.Disconnected.Idle,
                         activeSubscriptions = emptySet(),
                     )
                 }


### PR DESCRIPTION
## Summary

Converts `ConnectionState` from an `enum` to a `sealed class` so disconnect and reconnect events carry diagnostic context, enabling consumer UIs to surface meaningful error messages (e.g. "DNS failed", broker reason codes).

## Breaking Change

`ConnectionState` is now a sealed class — pattern-match with `is` instead of `==`:

| Before | After |
|--------|-------|
| `state == ConnectionState.CONNECTED` | `state is ConnectionState.Connected` |
| `state == ConnectionState.DISCONNECTED` | `state is ConnectionState.Disconnected` |
| `state == ConnectionState.RECONNECTING` | `state is ConnectionState.Reconnecting` |

## New shape

- `Connecting` — object (unchanged semantics)
- `Connected` — object (unchanged semantics)
- `Reconnecting(attempt, lastError)` — current attempt count + last failure
- `Disconnected(reason: MqttException?)` — use `Disconnected.Idle` for the no-reason singleton (idle/initial/intentional-close)

## Changes

- `ConnectionState.kt` rewritten as sealed class hierarchy
- `MqttConnection.kt` updated to emit typed states throughout the connection lifecycle
- `ConnectionStateTest.kt` added with shape-contract tests (object identity, equality, exhaustive `is`-matching)
- CHANGELOG `[Unreleased] ### Changed (BREAKING)` + `### Added` entries

## Verification

`./gradlew spotlessCheck detekt allTests apiCheck koverVerify` — all green on JVM + iOS sim + wasmJs.