### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-17
+
 ### Changed (BREAKING)
 - **`ConnectionState` is now a `sealed class`** (was an `enum`) so disconnect / reconnect events
   carry diagnostic context. Pattern-match with `is` instead of `==`:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ repositories {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("org.meshtastic:mqtt-client:0.1.0")
+            implementation("org.meshtastic:mqtt-client:0.2.0")
         }
     }
 }
@@ -105,7 +105,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation 'org.meshtastic:mqtt-client:0.1.0'
+                implementation 'org.meshtastic:mqtt-client:0.2.0'
             }
         }
     }
@@ -118,7 +118,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation("org.meshtastic:mqtt-client:0.1.0")
+    implementation("org.meshtastic:mqtt-client:0.2.0")
 }
 ```
 </details>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ android.nonTransitiveRClass=true
 #Picked up automatically by com.vanniktech.maven.publish. Override in CI with -PVERSION_NAME=...
 GROUP=org.meshtastic
 POM_ARTIFACT_ID=mqtt-client
-VERSION_NAME=0.1.0
+VERSION_NAME=0.2.0
 #Compose Desktop — allow Homebrew/OpenJDK vendors for local `packageReleaseDmg` runs.
 #CI uses Temurin via setup-java so this is a no-op there.
 compose.desktop.packaging.checkJdkVendor=false


### PR DESCRIPTION
## 0.2.0 Release

Merges the 0.2.0 release branch into `main` after #25 lands in the merge queue.

### What's in this release

**Breaking change:**
- `ConnectionState` is now a `sealed class` (was `enum`) — pattern-match with `is`

**New:**
- `MqttClient.probe()` — one-shot connectivity diagnostic / "Test Connection" UX
- `ProbeResult` sealed class (7 outcomes), `ProbeServerInfo`, `DEFAULT_PROBE_TIMEOUT_MS`
- `ConnectionState.Disconnected.reason` and `Reconnecting.lastError`

### Release checklist
- [ ] #25 merged via merge queue
- [ ] CI green on this branch
- [ ] Tag `v0.2.0` after merge
- [ ] Publish to Maven (via CI or `./gradlew publishToMavenLocal`)