### PR TITLE
feat(codec): add MQTT 3.1.1 protocol support with seamless version negotiation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # MQTTastic Client KMP — Unified Agent & Developer Guide
 
 <role>
-You are an expert Kotlin Multiplatform engineer working on MQTTastic-Client-KMP, a fully-featured MQTT 5.0 client library. You must maintain strict KMP architectural boundaries, write zero-dependency common code, and implement the MQTT 5.0 specification with precision.
+You are an expert Kotlin Multiplatform engineer working on MQTTastic-Client-KMP, a fully-featured MQTT 5.0 and 3.1.1 client library. You must maintain strict KMP architectural boundaries, write zero-dependency common code, and implement the MQTT specifications with precision.
 </role>
 
 <context_and_memory>
-- **Project:** `org.meshtastic:mqtt-client` — production-grade MQTT 5.0 client for Kotlin Multiplatform (JVM, Android, iOS, macOS, Linux, Windows, wasmJs).
+- **Project:** `org.meshtastic:mqtt-client` — production-grade MQTT 5.0 and 3.1.1 client for Kotlin Multiplatform (JVM, Android, iOS, macOS, Linux, Windows, wasmJs).
 - **Stack:** Kotlin 2.3.20, Gradle 9.3.0, Ktor 3.4.2, kotlinx-coroutines 1.10.2, kotlinx-io-bytestring 0.8.2. Zero external deps beyond these.
-- **Reference Spec:** [OASIS MQTT 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html) — consult for byte-level packet layouts, property definitions, and reason codes.
+- **Reference Spec:** [OASIS MQTT 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html) and [OASIS MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) — consult for byte-level packet layouts, property definitions, and reason codes.
 </context_and_memory>
 
 ## Architecture
@@ -66,7 +66,7 @@ ByteArray ←→ MqttDecoder/MqttEncoder ←→ MqttPacket (sealed interface hie
 
 ### Implementation status
 
-All protocol features are fully implemented: 15 MQTT 5.0 packet types, QoS 0/1/2 state machines, enhanced auth, topic aliases, flow control, auto-reconnect, will messages, shared subscriptions, and request/response. See README.md for detailed MQTT 5.0 coverage tables.
+All protocol features are fully implemented: 15 MQTT 5.0 packet types, QoS 0/1/2 state machines, enhanced auth, topic aliases, flow control, auto-reconnect, will messages, shared subscriptions, and request/response. MQTT 3.1.1 is also fully supported via a `MqttProtocolVersion` enum threaded through the codec and connection layers. See README.md for detailed coverage tables.
 
 ## Build & Test Commands
 
@@ -114,7 +114,7 @@ Build system: Kotlin DSL (`build.gradle.kts`) with version catalog (`gradle/libs
 - **Zero Lint Tolerance:** A task is incomplete if `detekt` fails or `spotlessCheck` does not pass.
 - **Spec Compliance:** Every packet encoder/decoder must match the byte-level layout in the OASIS MQTT 5.0 specification exactly. When in doubt, cite the relevant spec section number.
 - **Test Coverage:** Every new packet type, property, or protocol feature must have encode/decode round-trip tests with known byte sequences from the spec. QoS 2 flow tests must cover the full state machine including retransmission and session resumption.
-- **Internal by Default:** Only `MqttClient`, `MqttConfig`, `MqttMessage`, `PublishProperties`, `MqttEndpoint`, `QoS`, `ConnectionState`, `ReasonCode`, `WillConfig`, `MqttLogger`, `MqttLogLevel`, `RetainHandling`, and `AuthChallenge` are public. Top-level convenience extensions (`messagesForTopic`, `messagesMatching`, `use`) and the `MqttClient(clientId) {}` factory function are also public. Everything else (including `MqttTransport`, `MqttProperties`) is `internal`.
+- **Internal by Default:** Only `MqttClient`, `MqttConfig`, `MqttMessage`, `PublishProperties`, `MqttEndpoint`, `QoS`, `ConnectionState`, `ReasonCode`, `WillConfig`, `MqttLogger`, `MqttLogLevel`, `RetainHandling`, `AuthChallenge`, and `MqttProtocolVersion` are public. Top-level convenience extensions (`messagesForTopic`, `messagesMatching`, `use`) and the `MqttClient(clientId) {}` factory function are also public. Everything else (including `MqttTransport`, `MqttProperties`) is `internal`.
 - **Concurrency Safety:** Use `Mutex` for send operations (one packet on the wire at a time). Use `StateFlow`/`SharedFlow` for observable state. No shared mutable state. Use `Mutex`-guarded counters for packet ID allocation.
 - **Read Before Refactoring:** When a pattern contradicts best practices, analyze whether it is a deliberate design choice before proposing a change.
 </rules>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![codecov](https://codecov.io/gh/meshtastic/MQTTastic-Client-KMP/graph/badge.svg)](https://codecov.io/gh/meshtastic/MQTTastic-Client-KMP)
 [![API Docs](https://img.shields.io/badge/API%20Docs-latest-blue.svg)](https://meshtastic.github.io/MQTTastic-Client-KMP)
 
-A fully-featured **MQTT 5.0** client library for **Kotlin Multiplatform** — connecting JVM, Android, iOS, macOS, Linux, Windows, and browsers through a single, idiomatic Kotlin API.
+A fully-featured **MQTT 5.0 and 3.1.1** client library for **Kotlin Multiplatform** — connecting JVM, Android, iOS, macOS, Linux, Windows, and browsers through a single, idiomatic Kotlin API.
 
 <p align="center">
   <img src="docs/images/sample-app.png" alt="MQTTastic sample app running on Android, connected to mqtt.meshtastic.org and streaming live mesh traffic" width="820" />
@@ -19,7 +19,7 @@ A fully-featured **MQTT 5.0** client library for **Kotlin Multiplatform** — co
 
 ## Features
 
-- 📦 **Full MQTT 5.0** — all 15 packet types, properties, reason codes, and enhanced auth
+- 📦 **Full MQTT 5.0 + 3.1.1** — all 15 packet types, properties, reason codes, and enhanced auth (5.0); backward-compatible 3.1.1 support
 - 🔄 **All QoS levels** — QoS 0, 1, and 2 with complete state machine handling
 - 🌍 **True multiplatform** — one codebase, 9 targets (see [Platform Support](#platform-support))
 - 🔒 **TLS/SSL** — secure connections on all native/JVM targets
@@ -174,6 +174,33 @@ client.messages.collect { msg ->
 client.close()
 ```
 </details>
+
+### MQTT 3.1.1 Support
+
+To connect to an MQTT 3.1.1 broker, set `protocolVersion` in your config:
+
+```kotlin
+val client = MqttClient("my-client") {
+    protocolVersion = MqttProtocolVersion.V3_1_1
+    keepAliveSeconds = 30
+}
+
+client.use(MqttEndpoint.parse("tcp://legacy-broker:1883")) { c ->
+    c.subscribe("sensors/#")
+    c.messagesForTopic("sensors/#").collect { msg ->
+        println("Received: ${msg.payloadAsString()}")
+    }
+}
+```
+
+MQTT 3.1.1 mode automatically:
+- Omits properties sections from all packets
+- Uses 3.1.1 CONNACK return codes (mapped to `ReasonCode`)
+- Encodes subscribe options as QoS-only (no `noLocal`, `retainAsPublished`, `retainHandling`)
+- Sends a body-less DISCONNECT on close
+- Skips topic aliases and flow control (Receive Maximum)
+
+5.0-only config options (`sessionExpiryInterval`, `authenticationMethod`) are rejected at config-build time when `V3_1_1` is selected. The default protocol version is `V5_0` — existing code is unaffected.
 
 ### Convenience APIs
 

--- a/README.md
+++ b/README.md
@@ -177,19 +177,35 @@ client.close()
 
 ### MQTT 3.1.1 Support
 
-To connect to an MQTT 3.1.1 broker, set `protocolVersion` in your config:
+By default, the client automatically negotiates the protocol version. It connects with MQTT 5.0 first and, if the broker rejects it with `UNSUPPORTED_PROTOCOL_VERSION`, seamlessly retries with MQTT 3.1.1 on a fresh connection — no configuration needed:
 
 ```kotlin
+// Auto-negotiation is on by default — works with both 5.0 and 3.1.1 brokers
 val client = MqttClient("my-client") {
-    protocolVersion = MqttProtocolVersion.V3_1_1
     keepAliveSeconds = 30
 }
 
-client.use(MqttEndpoint.parse("tcp://legacy-broker:1883")) { c ->
+client.use(MqttEndpoint.parse("tcp://any-broker:1883")) { c ->
+    // After connect, check which version was negotiated:
+    println("Connected with ${c.negotiatedProtocolVersion}")
     c.subscribe("sensors/#")
     c.messagesForTopic("sensors/#").collect { msg ->
         println("Received: ${msg.payloadAsString()}")
     }
+}
+```
+
+To force a specific version or disable negotiation:
+
+```kotlin
+// Force MQTT 3.1.1 (no negotiation)
+val v311Client = MqttClient("my-client") {
+    protocolVersion = MqttProtocolVersion.V3_1_1
+}
+
+// Force MQTT 5.0 only (disable fallback)
+val v5OnlyClient = MqttClient("my-client") {
+    negotiateVersion = false
 }
 ```
 
@@ -200,7 +216,7 @@ MQTT 3.1.1 mode automatically:
 - Sends a body-less DISCONNECT on close
 - Skips topic aliases and flow control (Receive Maximum)
 
-5.0-only config options (`sessionExpiryInterval`, `authenticationMethod`) are rejected at config-build time when `V3_1_1` is selected. The default protocol version is `V5_0` — existing code is unaffected.
+5.0-only config options (`sessionExpiryInterval`, `authenticationMethod`) are rejected at config-build time when `V3_1_1` is explicitly selected. When using auto-negotiation, fallback is skipped if the config uses 5.0-only features — the original rejection is re-thrown so you know the broker doesn't support your configuration.
 
 ### Convenience APIs
 

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -68,6 +68,7 @@ public final class org/meshtastic/mqtt/MqttClient {
 	public final fun getAuthChallenges ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getMessages ()Lkotlinx/coroutines/flow/SharedFlow;
+	public final fun getNegotiatedProtocolVersion ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
 	public final fun publish (Ljava/lang/String;Ljava/lang/String;Lorg/meshtastic/mqtt/QoS;Ljava/lang/Boolean;Lorg/meshtastic/mqtt/PublishProperties;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun publish (Lorg/meshtastic/mqtt/MqttMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun publish$default (Lorg/meshtastic/mqtt/MqttClient;Ljava/lang/String;Ljava/lang/String;Lorg/meshtastic/mqtt/QoS;Ljava/lang/Boolean;Lorg/meshtastic/mqtt/PublishProperties;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -93,34 +94,35 @@ public final class org/meshtastic/mqtt/MqttClientKt {
 public final class org/meshtastic/mqtt/MqttConfig {
 	public static final field Companion Lorg/meshtastic/mqtt/MqttConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)V
-	public synthetic fun <init> (Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/meshtastic/mqtt/MqttProtocolVersion;ZLjava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)V
+	public synthetic fun <init> (Lorg/meshtastic/mqtt/MqttProtocolVersion;ZLjava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
-	public final fun component10 ()Ljava/lang/Long;
-	public final fun component11 ()I
-	public final fun component12 ()Z
+	public final fun component10 ()I
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()I
 	public final fun component13 ()Z
-	public final fun component14 ()Ljava/util/List;
-	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Lkotlinx/io/bytestring/ByteString;
-	public final fun component17 ()Z
-	public final fun component18 ()J
+	public final fun component14 ()Z
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Lkotlinx/io/bytestring/ByteString;
+	public final fun component18 ()Z
 	public final fun component19 ()J
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component20 ()I
-	public final fun component21 ()Lorg/meshtastic/mqtt/QoS;
-	public final fun component22 ()Z
-	public final fun component23 ()Lorg/meshtastic/mqtt/MqttLogger;
-	public final fun component24 ()Lorg/meshtastic/mqtt/MqttLogLevel;
-	public final fun component3 ()I
-	public final fun component4 ()Z
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lkotlinx/io/bytestring/ByteString;
-	public final fun component7 ()Lorg/meshtastic/mqtt/WillConfig;
-	public final fun component8 ()Ljava/lang/Long;
-	public final fun component9 ()I
-	public final fun copy (Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)Lorg/meshtastic/mqtt/MqttConfig;
-	public static synthetic fun copy$default (Lorg/meshtastic/mqtt/MqttConfig;Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILjava/lang/Object;)Lorg/meshtastic/mqtt/MqttConfig;
+	public final fun component2 ()Z
+	public final fun component20 ()J
+	public final fun component21 ()I
+	public final fun component22 ()Lorg/meshtastic/mqtt/QoS;
+	public final fun component23 ()Z
+	public final fun component24 ()Lorg/meshtastic/mqtt/MqttLogger;
+	public final fun component25 ()Lorg/meshtastic/mqtt/MqttLogLevel;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lkotlinx/io/bytestring/ByteString;
+	public final fun component8 ()Lorg/meshtastic/mqtt/WillConfig;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Lorg/meshtastic/mqtt/MqttProtocolVersion;ZLjava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)Lorg/meshtastic/mqtt/MqttConfig;
+	public static synthetic fun copy$default (Lorg/meshtastic/mqtt/MqttConfig;Lorg/meshtastic/mqtt/MqttProtocolVersion;ZLjava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILjava/lang/Object;)Lorg/meshtastic/mqtt/MqttConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthenticationData ()Lkotlinx/io/bytestring/ByteString;
 	public final fun getAuthenticationMethod ()Ljava/lang/String;
@@ -134,6 +136,7 @@ public final class org/meshtastic/mqtt/MqttConfig {
 	public final fun getLogger ()Lorg/meshtastic/mqtt/MqttLogger;
 	public final fun getMaxReconnectAttempts ()I
 	public final fun getMaximumPacketSize ()Ljava/lang/Long;
+	public final fun getNegotiateVersion ()Z
 	public final fun getPassword ()Lkotlinx/io/bytestring/ByteString;
 	public final fun getProtocolVersion ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
 	public final fun getReceiveMaximum ()I
@@ -165,6 +168,7 @@ public final class org/meshtastic/mqtt/MqttConfig$Builder {
 	public final fun getLogger ()Lorg/meshtastic/mqtt/MqttLogger;
 	public final fun getMaxReconnectAttempts ()I
 	public final fun getMaximumPacketSize ()Ljava/lang/Long;
+	public final fun getNegotiateVersion ()Z
 	public final fun getPassword ()Lkotlinx/io/bytestring/ByteString;
 	public final fun getProtocolVersion ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
 	public final fun getReceiveMaximum ()I
@@ -190,6 +194,7 @@ public final class org/meshtastic/mqtt/MqttConfig$Builder {
 	public final fun setLogger (Lorg/meshtastic/mqtt/MqttLogger;)V
 	public final fun setMaxReconnectAttempts (I)V
 	public final fun setMaximumPacketSize (Ljava/lang/Long;)V
+	public final fun setNegotiateVersion (Z)V
 	public final fun setPassword (Lkotlinx/io/bytestring/ByteString;)V
 	public final fun setProtocolVersion (Lorg/meshtastic/mqtt/MqttProtocolVersion;)V
 	public final fun setReceiveMaximum (I)V

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -93,33 +93,34 @@ public final class org/meshtastic/mqtt/MqttClientKt {
 public final class org/meshtastic/mqtt/MqttConfig {
 	public static final field Companion Lorg/meshtastic/mqtt/MqttConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)V
-	public synthetic fun <init> (Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()I
-	public final fun component11 ()Z
+	public fun <init> (Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)V
+	public synthetic fun <init> (Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()I
 	public final fun component12 ()Z
-	public final fun component13 ()Ljava/util/List;
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Lkotlinx/io/bytestring/ByteString;
-	public final fun component16 ()Z
-	public final fun component17 ()J
+	public final fun component13 ()Z
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Lkotlinx/io/bytestring/ByteString;
+	public final fun component17 ()Z
 	public final fun component18 ()J
-	public final fun component19 ()I
-	public final fun component2 ()I
-	public final fun component20 ()Lorg/meshtastic/mqtt/QoS;
-	public final fun component21 ()Z
-	public final fun component22 ()Lorg/meshtastic/mqtt/MqttLogger;
-	public final fun component23 ()Lorg/meshtastic/mqtt/MqttLogLevel;
-	public final fun component3 ()Z
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Lkotlinx/io/bytestring/ByteString;
-	public final fun component6 ()Lorg/meshtastic/mqtt/WillConfig;
-	public final fun component7 ()Ljava/lang/Long;
-	public final fun component8 ()I
-	public final fun component9 ()Ljava/lang/Long;
-	public final fun copy (Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)Lorg/meshtastic/mqtt/MqttConfig;
-	public static synthetic fun copy$default (Lorg/meshtastic/mqtt/MqttConfig;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILjava/lang/Object;)Lorg/meshtastic/mqtt/MqttConfig;
+	public final fun component19 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()I
+	public final fun component21 ()Lorg/meshtastic/mqtt/QoS;
+	public final fun component22 ()Z
+	public final fun component23 ()Lorg/meshtastic/mqtt/MqttLogger;
+	public final fun component24 ()Lorg/meshtastic/mqtt/MqttLogLevel;
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lkotlinx/io/bytestring/ByteString;
+	public final fun component7 ()Lorg/meshtastic/mqtt/WillConfig;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()I
+	public final fun copy (Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;)Lorg/meshtastic/mqtt/MqttConfig;
+	public static synthetic fun copy$default (Lorg/meshtastic/mqtt/MqttConfig;Lorg/meshtastic/mqtt/MqttProtocolVersion;Ljava/lang/String;IZLjava/lang/String;Lkotlinx/io/bytestring/ByteString;Lorg/meshtastic/mqtt/WillConfig;Ljava/lang/Long;ILjava/lang/Long;IZZLjava/util/List;Ljava/lang/String;Lkotlinx/io/bytestring/ByteString;ZJJILorg/meshtastic/mqtt/QoS;ZLorg/meshtastic/mqtt/MqttLogger;Lorg/meshtastic/mqtt/MqttLogLevel;ILjava/lang/Object;)Lorg/meshtastic/mqtt/MqttConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthenticationData ()Lkotlinx/io/bytestring/ByteString;
 	public final fun getAuthenticationMethod ()Ljava/lang/String;
@@ -134,6 +135,7 @@ public final class org/meshtastic/mqtt/MqttConfig {
 	public final fun getMaxReconnectAttempts ()I
 	public final fun getMaximumPacketSize ()Ljava/lang/Long;
 	public final fun getPassword ()Lkotlinx/io/bytestring/ByteString;
+	public final fun getProtocolVersion ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
 	public final fun getReceiveMaximum ()I
 	public final fun getReconnectBaseDelayMs ()J
 	public final fun getReconnectMaxDelayMs ()J
@@ -164,6 +166,7 @@ public final class org/meshtastic/mqtt/MqttConfig$Builder {
 	public final fun getMaxReconnectAttempts ()I
 	public final fun getMaximumPacketSize ()Ljava/lang/Long;
 	public final fun getPassword ()Lkotlinx/io/bytestring/ByteString;
+	public final fun getProtocolVersion ()Lorg/meshtastic/mqtt/MqttProtocolVersion;
 	public final fun getReceiveMaximum ()I
 	public final fun getReconnectBaseDelayMs ()J
 	public final fun getReconnectMaxDelayMs ()J
@@ -188,6 +191,7 @@ public final class org/meshtastic/mqtt/MqttConfig$Builder {
 	public final fun setMaxReconnectAttempts (I)V
 	public final fun setMaximumPacketSize (Ljava/lang/Long;)V
 	public final fun setPassword (Lkotlinx/io/bytestring/ByteString;)V
+	public final fun setProtocolVersion (Lorg/meshtastic/mqtt/MqttProtocolVersion;)V
 	public final fun setReceiveMaximum (I)V
 	public final fun setReconnectBaseDelayMs (J)V
 	public final fun setReconnectMaxDelayMs (J)V
@@ -316,6 +320,21 @@ public final class org/meshtastic/mqtt/MqttMessage {
 	public fun hashCode ()I
 	public final fun payloadAsString ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/meshtastic/mqtt/MqttProtocolVersion : java/lang/Enum {
+	public static final field Companion Lorg/meshtastic/mqtt/MqttProtocolVersion$Companion;
+	public static final field V3_1_1 Lorg/meshtastic/mqtt/MqttProtocolVersion;
+	public static final field V5_0 Lorg/meshtastic/mqtt/MqttProtocolVersion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getProtocolLevel ()I
+	public final fun getSupportsProperties ()Z
+	public static fun valueOf (Ljava/lang/String;)Lorg/meshtastic/mqtt/MqttProtocolVersion;
+	public static fun values ()[Lorg/meshtastic/mqtt/MqttProtocolVersion;
+}
+
+public final class org/meshtastic/mqtt/MqttProtocolVersion$Companion {
+	public final fun fromProtocolLevel (I)Lorg/meshtastic/mqtt/MqttProtocolVersion;
 }
 
 public final class org/meshtastic/mqtt/ProbeKt {

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
@@ -252,6 +252,15 @@ public class MqttClient
             effectiveTransportFactory = { transport }
         }
 
+        /** Internal constructor for testing with a transport factory and injected scope. */
+        internal constructor(
+            config: MqttConfig,
+            scope: CoroutineScope,
+            transportFactory: (MqttEndpoint) -> MqttTransport,
+        ) : this(config, scope) {
+            effectiveTransportFactory = transportFactory
+        }
+
         @Volatile
         private var closed = false
 
@@ -310,6 +319,19 @@ public class MqttClient
 
         @Volatile
         private var currentEndpoint: MqttEndpoint? = null
+
+        /**
+         * The protocol version actually in use after connection negotiation.
+         *
+         * - Before connection: matches [MqttConfig.protocolVersion].
+         * - After connection: reflects the version that the broker accepted
+         *   (may be [MqttProtocolVersion.V3_1_1] if fallback occurred).
+         * - Reset on explicit [connect] calls; preserved across auto-reconnects.
+         */
+        @Volatile
+        public var negotiatedProtocolVersion: MqttProtocolVersion = config.protocolVersion
+            private set
+
         private var messageForwardJob: Job? = null
         private var stateForwardJob: Job? = null
         private var authForwardJob: Job? = null
@@ -361,6 +383,7 @@ public class MqttClient
                     log.info(TAG) { "Connecting to $endpoint" }
                     intentionalDisconnect = false
                     currentEndpoint = endpoint
+                    negotiatedProtocolVersion = config.protocolVersion
                     connectWithRedirect(endpoint, redirectsRemaining = MAX_REDIRECTS)
                 }
             } catch (e: MqttConnectionException) {
@@ -680,9 +703,59 @@ public class MqttClient
         // --- Private helpers ---
 
         private suspend fun connectInternal(endpoint: MqttEndpoint) {
+            val effectiveVersion = negotiatedProtocolVersion
+            val effectiveConfig =
+                if (effectiveVersion != config.protocolVersion) {
+                    config.copy(protocolVersion = effectiveVersion)
+                } else {
+                    config
+                }
+
             val transport = effectiveTransportFactory(endpoint)
-            val conn = MqttConnection(transport, config, scope, log)
-            conn.connect(endpoint)
+            val conn = MqttConnection(transport, effectiveConfig, scope, log)
+
+            try {
+                conn.connect(endpoint)
+            } catch (e: MqttConnectionException) {
+                // Version fallback: if broker rejected V5_0, try V3_1_1 on a fresh transport
+                if (
+                    e.reasonCode == ReasonCode.UNSUPPORTED_PROTOCOL_VERSION &&
+                    effectiveVersion == MqttProtocolVersion.V5_0 &&
+                    config.negotiateVersion
+                ) {
+                    log.info(TAG) {
+                        "Broker rejected MQTT 5.0 — falling back to MQTT 3.1.1"
+                    }
+                    // Validate the config is compatible with 3.1.1 before retrying
+                    try {
+                        config.validateV311Compatibility()
+                    } catch (validationErr: IllegalArgumentException) {
+                        log.error(TAG) {
+                            "Cannot fall back to MQTT 3.1.1: ${validationErr.message}"
+                        }
+                        throw e // Re-throw original rejection
+                    }
+                    try {
+                        transport.close()
+                    } catch (
+                        @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+                    ) {
+                        // Best-effort close
+                    }
+
+                    negotiatedProtocolVersion = MqttProtocolVersion.V3_1_1
+                    val fallbackConfig = config.copy(protocolVersion = MqttProtocolVersion.V3_1_1)
+                    val fallbackTransport = effectiveTransportFactory(endpoint)
+                    val fallbackConn = MqttConnection(fallbackTransport, fallbackConfig, scope, log)
+                    fallbackConn.connect(endpoint)
+                    connection = fallbackConn
+                    startForwarding(fallbackConn)
+                    log.info(TAG) { "Connected to $endpoint (MQTT 3.1.1 via fallback)" }
+                    return
+                }
+                throw e
+            }
+
             connection = conn
             startForwarding(conn)
             log.info(TAG) { "Connected to $endpoint" }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
@@ -743,11 +743,12 @@ public class MqttClient
                         // Best-effort close
                     }
 
-                    negotiatedProtocolVersion = MqttProtocolVersion.V3_1_1
                     val fallbackConfig = config.copy(protocolVersion = MqttProtocolVersion.V3_1_1)
                     val fallbackTransport = effectiveTransportFactory(endpoint)
                     val fallbackConn = MqttConnection(fallbackTransport, fallbackConfig, scope, log)
                     fallbackConn.connect(endpoint)
+                    // Only set after successful connect — don't leave stale state on failure
+                    negotiatedProtocolVersion = MqttProtocolVersion.V3_1_1
                     connection = fallbackConn
                     startForwarding(fallbackConn)
                     log.info(TAG) { "Connected to $endpoint (MQTT 3.1.1 via fallback)" }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConfig.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConfig.kt
@@ -108,6 +108,7 @@ import kotlinx.io.bytestring.ByteString
  *   [MqttLogLevel.NONE] (all logging disabled).
  */
 public data class MqttConfig(
+    val protocolVersion: MqttProtocolVersion = MqttProtocolVersion.V5_0,
     val clientId: String = "",
     val keepAliveSeconds: Int = 60,
     val cleanStart: Boolean = true,
@@ -161,6 +162,24 @@ public data class MqttConfig(
         require(maxReconnectAttempts >= 0) {
             "maxReconnectAttempts must be >= 0, got: $maxReconnectAttempts"
         }
+        // MQTT 3.1.1 does not support these features — fail fast if configured
+        if (protocolVersion == MqttProtocolVersion.V3_1_1) {
+            require(sessionExpiryInterval == null) {
+                "sessionExpiryInterval is not supported in MQTT 3.1.1"
+            }
+            require(authenticationMethod == null) {
+                "Enhanced authentication (authenticationMethod) is not supported in MQTT 3.1.1"
+            }
+            require(authenticationData == null) {
+                "Enhanced authentication (authenticationData) is not supported in MQTT 3.1.1"
+            }
+            // §3.1.2.3: In 3.1.1, password flag requires username flag
+            if (password != null) {
+                require(username != null) {
+                    "MQTT 3.1.1 requires username when password is set (§3.1.2.3)"
+                }
+            }
+        }
     }
 
     public companion object {
@@ -196,6 +215,9 @@ public data class MqttConfig(
     @MqttDsl
     @Suppress("TooManyFunctions")
     public class Builder {
+        /** MQTT protocol version for this connection. Defaults to MQTT 5.0. */
+        public var protocolVersion: MqttProtocolVersion = MqttProtocolVersion.V5_0
+
         /** Client identifier sent to the broker. Empty requests broker-assigned ID. */
         public var clientId: String = ""
 
@@ -309,6 +331,7 @@ public data class MqttConfig(
         /** Build the immutable [MqttConfig] from the current builder state. */
         public fun build(): MqttConfig =
             MqttConfig(
+                protocolVersion = protocolVersion,
                 clientId = clientId,
                 keepAliveSeconds = keepAliveSeconds,
                 cleanStart = cleanStart,

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConfig.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConfig.kt
@@ -109,6 +109,7 @@ import kotlinx.io.bytestring.ByteString
  */
 public data class MqttConfig(
     val protocolVersion: MqttProtocolVersion = MqttProtocolVersion.V5_0,
+    val negotiateVersion: Boolean = true,
     val clientId: String = "",
     val keepAliveSeconds: Int = 60,
     val cleanStart: Boolean = true,
@@ -162,22 +163,34 @@ public data class MqttConfig(
         require(maxReconnectAttempts >= 0) {
             "maxReconnectAttempts must be >= 0, got: $maxReconnectAttempts"
         }
-        // MQTT 3.1.1 does not support these features — fail fast if configured
+        // MQTT 3.1.1 does not support these features — fail fast if explicitly configured
         if (protocolVersion == MqttProtocolVersion.V3_1_1) {
-            require(sessionExpiryInterval == null) {
-                "sessionExpiryInterval is not supported in MQTT 3.1.1"
-            }
-            require(authenticationMethod == null) {
-                "Enhanced authentication (authenticationMethod) is not supported in MQTT 3.1.1"
-            }
-            require(authenticationData == null) {
-                "Enhanced authentication (authenticationData) is not supported in MQTT 3.1.1"
-            }
-            // §3.1.2.3: In 3.1.1, password flag requires username flag
-            if (password != null) {
-                require(username != null) {
-                    "MQTT 3.1.1 requires username when password is set (§3.1.2.3)"
-                }
+            validateV311Compatibility()
+        }
+    }
+
+    /**
+     * Check whether this config is compatible with MQTT 3.1.1.
+     *
+     * Called eagerly when [protocolVersion] is [MqttProtocolVersion.V3_1_1], and
+     * at connection time when [negotiateVersion] triggers a fallback from 5.0 to 3.1.1.
+     *
+     * @throws IllegalArgumentException if any 5.0-only options are configured.
+     */
+    internal fun validateV311Compatibility() {
+        require(sessionExpiryInterval == null) {
+            "sessionExpiryInterval is not supported in MQTT 3.1.1"
+        }
+        require(authenticationMethod == null) {
+            "Enhanced authentication (authenticationMethod) is not supported in MQTT 3.1.1"
+        }
+        require(authenticationData == null) {
+            "Enhanced authentication (authenticationData) is not supported in MQTT 3.1.1"
+        }
+        // §3.1.2.3: In 3.1.1, password flag requires username flag
+        if (password != null) {
+            require(username != null) {
+                "MQTT 3.1.1 requires username when password is set (§3.1.2.3)"
             }
         }
     }
@@ -217,6 +230,14 @@ public data class MqttConfig(
     public class Builder {
         /** MQTT protocol version for this connection. Defaults to MQTT 5.0. */
         public var protocolVersion: MqttProtocolVersion = MqttProtocolVersion.V5_0
+
+        /**
+         * If `true` (default) and [protocolVersion] is [MqttProtocolVersion.V5_0], the client
+         * automatically falls back to MQTT 3.1.1 when the broker rejects the 5.0 CONNECT with
+         * `UNSUPPORTED_PROTOCOL_VERSION`. The negotiated version is remembered for reconnects.
+         * Set to `false` to require the exact [protocolVersion] without fallback.
+         */
+        public var negotiateVersion: Boolean = true
 
         /** Client identifier sent to the broker. Empty requests broker-assigned ID. */
         public var clientId: String = ""
@@ -332,6 +353,7 @@ public data class MqttConfig(
         public fun build(): MqttConfig =
             MqttConfig(
                 protocolVersion = protocolVersion,
+                negotiateVersion = negotiateVersion,
                 clientId = clientId,
                 keepAliveSeconds = keepAliveSeconds,
                 cleanStart = cleanStart,

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConfig.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConfig.kt
@@ -187,10 +187,47 @@ public data class MqttConfig(
         require(authenticationData == null) {
             "Enhanced authentication (authenticationData) is not supported in MQTT 3.1.1"
         }
+        require(userProperties.isEmpty()) {
+            "userProperties are not supported in MQTT 3.1.1"
+        }
+        require(maximumPacketSize == null) {
+            "maximumPacketSize is not supported in MQTT 3.1.1"
+        }
+        require(topicAliasMaximum == 0) {
+            "topicAliasMaximum is not supported in MQTT 3.1.1"
+        }
+        require(!requestResponseInformation) {
+            "requestResponseInformation is not supported in MQTT 3.1.1"
+        }
+        // receiveMaximum default (65535) is fine — it means "no limit" which is 3.1.1 behavior
+        require(receiveMaximum == 65535) {
+            "receiveMaximum is not supported in MQTT 3.1.1 (must be default 65535)"
+        }
         // §3.1.2.3: In 3.1.1, password flag requires username flag
         if (password != null) {
             require(username != null) {
                 "MQTT 3.1.1 requires username when password is set (§3.1.2.3)"
+            }
+        }
+        // Validate will properties are 3.1.1 compatible (no 5.0-only will properties)
+        will?.let { w ->
+            require(w.willDelayInterval == null) {
+                "willDelayInterval is not supported in MQTT 3.1.1"
+            }
+            require(w.messageExpiryInterval == null) {
+                "will messageExpiryInterval is not supported in MQTT 3.1.1"
+            }
+            require(w.contentType == null) {
+                "will contentType is not supported in MQTT 3.1.1"
+            }
+            require(w.responseTopic == null) {
+                "will responseTopic is not supported in MQTT 3.1.1"
+            }
+            require(w.correlationData == null) {
+                "will correlationData is not supported in MQTT 3.1.1"
+            }
+            require(!w.payloadFormatIndicator) {
+                "will payloadFormatIndicator is not supported in MQTT 3.1.1"
             }
         }
     }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -101,6 +101,9 @@ internal class MqttConnection(
     private val log: MqttLoggerInternal = MqttLoggerInternal.NOOP,
     private val timeSource: TimeSource = TimeSource.Monotonic,
 ) {
+    /** The MQTT protocol version for this connection. */
+    private val version: MqttProtocolVersion get() = config.protocolVersion
+
     private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected.Idle)
 
     /** Observable connection state. */
@@ -221,42 +224,47 @@ internal class MqttConnection(
 
             log.debug(TAG) { "Received CONNACK: reasonCode=${connAck.reasonCode}" }
 
-            // Store server-assigned values from CONNACK properties
-            connAck.properties.receiveMaximum?.let { serverReceiveMaximum = it }
-            connAck.properties.assignedClientIdentifier?.let { assignedClientId = it }
-            connAck.properties.topicAliasMaximum?.let { serverTopicAliasMaximum = it }
-            connAck.properties.sharedSubscriptionAvailable?.let { serverSharedSubscriptionAvailable = it }
-            connAck.properties.maximumQos?.let { value ->
-                serverMaximumQos =
-                    when (value) {
-                        0 -> {
-                            QoS.AT_MOST_ONCE
-                        }
+            if (version.supportsProperties) {
+                // Store server-assigned values from CONNACK properties
+                connAck.properties.receiveMaximum?.let { serverReceiveMaximum = it }
+                connAck.properties.assignedClientIdentifier?.let { assignedClientId = it }
+                connAck.properties.topicAliasMaximum?.let { serverTopicAliasMaximum = it }
+                connAck.properties.sharedSubscriptionAvailable?.let { serverSharedSubscriptionAvailable = it }
+                connAck.properties.maximumQos?.let { value ->
+                    serverMaximumQos =
+                        when (value) {
+                            0 -> {
+                                QoS.AT_MOST_ONCE
+                            }
 
-                        1 -> {
-                            QoS.AT_LEAST_ONCE
-                        }
+                            1 -> {
+                                QoS.AT_LEAST_ONCE
+                            }
 
-                        else -> {
-                            log.warn(TAG) { "Invalid Maximum QoS value $value in CONNACK, treating as protocol error" }
-                            throw MqttConnectionException(
-                                ReasonCode.PROTOCOL_ERROR,
-                                "Invalid Maximum QoS value $value in CONNACK (§3.2.2.3.4)",
-                            )
+                            else -> {
+                                log.warn(TAG) { "Invalid Maximum QoS value $value in CONNACK, treating as protocol error" }
+                                throw MqttConnectionException(
+                                    ReasonCode.PROTOCOL_ERROR,
+                                    "Invalid Maximum QoS value $value in CONNACK (§3.2.2.3.4)",
+                                )
+                            }
                         }
-                    }
+                }
+                connAck.properties.retainAvailable?.let { serverRetainAvailable = it }
+                connAck.properties.wildcardSubscriptionAvailable?.let { serverWildcardSubscriptionAvailable = it }
+                connAck.properties.subscriptionIdentifiersAvailable?.let { serverSubscriptionIdentifiersAvailable = it }
+                connAck.properties.maximumPacketSize?.let { serverMaximumPacketSize = it }
+
+                // Honor Server Keep Alive override (§3.2.2.3.14)
+                effectiveKeepAliveSeconds =
+                    connAck.properties.serverKeepAlive ?: config.keepAliveSeconds
+
+                // Initialize flow control semaphore based on server's Receive Maximum (§3.3.4)
+                inflightSemaphore = Semaphore(serverReceiveMaximum)
+            } else {
+                // MQTT 3.1.1: no properties in CONNACK, use config values
+                effectiveKeepAliveSeconds = config.keepAliveSeconds
             }
-            connAck.properties.retainAvailable?.let { serverRetainAvailable = it }
-            connAck.properties.wildcardSubscriptionAvailable?.let { serverWildcardSubscriptionAvailable = it }
-            connAck.properties.subscriptionIdentifiersAvailable?.let { serverSubscriptionIdentifiersAvailable = it }
-            connAck.properties.maximumPacketSize?.let { serverMaximumPacketSize = it }
-
-            // Honor Server Keep Alive override (§3.2.2.3.14)
-            effectiveKeepAliveSeconds =
-                connAck.properties.serverKeepAlive ?: config.keepAliveSeconds
-
-            // Initialize flow control semaphore based on server's Receive Maximum (§3.3.4)
-            inflightSemaphore = Semaphore(serverReceiveMaximum)
 
             log.debug(TAG) {
                 "Session established: keepAlive=${effectiveKeepAliveSeconds}s, " +
@@ -315,7 +323,7 @@ internal class MqttConnection(
         withTimeout(ACK_TIMEOUT_MS) {
             while (true) {
                 val responseBytes = transport.receive()
-                val response = decodePacket(responseBytes)
+                val response = decodePacket(responseBytes, version)
 
                 when (response) {
                     is ConnAck -> {
@@ -323,6 +331,13 @@ internal class MqttConnection(
                     }
 
                     is Auth -> {
+                        // AUTH is only valid in MQTT 5.0
+                        if (!version.supportsProperties) {
+                            throw MqttConnectionException(
+                                ReasonCode.PROTOCOL_ERROR,
+                                "Received AUTH packet during MQTT 3.1.1 handshake",
+                            )
+                        }
                         _authChallenges.emit(
                             AuthChallenge(
                                 reasonCode = response.reasonCode,
@@ -356,6 +371,8 @@ internal class MqttConnection(
 
         try {
             if (transport.isConnected) {
+                // MQTT 3.1.1: DISCONNECT has no variable header/payload — always send empty
+                // MQTT 5.0: send with reason code and optional properties
                 sendPacket(Disconnect(reasonCode = reasonCode))
                 transport.close()
             }
@@ -438,8 +455,13 @@ internal class MqttConnection(
             }
         }
 
-        val publishProperties = buildPublishProperties(message.properties)
-        val (resolvedTopic, resolvedProperties) = applyOutboundTopicAlias(message.topic, publishProperties)
+        val publishProperties = if (version.supportsProperties) buildPublishProperties(message.properties) else MqttProperties.EMPTY
+        val (resolvedTopic, resolvedProperties) =
+            if (version.supportsProperties) {
+                applyOutboundTopicAlias(message.topic, publishProperties)
+            } else {
+                message.topic to MqttProperties.EMPTY
+            }
 
         return when (message.qos) {
             QoS.AT_MOST_ONCE -> {
@@ -481,28 +503,46 @@ internal class MqttConnection(
     ): SubAck {
         check(_connectionState.value is ConnectionState.Connected) { "Not connected" }
 
-        // Enforce shared subscription availability (§4.8.2)
-        if (!serverSharedSubscriptionAvailable) {
-            subscriptions.forEach { sub ->
-                require(!TopicValidator.isSharedSubscription(sub.topicFilter)) {
-                    "Server does not support shared subscriptions (§4.8.2): '${sub.topicFilter}'"
+        if (version.supportsProperties) {
+            // Enforce shared subscription availability (§4.8.2)
+            if (!serverSharedSubscriptionAvailable) {
+                subscriptions.forEach { sub ->
+                    require(!TopicValidator.isSharedSubscription(sub.topicFilter)) {
+                        "Server does not support shared subscriptions (§4.8.2): '${sub.topicFilter}'"
+                    }
                 }
             }
-        }
 
-        // Enforce wildcard subscription availability (§3.2.2.3.12)
-        if (!serverWildcardSubscriptionAvailable) {
-            subscriptions.forEach { sub ->
-                require(!TopicValidator.containsWildcards(sub.topicFilter)) {
-                    "Server does not support wildcard subscriptions (§3.2.2.3.12): '${sub.topicFilter}'"
+            // Enforce wildcard subscription availability (§3.2.2.3.12)
+            if (!serverWildcardSubscriptionAvailable) {
+                subscriptions.forEach { sub ->
+                    require(!TopicValidator.containsWildcards(sub.topicFilter)) {
+                        "Server does not support wildcard subscriptions (§3.2.2.3.12): '${sub.topicFilter}'"
+                    }
                 }
             }
-        }
 
-        // Enforce subscription identifier availability (§3.2.2.3.14)
-        if (!serverSubscriptionIdentifiersAvailable) {
-            require(properties.subscriptionIdentifier.isEmpty()) {
-                "Server does not support subscription identifiers (§3.2.2.3.14)"
+            // Enforce subscription identifier availability (§3.2.2.3.14)
+            if (!serverSubscriptionIdentifiersAvailable) {
+                require(properties.subscriptionIdentifier.isEmpty()) {
+                    "Server does not support subscription identifiers (§3.2.2.3.14)"
+                }
+            }
+        } else {
+            // MQTT 3.1.1: validate no 5.0-only subscription options
+            subscriptions.forEach { sub ->
+                require(!sub.noLocal) {
+                    "noLocal subscription option is not supported in MQTT 3.1.1"
+                }
+                require(!sub.retainAsPublished) {
+                    "retainAsPublished subscription option is not supported in MQTT 3.1.1"
+                }
+                require(sub.retainHandling == RetainHandling.SEND_AT_SUBSCRIBE) {
+                    "retainHandling subscription option is not supported in MQTT 3.1.1"
+                }
+            }
+            require(properties == MqttProperties.EMPTY) {
+                "Subscribe properties are not supported in MQTT 3.1.1"
             }
         }
 
@@ -602,7 +642,7 @@ internal class MqttConnection(
     /** Send a packet over the transport, guarded by [sendMutex] for wire-level serialization. */
     private suspend fun sendPacket(packet: MqttPacket) {
         sendMutex.withLock {
-            val bytes = packet.encode()
+            val bytes = packet.encode(version)
 
             // Enforce broker's Maximum Packet Size on outbound packets (§3.2.2.3.6)
             serverMaximumPacketSize?.let { maxSize ->
@@ -771,7 +811,7 @@ internal class MqttConnection(
                             }
                         }
 
-                        val packet = decodePacket(bytes)
+                        val packet = decodePacket(bytes, version)
                         log.debug(TAG) { "Received ${packet.packetType}" }
                         handlePacket(packet)
                     }
@@ -813,9 +853,12 @@ internal class MqttConnection(
         log.error(TAG) { "Fatal error — tearing down connection" }
         stopBackgroundJobs()
         try {
-            // §4.13: Send DISCONNECT with appropriate reason code before closing
             if (transport.isConnected) {
-                sendPacket(Disconnect(reasonCode = effectiveReasonCode))
+                if (version.supportsProperties) {
+                    // §4.13: Send DISCONNECT with appropriate reason code before closing
+                    sendPacket(Disconnect(reasonCode = effectiveReasonCode))
+                }
+                // MQTT 3.1.1: no DISCONNECT with reason code — just close the transport
             }
         } catch (
             @Suppress("SwallowedException") _: kotlin.coroutines.cancellation.CancellationException,
@@ -929,6 +972,12 @@ internal class MqttConnection(
             }
 
             is Disconnect -> {
+                if (!version.supportsProperties) {
+                    // MQTT 3.1.1: server should never send DISCONNECT
+                    log.error(TAG) { "Protocol violation: received DISCONNECT from broker in MQTT 3.1.1" }
+                    handleFatalError(ReasonCode.PROTOCOL_ERROR)
+                    return
+                }
                 log.warn(TAG) { "Received DISCONNECT from broker: reasonCode=${packet.reasonCode}" }
                 val isRedirect =
                     packet.reasonCode == ReasonCode.USE_ANOTHER_SERVER ||
@@ -977,6 +1026,12 @@ internal class MqttConnection(
             }
 
             is Auth -> {
+                if (!version.supportsProperties) {
+                    // MQTT 3.1.1: AUTH packet does not exist
+                    log.error(TAG) { "Protocol violation: received AUTH packet in MQTT 3.1.1" }
+                    handleFatalError(ReasonCode.PROTOCOL_ERROR)
+                    return
+                }
                 log.debug(TAG) { "Received AUTH: reasonCode=${packet.reasonCode}" }
                 handleAuthPacket(packet)
             }
@@ -1119,20 +1174,25 @@ internal class MqttConnection(
     @Suppress("CyclomaticComplexMethod")
     private fun buildConnectPacket(): Connect {
         val connectProperties =
-            MqttProperties(
-                sessionExpiryInterval = config.sessionExpiryInterval,
-                receiveMaximum = if (config.receiveMaximum != DEFAULT_RECEIVE_MAXIMUM) config.receiveMaximum else null,
-                maximumPacketSize = config.maximumPacketSize,
-                topicAliasMaximum = if (config.topicAliasMaximum != 0) config.topicAliasMaximum else null,
-                requestResponseInformation = if (config.requestResponseInformation) true else null,
-                requestProblemInformation = if (!config.requestProblemInformation) false else null,
-                userProperties = config.userProperties,
-                authenticationMethod = config.authenticationMethod,
-                authenticationData = config.authenticationData?.toByteArray(),
-            )
+            if (version.supportsProperties) {
+                MqttProperties(
+                    sessionExpiryInterval = config.sessionExpiryInterval,
+                    receiveMaximum = if (config.receiveMaximum != DEFAULT_RECEIVE_MAXIMUM) config.receiveMaximum else null,
+                    maximumPacketSize = config.maximumPacketSize,
+                    topicAliasMaximum = if (config.topicAliasMaximum != 0) config.topicAliasMaximum else null,
+                    requestResponseInformation = if (config.requestResponseInformation) true else null,
+                    requestProblemInformation = if (!config.requestProblemInformation) false else null,
+                    userProperties = config.userProperties,
+                    authenticationMethod = config.authenticationMethod,
+                    authenticationData = config.authenticationData?.toByteArray(),
+                )
+            } else {
+                MqttProperties.EMPTY
+            }
 
         val willConfig = config.will
         return Connect(
+            protocolLevel = version.protocolLevel,
             cleanStart = config.cleanStart,
             keepAliveSeconds = config.keepAliveSeconds,
             clientId = config.clientId,
@@ -1140,7 +1200,12 @@ internal class MqttConnection(
             willPayload = willConfig?.payload?.toByteArray(),
             willQos = willConfig?.qos ?: QoS.AT_MOST_ONCE,
             willRetain = willConfig?.retain ?: false,
-            willProperties = willConfig?.let { buildWillProperties(it) } ?: MqttProperties.EMPTY,
+            willProperties =
+                if (version.supportsProperties) {
+                    willConfig?.let { buildWillProperties(it) } ?: MqttProperties.EMPTY
+                } else {
+                    MqttProperties.EMPTY
+                },
             username = config.username,
             password = config.password?.toByteArray(),
             properties = connectProperties,

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttProtocolVersion.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttProtocolVersion.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt
+
+/**
+ * MQTT protocol version for the client connection.
+ *
+ * Determines the wire format, packet encoding, and available features.
+ * MQTT 3.1.1 uses a simpler packet format without properties, reason codes
+ * in most packets, or advanced features like topic aliases and enhanced auth.
+ *
+ * @property protocolLevel The protocol level byte sent in the CONNECT packet variable header.
+ */
+public enum class MqttProtocolVersion(
+    public val protocolLevel: Int,
+) {
+    /** MQTT 3.1.1 (protocol level 4). */
+    V3_1_1(4),
+
+    /** MQTT 5.0 (protocol level 5). */
+    V5_0(5),
+    ;
+
+    /** Returns `true` if this version supports MQTT 5.0 properties on packets. */
+    public val supportsProperties: Boolean get() = this == V5_0
+
+    public companion object {
+        /** Look up version by protocol level byte. */
+        public fun fromProtocolLevel(level: Int): MqttProtocolVersion =
+            when (level) {
+                4 -> V3_1_1
+
+                5 -> V5_0
+
+                else -> throw IllegalArgumentException(
+                    "Unsupported MQTT protocol level: $level (supported: 4 for 3.1.1, 5 for 5.0)",
+                )
+            }
+    }
+}

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
@@ -111,7 +111,13 @@ internal suspend fun runProbe(
     val connection = MqttConnection(transport, config, probeScope)
     return try {
         val connAck = withTimeout(timeoutMs) { connection.connect(endpoint) }
-        ProbeResult.Success(serverInfo = connAck.properties.toProbeServerInfo())
+        val serverInfo =
+            if (config.protocolVersion.supportsProperties) {
+                connAck.properties.toProbeServerInfo()
+            } else {
+                ProbeServerInfo() // Empty info for MQTT 3.1.1
+            }
+        ProbeResult.Success(serverInfo = serverInfo)
     } catch (e: TimeoutCancellationException) {
         ProbeResult.Timeout(durationMs = timeoutMs)
     } catch (e: CancellationException) {

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
@@ -16,18 +16,24 @@
  */
 package org.meshtastic.mqtt.packet
 
+import org.meshtastic.mqtt.MqttProtocolVersion
 import org.meshtastic.mqtt.QoS
 import org.meshtastic.mqtt.ReasonCode
 import org.meshtastic.mqtt.RetainHandling
 
 /**
- * Decode a complete MQTT 5.0 packet (including fixed header) into the appropriate [MqttPacket] subclass.
+ * Decode a complete MQTT packet (including fixed header) into the appropriate [MqttPacket] subclass.
  *
  * @param bytes The complete packet bytes starting with the fixed header.
+ * @param version The MQTT protocol version to decode as. Determines whether properties
+ *   and reason codes are expected in the packet body.
  * @throws IllegalArgumentException if the packet is malformed or unrecognized.
  */
 @Suppress("CyclomaticComplexMethod")
-internal fun decodePacket(bytes: ByteArray): MqttPacket {
+internal fun decodePacket(
+    bytes: ByteArray,
+    version: MqttProtocolVersion = MqttProtocolVersion.V5_0,
+): MqttPacket {
     require(bytes.isNotEmpty()) { "Packet bytes must not be empty" }
 
     val firstByte = bytes[0].toInt() and 0xFF
@@ -35,6 +41,11 @@ internal fun decodePacket(bytes: ByteArray): MqttPacket {
     val flags = firstByte and 0x0F
 
     val type = PacketType.fromValue(typeValue)
+
+    // MQTT 3.1.1 does not have AUTH packets
+    if (!version.supportsProperties && type == PacketType.AUTH) {
+        throw IllegalArgumentException("AUTH packets are not valid in MQTT 3.1.1")
+    }
 
     // Validate flags (PUBLISH has variable flags)
     type.requiredFlags?.let { required ->
@@ -54,20 +65,20 @@ internal fun decodePacket(bytes: ByteArray): MqttPacket {
     val body = bytes.copyOfRange(headerSize, headerSize + remainingLength)
 
     return when (type) {
-        PacketType.CONNECT -> decodeConnect(body)
-        PacketType.CONNACK -> decodeConnAck(body)
-        PacketType.PUBLISH -> decodePublish(body, flags)
-        PacketType.PUBACK -> decodePubAckLike(body, ::PubAck)
-        PacketType.PUBREC -> decodePubAckLike(body, ::PubRec)
-        PacketType.PUBREL -> decodePubAckLike(body, ::PubRel)
-        PacketType.PUBCOMP -> decodePubAckLike(body, ::PubComp)
-        PacketType.SUBSCRIBE -> decodeSubscribe(body)
-        PacketType.SUBACK -> decodeSubAck(body)
-        PacketType.UNSUBSCRIBE -> decodeUnsubscribe(body)
-        PacketType.UNSUBACK -> decodeUnsubAck(body)
+        PacketType.CONNECT -> decodeConnect(body, version)
+        PacketType.CONNACK -> decodeConnAck(body, version)
+        PacketType.PUBLISH -> decodePublish(body, flags, version)
+        PacketType.PUBACK -> decodePubAckLike(body, version, ::PubAck)
+        PacketType.PUBREC -> decodePubAckLike(body, version, ::PubRec)
+        PacketType.PUBREL -> decodePubAckLike(body, version, ::PubRel)
+        PacketType.PUBCOMP -> decodePubAckLike(body, version, ::PubComp)
+        PacketType.SUBSCRIBE -> decodeSubscribe(body, version)
+        PacketType.SUBACK -> decodeSubAck(body, version)
+        PacketType.UNSUBSCRIBE -> decodeUnsubscribe(body, version)
+        PacketType.UNSUBACK -> decodeUnsubAck(body, version)
         PacketType.PINGREQ -> PingReq
         PacketType.PINGRESP -> PingResp
-        PacketType.DISCONNECT -> decodeDisconnect(body)
+        PacketType.DISCONNECT -> decodeDisconnect(body, version)
         PacketType.AUTH -> decodeAuth(body)
     }
 }
@@ -75,7 +86,10 @@ internal fun decodePacket(bytes: ByteArray): MqttPacket {
 // --- §3.1 CONNECT ---
 
 @Suppress("CyclomaticComplexMethod")
-private fun decodeConnect(body: ByteArray): Connect {
+private fun decodeConnect(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): Connect {
     var pos = 0
 
     // Protocol Name
@@ -101,9 +115,15 @@ private fun decodeConnect(body: ByteArray): Connect {
     val keepAlive = WireFormat.decodeTwoByteInt(body, pos)
     pos += 2
 
-    // Properties
-    val (properties, propsConsumed) = decodePropertiesSection(body, pos)
-    pos += propsConsumed
+    // Properties (MQTT 5.0 only)
+    val properties =
+        if (version.supportsProperties) {
+            val (props, propsConsumed) = decodePropertiesSection(body, pos)
+            pos += propsConsumed
+            props
+        } else {
+            MqttProperties.EMPTY
+        }
 
     // Payload: Client ID
     val (clientId, clientIdConsumed) = WireFormat.decodeUtf8String(body, pos)
@@ -114,9 +134,11 @@ private fun decodeConnect(body: ByteArray): Connect {
     var willPayload: ByteArray? = null
     var willProperties = MqttProperties.EMPTY
     if (willFlag) {
-        val (wp, wpConsumed) = decodePropertiesSection(body, pos)
-        willProperties = wp
-        pos += wpConsumed
+        if (version.supportsProperties) {
+            val (wp, wpConsumed) = decodePropertiesSection(body, pos)
+            willProperties = wp
+            pos += wpConsumed
+        }
 
         val (wt, wtConsumed) = WireFormat.decodeUtf8String(body, pos)
         willTopic = wt
@@ -162,22 +184,31 @@ private fun decodeConnect(body: ByteArray): Connect {
 
 // --- §3.2 CONNACK ---
 
-private fun decodeConnAck(body: ByteArray): ConnAck {
-    require(body.size >= 3) { "CONNACK body too short" }
+private fun decodeConnAck(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): ConnAck {
+    if (version.supportsProperties) {
+        require(body.size >= 3) { "CONNACK body too short" }
+    } else {
+        require(body.size >= 2) { "CONNACK body too short" }
+    }
     // Connect Acknowledge Flags — bits 7-1 are reserved and MUST be 0 (§3.2.2.1)
     require((body[0].toInt() and 0xFE) == 0) {
         "Reserved bits in Connect Acknowledge Flags must be 0 (§3.2.2.1)"
     }
     val sessionPresent = (body[0].toInt() and 0x01) != 0
-    val reasonCode = ReasonCode.fromValue(body[1].toInt() and 0xFF)
 
-    val (properties, _) = decodePropertiesSection(body, 2)
-
-    return ConnAck(
-        sessionPresent = sessionPresent,
-        reasonCode = reasonCode,
-        properties = properties,
-    )
+    return if (version.supportsProperties) {
+        val reasonCode = ReasonCode.fromValue(body[1].toInt() and 0xFF)
+        val (properties, _) = decodePropertiesSection(body, 2)
+        ConnAck(sessionPresent = sessionPresent, reasonCode = reasonCode, properties = properties)
+    } else {
+        // MQTT 3.1.1: single return code byte, no properties (§3.2.2.3)
+        val returnCode = body[1].toInt() and 0xFF
+        val reasonCode = reasonCodeFromConnAckReturnCode(returnCode)
+        ConnAck(sessionPresent = sessionPresent, reasonCode = reasonCode)
+    }
 }
 
 // --- §3.3 PUBLISH ---
@@ -185,6 +216,7 @@ private fun decodeConnAck(body: ByteArray): ConnAck {
 private fun decodePublish(
     body: ByteArray,
     flags: Int,
+    version: MqttProtocolVersion,
 ): Publish {
     val dup = (flags and 0x08) != 0
     val qos = QoS.fromValue((flags shr 1) and 0x03)
@@ -200,8 +232,14 @@ private fun decodePublish(
         pos += 2
     }
 
-    val (properties, propsConsumed) = decodePropertiesSection(body, pos)
-    pos += propsConsumed
+    val properties: MqttProperties
+    if (version.supportsProperties) {
+        val (props, propsConsumed) = decodePropertiesSection(body, pos)
+        properties = props
+        pos += propsConsumed
+    } else {
+        properties = MqttProperties.EMPTY
+    }
 
     val payload = body.copyOfRange(pos, body.size)
 
@@ -220,10 +258,16 @@ private fun decodePublish(
 
 private fun <T : MqttPacket> decodePubAckLike(
     body: ByteArray,
+    version: MqttProtocolVersion,
     factory: (Int, ReasonCode, MqttProperties) -> T,
 ): T {
     require(body.size >= 2) { "Packet body too short for packet identifier" }
     val packetId = WireFormat.decodeTwoByteInt(body, 0)
+
+    // MQTT 3.1.1: only packet identifier, no reason code or properties
+    if (!version.supportsProperties) {
+        return factory(packetId, ReasonCode.SUCCESS, MqttProperties.EMPTY)
+    }
 
     // Short form: remaining length == 2 → SUCCESS with no properties
     if (body.size == 2) {
@@ -243,14 +287,23 @@ private fun <T : MqttPacket> decodePubAckLike(
 
 // --- §3.8 SUBSCRIBE ---
 
-private fun decodeSubscribe(body: ByteArray): Subscribe {
+private fun decodeSubscribe(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): Subscribe {
     var pos = 0
 
     val packetId = WireFormat.decodeTwoByteInt(body, pos)
     pos += 2
 
-    val (properties, propsConsumed) = decodePropertiesSection(body, pos)
-    pos += propsConsumed
+    val properties: MqttProperties
+    if (version.supportsProperties) {
+        val (props, propsConsumed) = decodePropertiesSection(body, pos)
+        properties = props
+        pos += propsConsumed
+    } else {
+        properties = MqttProperties.EMPTY
+    }
 
     val subscriptions = mutableListOf<Subscription>()
     while (pos < body.size) {
@@ -260,19 +313,28 @@ private fun decodeSubscribe(body: ByteArray): Subscribe {
         val options = body[pos].toInt() and 0xFF
         pos++
 
-        // Subscription Options bits 6-7 are reserved and MUST be 0 (§3.8.3.1)
-        require((options and 0xC0) == 0) {
-            "Reserved bits 6-7 in Subscription Options must be 0 (§3.8.3.1)"
-        }
+        if (version.supportsProperties) {
+            // Subscription Options bits 6-7 are reserved and MUST be 0 (§3.8.3.1)
+            require((options and 0xC0) == 0) {
+                "Reserved bits 6-7 in Subscription Options must be 0 (§3.8.3.1)"
+            }
 
-        subscriptions +=
-            Subscription(
-                topicFilter = topicFilter,
-                maxQos = QoS.fromValue(options and 0x03),
-                noLocal = (options and 0x04) != 0,
-                retainAsPublished = (options and 0x08) != 0,
-                retainHandling = RetainHandling.fromValue((options shr 4) and 0x03),
-            )
+            subscriptions +=
+                Subscription(
+                    topicFilter = topicFilter,
+                    maxQos = QoS.fromValue(options and 0x03),
+                    noLocal = (options and 0x04) != 0,
+                    retainAsPublished = (options and 0x08) != 0,
+                    retainHandling = RetainHandling.fromValue((options shr 4) and 0x03),
+                )
+        } else {
+            // MQTT 3.1.1: options byte is just QoS (bits 0-1), rest reserved as 0
+            subscriptions +=
+                Subscription(
+                    topicFilter = topicFilter,
+                    maxQos = QoS.fromValue(options and 0x03),
+                )
+        }
     }
 
     return Subscribe(
@@ -284,19 +346,34 @@ private fun decodeSubscribe(body: ByteArray): Subscribe {
 
 // --- §3.9 SUBACK ---
 
-private fun decodeSubAck(body: ByteArray): SubAck {
+private fun decodeSubAck(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): SubAck {
     var pos = 0
 
     val packetId = WireFormat.decodeTwoByteInt(body, pos)
     pos += 2
 
-    val (properties, propsConsumed) = decodePropertiesSection(body, pos)
-    pos += propsConsumed
+    val properties: MqttProperties
+    if (version.supportsProperties) {
+        val (props, propsConsumed) = decodePropertiesSection(body, pos)
+        properties = props
+        pos += propsConsumed
+    } else {
+        properties = MqttProperties.EMPTY
+    }
 
     val reasonCodes = mutableListOf<ReasonCode>()
     while (pos < body.size) {
-        reasonCodes += ReasonCode.fromValue(body[pos].toInt() and 0xFF)
+        val codeByte = body[pos].toInt() and 0xFF
         pos++
+        if (version.supportsProperties) {
+            reasonCodes += ReasonCode.fromValue(codeByte)
+        } else {
+            // MQTT 3.1.1 SUBACK return codes: 0x00=QoS0, 0x01=QoS1, 0x02=QoS2, 0x80=Failure
+            reasonCodes += reasonCodeFromSubAckReturnCode(codeByte)
+        }
     }
 
     require(reasonCodes.isNotEmpty()) {
@@ -312,14 +389,23 @@ private fun decodeSubAck(body: ByteArray): SubAck {
 
 // --- §3.10 UNSUBSCRIBE ---
 
-private fun decodeUnsubscribe(body: ByteArray): Unsubscribe {
+private fun decodeUnsubscribe(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): Unsubscribe {
     var pos = 0
 
     val packetId = WireFormat.decodeTwoByteInt(body, pos)
     pos += 2
 
-    val (properties, propsConsumed) = decodePropertiesSection(body, pos)
-    pos += propsConsumed
+    val properties: MqttProperties
+    if (version.supportsProperties) {
+        val (props, propsConsumed) = decodePropertiesSection(body, pos)
+        properties = props
+        pos += propsConsumed
+    } else {
+        properties = MqttProperties.EMPTY
+    }
 
     val topicFilters = mutableListOf<String>()
     while (pos < body.size) {
@@ -337,11 +423,24 @@ private fun decodeUnsubscribe(body: ByteArray): Unsubscribe {
 
 // --- §3.11 UNSUBACK ---
 
-private fun decodeUnsubAck(body: ByteArray): UnsubAck {
+private fun decodeUnsubAck(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): UnsubAck {
     var pos = 0
 
     val packetId = WireFormat.decodeTwoByteInt(body, pos)
     pos += 2
+
+    if (!version.supportsProperties) {
+        // MQTT 3.1.1: UNSUBACK has no payload beyond packet identifier (§3.11)
+        // Synthesize a single SUCCESS — callers that need per-topic status should
+        // track the original UNSUBSCRIBE request.
+        return UnsubAck(
+            packetIdentifier = packetId,
+            reasonCodes = listOf(ReasonCode.SUCCESS),
+        )
+    }
 
     val (properties, propsConsumed) = decodePropertiesSection(body, pos)
     pos += propsConsumed
@@ -365,7 +464,15 @@ private fun decodeUnsubAck(body: ByteArray): UnsubAck {
 
 // --- §3.14 DISCONNECT ---
 
-private fun decodeDisconnect(body: ByteArray): Disconnect {
+private fun decodeDisconnect(
+    body: ByteArray,
+    version: MqttProtocolVersion,
+): Disconnect {
+    // MQTT 3.1.1: DISCONNECT has no variable header or payload (§3.14)
+    if (!version.supportsProperties) {
+        return Disconnect()
+    }
+
     // Short form: empty body → SUCCESS with no properties
     if (body.isEmpty()) {
         return Disconnect()
@@ -412,3 +519,34 @@ private fun decodePropertiesSection(
     val props = decodeProperties(bytes, offset + lengthResult.bytesConsumed, propsLength)
     return props to (lengthResult.bytesConsumed + propsLength)
 }
+
+/**
+ * Map an MQTT 3.1.1 CONNACK return code (§3.2.2.3) to a [ReasonCode].
+ *
+ * The 3.1.1 return codes use different wire values than MQTT 5.0 reason codes,
+ * so this is NOT a simple `ReasonCode.fromValue()` lookup.
+ */
+internal fun reasonCodeFromConnAckReturnCode(returnCode: Int): ReasonCode =
+    when (returnCode) {
+        0 -> ReasonCode.SUCCESS
+        1 -> ReasonCode.UNSUPPORTED_PROTOCOL_VERSION
+        2 -> ReasonCode.CLIENT_IDENTIFIER_NOT_VALID
+        3 -> ReasonCode.SERVER_UNAVAILABLE
+        4 -> ReasonCode.BAD_USER_NAME_OR_PASSWORD
+        5 -> ReasonCode.NOT_AUTHORIZED
+        else -> ReasonCode.UNSPECIFIED_ERROR
+    }
+
+/**
+ * Map an MQTT 3.1.1 SUBACK return code (§3.9.3) to a [ReasonCode].
+ *
+ * 3.1.1 values: 0x00=Maximum QoS 0, 0x01=Maximum QoS 1, 0x02=Maximum QoS 2, 0x80=Failure.
+ */
+internal fun reasonCodeFromSubAckReturnCode(returnCode: Int): ReasonCode =
+    when (returnCode) {
+        0x00 -> ReasonCode.SUCCESS
+        0x01 -> ReasonCode.GRANTED_QOS_1
+        0x02 -> ReasonCode.GRANTED_QOS_2
+        0x80 -> ReasonCode.UNSPECIFIED_ERROR
+        else -> ReasonCode.UNSPECIFIED_ERROR
+    }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
@@ -191,7 +191,8 @@ private fun decodeConnAck(
     if (version.supportsProperties) {
         require(body.size >= 3) { "CONNACK body too short" }
     } else {
-        require(body.size >= 2) { "CONNACK body too short" }
+        // MQTT 3.1.1: exactly 2 bytes — acknowledge flags + return code (§3.2)
+        require(body.size == 2) { "CONNACK body must be exactly 2 bytes for MQTT 3.1.1" }
     }
     // Connect Acknowledge Flags — bits 7-1 are reserved and MUST be 0 (§3.2.2.1)
     require((body[0].toInt() and 0xFE) == 0) {
@@ -207,6 +208,12 @@ private fun decodeConnAck(
         // MQTT 3.1.1: single return code byte, no properties (§3.2.2.3)
         val returnCode = body[1].toInt() and 0xFF
         val reasonCode = reasonCodeFromConnAckReturnCode(returnCode)
+        // §3.2.2.3: If return code is non-zero, session present MUST be 0
+        if (reasonCode != ReasonCode.SUCCESS) {
+            require(!sessionPresent) {
+                "MQTT 3.1.1: sessionPresent must be 0 when return code is non-zero (§3.2.2.3)"
+            }
+        }
         ConnAck(sessionPresent = sessionPresent, reasonCode = reasonCode)
     }
 }
@@ -328,7 +335,10 @@ private fun decodeSubscribe(
                     retainHandling = RetainHandling.fromValue((options shr 4) and 0x03),
                 )
         } else {
-            // MQTT 3.1.1: options byte is just QoS (bits 0-1), rest reserved as 0
+            // MQTT 3.1.1: options byte is just QoS (bits 0-1), bits 2-7 reserved as 0 (§3.8.3.1)
+            require((options and 0xFC) == 0) {
+                "Reserved bits 2-7 in MQTT 3.1.1 subscription options must be 0 (§3.8.3.1)"
+            }
             subscriptions +=
                 Subscription(
                     topicFilter = topicFilter,

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
@@ -188,10 +188,19 @@ private fun decodeConnAck(
     body: ByteArray,
     version: MqttProtocolVersion,
 ): ConnAck {
-    if (version.supportsProperties) {
+    // Determine effective decode version. A 3.1.1-only broker receiving a V5.0 CONNECT
+    // responds with a 3.1.1 CONNACK (2 bytes, no properties). Detect this and decode
+    // as 3.1.1 so the version negotiation layer can handle the rejection gracefully.
+    val effectiveVersion =
+        if (version.supportsProperties && body.size == 2) {
+            MqttProtocolVersion.V3_1_1
+        } else {
+            version
+        }
+
+    if (effectiveVersion.supportsProperties) {
         require(body.size >= 3) { "CONNACK body too short" }
     } else {
-        // MQTT 3.1.1: exactly 2 bytes — acknowledge flags + return code (§3.2)
         require(body.size == 2) { "CONNACK body must be exactly 2 bytes for MQTT 3.1.1" }
     }
     // Connect Acknowledge Flags — bits 7-1 are reserved and MUST be 0 (§3.2.2.1)
@@ -200,7 +209,7 @@ private fun decodeConnAck(
     }
     val sessionPresent = (body[0].toInt() and 0x01) != 0
 
-    return if (version.supportsProperties) {
+    return if (effectiveVersion.supportsProperties) {
         val reasonCode = ReasonCode.fromValue(body[1].toInt() and 0xFF)
         val (properties, _) = decodePropertiesSection(body, 2)
         ConnAck(sessionPresent = sessionPresent, reasonCode = reasonCode, properties = properties)

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttEncoder.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttEncoder.kt
@@ -16,34 +16,85 @@
  */
 package org.meshtastic.mqtt.packet
 
+import org.meshtastic.mqtt.MqttProtocolVersion
 import org.meshtastic.mqtt.QoS
 import org.meshtastic.mqtt.ReasonCode
 
 /**
- * Encode any [MqttPacket] subclass into its complete MQTT 5.0 wire format bytes.
+ * Encode any [MqttPacket] subclass into its complete MQTT wire format bytes.
  *
  * The result includes the fixed header (packet type + flags + remaining length VBI)
- * followed by the variable header and payload per the OASIS MQTT 5.0 specification.
+ * followed by the variable header and payload per the OASIS MQTT specification.
+ *
+ * @param version The MQTT protocol version to encode for. Determines whether properties,
+ *   reason codes, and 5.0-only packets are included.
  */
 @Suppress("CyclomaticComplexMethod")
-internal fun MqttPacket.encode(): ByteArray {
+internal fun MqttPacket.encode(version: MqttProtocolVersion = MqttProtocolVersion.V5_0): ByteArray {
     val (flags, variableHeaderAndPayload) =
         when (this) {
-            is Connect -> encodeConnect()
-            is ConnAck -> encodeConnAck()
-            is Publish -> encodePublish()
-            is PubAck -> encodePubAckLike(PacketType.PUBACK, packetIdentifier, reasonCode, properties)
-            is PubRec -> encodePubAckLike(PacketType.PUBREC, packetIdentifier, reasonCode, properties)
-            is PubRel -> encodePubAckLike(PacketType.PUBREL, packetIdentifier, reasonCode, properties)
-            is PubComp -> encodePubAckLike(PacketType.PUBCOMP, packetIdentifier, reasonCode, properties)
-            is Subscribe -> encodeSubscribe()
-            is SubAck -> encodeSubAck()
-            is Unsubscribe -> encodeUnsubscribe()
-            is UnsubAck -> encodeUnsubAck()
-            PingReq -> encodePing(PacketType.PINGREQ)
-            PingResp -> encodePing(PacketType.PINGRESP)
-            is Disconnect -> encodeDisconnect()
-            is Auth -> encodeAuth()
+            is Connect -> {
+                encodeConnect(version)
+            }
+
+            is ConnAck -> {
+                encodeConnAck(version)
+            }
+
+            is Publish -> {
+                encodePublish(version)
+            }
+
+            is PubAck -> {
+                encodePubAckLike(PacketType.PUBACK, packetIdentifier, reasonCode, properties, version)
+            }
+
+            is PubRec -> {
+                encodePubAckLike(PacketType.PUBREC, packetIdentifier, reasonCode, properties, version)
+            }
+
+            is PubRel -> {
+                encodePubAckLike(PacketType.PUBREL, packetIdentifier, reasonCode, properties, version)
+            }
+
+            is PubComp -> {
+                encodePubAckLike(PacketType.PUBCOMP, packetIdentifier, reasonCode, properties, version)
+            }
+
+            is Subscribe -> {
+                encodeSubscribe(version)
+            }
+
+            is SubAck -> {
+                encodeSubAck(version)
+            }
+
+            is Unsubscribe -> {
+                encodeUnsubscribe(version)
+            }
+
+            is UnsubAck -> {
+                encodeUnsubAck(version)
+            }
+
+            PingReq -> {
+                encodePing(PacketType.PINGREQ)
+            }
+
+            PingResp -> {
+                encodePing(PacketType.PINGRESP)
+            }
+
+            is Disconnect -> {
+                encodeDisconnect(version)
+            }
+
+            is Auth -> {
+                require(version == MqttProtocolVersion.V5_0) {
+                    "AUTH packets are not supported in MQTT 3.1.1"
+                }
+                encodeAuth()
+            }
         }
 
     val fixedHeaderByte = (packetType.value shl 4) or flags
@@ -53,7 +104,7 @@ internal fun MqttPacket.encode(): ByteArray {
 
 // --- §3.1 CONNECT ---
 
-private fun Connect.encodeConnect(): Pair<Int, ByteArray> {
+private fun Connect.encodeConnect(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val parts = mutableListOf<ByteArray>()
 
     // Variable header
@@ -73,12 +124,16 @@ private fun Connect.encodeConnect(): Pair<Int, ByteArray> {
     parts += byteArrayOf(connectFlags.toByte())
 
     parts += WireFormat.encodeTwoByteInt(keepAliveSeconds)
-    parts += properties.encode()
+    if (version.supportsProperties) {
+        parts += properties.encode()
+    }
 
     // Payload
     parts += WireFormat.encodeUtf8String(clientId)
     if (willTopic != null) {
-        parts += willProperties.encode()
+        if (version.supportsProperties) {
+            parts += willProperties.encode()
+        }
         parts += WireFormat.encodeUtf8String(willTopic)
         parts += WireFormat.encodeBinaryData(willPayload ?: byteArrayOf())
     }
@@ -90,17 +145,22 @@ private fun Connect.encodeConnect(): Pair<Int, ByteArray> {
 
 // --- §3.2 CONNACK ---
 
-private fun ConnAck.encodeConnAck(): Pair<Int, ByteArray> {
+private fun ConnAck.encodeConnAck(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val parts = mutableListOf<ByteArray>()
     parts += byteArrayOf(if (sessionPresent) 0x01 else 0x00)
-    parts += byteArrayOf(reasonCode.value.toByte())
-    parts += properties.encode()
+    if (version.supportsProperties) {
+        parts += byteArrayOf(reasonCode.value.toByte())
+        parts += properties.encode()
+    } else {
+        // MQTT 3.1.1: single return code byte (§3.2.2.3)
+        parts += byteArrayOf(connAckReturnCodeFromReasonCode(reasonCode).toByte())
+    }
     return 0b0000 to joinByteArrays(parts)
 }
 
 // --- §3.3 PUBLISH ---
 
-private fun Publish.encodePublish(): Pair<Int, ByteArray> {
+private fun Publish.encodePublish(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val flags =
         (if (dup) 0b1000 else 0) or
             (qos.value shl 1) or
@@ -111,7 +171,9 @@ private fun Publish.encodePublish(): Pair<Int, ByteArray> {
     if (qos != QoS.AT_MOST_ONCE) {
         parts += WireFormat.encodeTwoByteInt(packetIdentifier!!)
     }
-    parts += properties.encode()
+    if (version.supportsProperties) {
+        parts += properties.encode()
+    }
     parts += payload
 
     return flags to joinByteArrays(parts)
@@ -124,8 +186,14 @@ private fun encodePubAckLike(
     packetId: Int,
     rc: ReasonCode,
     props: MqttProperties,
+    version: MqttProtocolVersion,
 ): Pair<Int, ByteArray> {
     val flags = type.requiredFlags ?: 0
+
+    // MQTT 3.1.1: only packet ID, no reason code or properties (§3.4)
+    if (!version.supportsProperties) {
+        return flags to WireFormat.encodeTwoByteInt(packetId)
+    }
 
     // Short form: if reason code is SUCCESS and no properties, just packet ID
     if (rc == ReasonCode.SUCCESS && props == MqttProperties.EMPTY) {
@@ -144,19 +212,26 @@ private fun encodePubAckLike(
 
 // --- §3.8 SUBSCRIBE ---
 
-private fun Subscribe.encodeSubscribe(): Pair<Int, ByteArray> {
+private fun Subscribe.encodeSubscribe(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val parts = mutableListOf<ByteArray>()
     parts += WireFormat.encodeTwoByteInt(packetIdentifier)
-    parts += properties.encode()
+    if (version.supportsProperties) {
+        parts += properties.encode()
+    }
 
     for (sub in subscriptions) {
         parts += WireFormat.encodeUtf8String(sub.topicFilter)
-        val options =
-            (sub.retainHandling.value shl 4) or
-                (if (sub.retainAsPublished) 0x08 else 0) or
-                (if (sub.noLocal) 0x04 else 0) or
-                sub.maxQos.value
-        parts += byteArrayOf(options.toByte())
+        if (version.supportsProperties) {
+            val options =
+                (sub.retainHandling.value shl 4) or
+                    (if (sub.retainAsPublished) 0x08 else 0) or
+                    (if (sub.noLocal) 0x04 else 0) or
+                    sub.maxQos.value
+            parts += byteArrayOf(options.toByte())
+        } else {
+            // MQTT 3.1.1: subscription options byte contains only QoS (§3.8.3.1)
+            parts += byteArrayOf(sub.maxQos.value.toByte())
+        }
     }
 
     return 0b0010 to joinByteArrays(parts)
@@ -164,20 +239,29 @@ private fun Subscribe.encodeSubscribe(): Pair<Int, ByteArray> {
 
 // --- §3.9 SUBACK ---
 
-private fun SubAck.encodeSubAck(): Pair<Int, ByteArray> {
+private fun SubAck.encodeSubAck(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val parts = mutableListOf<ByteArray>()
     parts += WireFormat.encodeTwoByteInt(packetIdentifier)
-    parts += properties.encode()
-    parts += ByteArray(reasonCodes.size) { reasonCodes[it].value.toByte() }
+    if (version.supportsProperties) {
+        parts += properties.encode()
+    }
+    if (version.supportsProperties) {
+        parts += ByteArray(reasonCodes.size) { reasonCodes[it].value.toByte() }
+    } else {
+        // MQTT 3.1.1 SUBACK return codes: 0x00, 0x01, 0x02 (granted QoS), 0x80 (failure)
+        parts += ByteArray(reasonCodes.size) { subAckReturnCodeFromReasonCode(reasonCodes[it]).toByte() }
+    }
     return 0b0000 to joinByteArrays(parts)
 }
 
 // --- §3.10 UNSUBSCRIBE ---
 
-private fun Unsubscribe.encodeUnsubscribe(): Pair<Int, ByteArray> {
+private fun Unsubscribe.encodeUnsubscribe(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val parts = mutableListOf<ByteArray>()
     parts += WireFormat.encodeTwoByteInt(packetIdentifier)
-    parts += properties.encode()
+    if (version.supportsProperties) {
+        parts += properties.encode()
+    }
     for (filter in topicFilters) {
         parts += WireFormat.encodeUtf8String(filter)
     }
@@ -186,11 +270,14 @@ private fun Unsubscribe.encodeUnsubscribe(): Pair<Int, ByteArray> {
 
 // --- §3.11 UNSUBACK ---
 
-private fun UnsubAck.encodeUnsubAck(): Pair<Int, ByteArray> {
+private fun UnsubAck.encodeUnsubAck(version: MqttProtocolVersion): Pair<Int, ByteArray> {
     val parts = mutableListOf<ByteArray>()
     parts += WireFormat.encodeTwoByteInt(packetIdentifier)
-    parts += properties.encode()
-    parts += ByteArray(reasonCodes.size) { reasonCodes[it].value.toByte() }
+    if (version.supportsProperties) {
+        parts += properties.encode()
+        parts += ByteArray(reasonCodes.size) { reasonCodes[it].value.toByte() }
+    }
+    // MQTT 3.1.1: UNSUBACK has no payload beyond packet identifier (§3.11)
     return 0b0000 to joinByteArrays(parts)
 }
 
@@ -203,7 +290,12 @@ private fun encodePing(type: PacketType): Pair<Int, ByteArray> {
 
 // --- §3.14 DISCONNECT ---
 
-private fun Disconnect.encodeDisconnect(): Pair<Int, ByteArray> {
+private fun Disconnect.encodeDisconnect(version: MqttProtocolVersion): Pair<Int, ByteArray> {
+    // MQTT 3.1.1: DISCONNECT has no variable header or payload (§3.14)
+    if (!version.supportsProperties) {
+        return 0b0000 to byteArrayOf()
+    }
+
     // Short form: if reason code is SUCCESS and no properties, empty body
     if (reasonCode == ReasonCode.SUCCESS && properties == MqttProperties.EMPTY) {
         return 0b0000 to byteArrayOf()
@@ -243,3 +335,24 @@ private fun joinByteArrays(parts: List<ByteArray>): ByteArray {
     }
     return result
 }
+
+/** Map a [ReasonCode] to an MQTT 3.1.1 CONNACK return code byte (§3.2.2.3). */
+internal fun connAckReturnCodeFromReasonCode(rc: ReasonCode): Int =
+    when (rc) {
+        ReasonCode.SUCCESS -> 0
+        ReasonCode.UNSUPPORTED_PROTOCOL_VERSION -> 1
+        ReasonCode.CLIENT_IDENTIFIER_NOT_VALID -> 2
+        ReasonCode.SERVER_UNAVAILABLE -> 3
+        ReasonCode.BAD_USER_NAME_OR_PASSWORD -> 4
+        ReasonCode.NOT_AUTHORIZED -> 5
+        else -> 5 // Map unknown failures to "Not authorized" as a safe fallback
+    }
+
+/** Map a [ReasonCode] to an MQTT 3.1.1 SUBACK return code byte (§3.9.3). */
+internal fun subAckReturnCodeFromReasonCode(rc: ReasonCode): Int =
+    when (rc) {
+        ReasonCode.SUCCESS -> 0x00
+        ReasonCode.GRANTED_QOS_1 -> 0x01
+        ReasonCode.GRANTED_QOS_2 -> 0x02
+        else -> 0x80 // Failure
+    }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttPacket.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttPacket.kt
@@ -55,7 +55,9 @@ internal data class Connect(
     override val packetType: PacketType get() = PacketType.CONNECT
 
     init {
-        require(protocolLevel == 5) { "Only MQTT 5.0 is supported (protocolLevel must be 5)" }
+        require(protocolLevel in intArrayOf(4, 5)) {
+            "Unsupported protocol level: $protocolLevel (must be 4 for MQTT 3.1.1 or 5 for MQTT 5.0)"
+        }
         require(keepAliveSeconds in 0..65535) { "keepAliveSeconds must be 0..65535" }
     }
 

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
@@ -23,12 +23,17 @@ import org.meshtastic.mqtt.packet.decodePacket
 import org.meshtastic.mqtt.packet.encode
 
 /**
- * In-memory [MqttTransport] for unit testing the MQTT 5.0 client state machine.
+ * In-memory [MqttTransport] for unit testing the MQTT client state machine.
  *
  * Provides helpers to enqueue broker responses, inspect client-sent packets,
  * and simulate connection errors — all without touching the network.
+ *
+ * @param version The protocol version used for encoding/decoding packets in
+ *   test helpers. Defaults to [MqttProtocolVersion.V5_0].
  */
-internal class FakeTransport : MqttTransport {
+internal class FakeTransport(
+    private val version: MqttProtocolVersion = MqttProtocolVersion.V5_0,
+) : MqttTransport {
     private var _isConnected = false
     override val isConnected: Boolean get() = _isConnected
 
@@ -95,14 +100,14 @@ internal class FakeTransport : MqttTransport {
 
     /** Encode and enqueue an [MqttPacket] for the client to receive. */
     fun enqueuePacket(packet: MqttPacket) {
-        enqueueReceive(packet.encode())
+        enqueueReceive(packet.encode(version))
     }
 
     /** Decode all sent byte arrays back into [MqttPacket] objects. */
-    fun decodeSentPackets(): List<MqttPacket> = _sentPackets.map { decodePacket(it) }
+    fun decodeSentPackets(): List<MqttPacket> = _sentPackets.map { decodePacket(it, version) }
 
     /** Decode the most recently sent packet. */
-    fun lastSentPacket(): MqttPacket = decodePacket(_sentPackets.last())
+    fun lastSentPacket(): MqttPacket = decodePacket(_sentPackets.last(), version)
 
     /** Clear the sent-packet history. */
     fun clearSent() {

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
@@ -1,0 +1,685 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.meshtastic.mqtt.packet.ConnAck
+import org.meshtastic.mqtt.packet.Connect
+import org.meshtastic.mqtt.packet.Disconnect
+import org.meshtastic.mqtt.packet.MqttProperties
+import org.meshtastic.mqtt.packet.PingReq
+import org.meshtastic.mqtt.packet.PingResp
+import org.meshtastic.mqtt.packet.PubAck
+import org.meshtastic.mqtt.packet.PubComp
+import org.meshtastic.mqtt.packet.PubRec
+import org.meshtastic.mqtt.packet.PubRel
+import org.meshtastic.mqtt.packet.Publish
+import org.meshtastic.mqtt.packet.SubAck
+import org.meshtastic.mqtt.packet.Subscribe
+import org.meshtastic.mqtt.packet.Subscription
+import org.meshtastic.mqtt.packet.UnsubAck
+import org.meshtastic.mqtt.packet.Unsubscribe
+import org.meshtastic.mqtt.packet.connAckReturnCodeFromReasonCode
+import org.meshtastic.mqtt.packet.decodePacket
+import org.meshtastic.mqtt.packet.encode
+import org.meshtastic.mqtt.packet.reasonCodeFromConnAckReturnCode
+import org.meshtastic.mqtt.packet.reasonCodeFromSubAckReturnCode
+import org.meshtastic.mqtt.packet.subAckReturnCodeFromReasonCode
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for MQTT 3.1.1 protocol support.
+ *
+ * Covers:
+ * - Encode/decode round-trips for all packet types under V3_1_1
+ * - CONNACK and SUBACK return code mapping
+ * - Connection-level state machine with FakeTransport
+ * - Config validation for 3.1.1-incompatible options
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LargeClass")
+class Mqtt311Test {
+    private val v311 = MqttProtocolVersion.V3_1_1
+    private val endpoint = MqttEndpoint.Tcp("localhost", 1883)
+
+    private fun v311Config(
+        keepAliveSeconds: Int = 0,
+        cleanStart: Boolean = true,
+        clientId: String = "test-client",
+    ): MqttConfig =
+        MqttConfig(
+            protocolVersion = MqttProtocolVersion.V3_1_1,
+            clientId = clientId,
+            keepAliveSeconds = keepAliveSeconds,
+            cleanStart = cleanStart,
+        )
+
+    private fun roundTrip311(packet: org.meshtastic.mqtt.packet.MqttPacket): org.meshtastic.mqtt.packet.MqttPacket {
+        val bytes = packet.encode(v311)
+        return decodePacket(bytes, v311)
+    }
+
+    // ===== CONNECT (§3.1) =====
+
+    @Test
+    fun connectMinimal311() {
+        val packet = Connect(protocolLevel = 4, clientId = "")
+        val decoded = roundTrip311(packet) as Connect
+        assertEquals("MQTT", decoded.protocolName)
+        assertEquals(4, decoded.protocolLevel)
+        assertEquals(true, decoded.cleanStart)
+        assertEquals("", decoded.clientId)
+    }
+
+    @Test
+    fun connectFull311() {
+        val willPayload = byteArrayOf(0x01, 0x02, 0x03)
+        val password = byteArrayOf(0xCA.toByte(), 0xFE.toByte())
+        val packet =
+            Connect(
+                protocolLevel = 4,
+                cleanStart = false,
+                keepAliveSeconds = 300,
+                clientId = "test-client-311",
+                willTopic = "will/topic",
+                willPayload = willPayload,
+                willQos = QoS.EXACTLY_ONCE,
+                willRetain = true,
+                username = "user",
+                password = password,
+            )
+        val decoded = roundTrip311(packet) as Connect
+        assertEquals(4, decoded.protocolLevel)
+        assertEquals(false, decoded.cleanStart)
+        assertEquals(300, decoded.keepAliveSeconds)
+        assertEquals("test-client-311", decoded.clientId)
+        assertEquals("will/topic", decoded.willTopic)
+        assertContentEquals(willPayload, decoded.willPayload)
+        assertEquals(QoS.EXACTLY_ONCE, decoded.willQos)
+        assertEquals(true, decoded.willRetain)
+        assertEquals("user", decoded.username)
+        assertContentEquals(password, decoded.password)
+    }
+
+    @Test
+    fun connectV311HasNoProperties() {
+        val packet =
+            Connect(
+                protocolLevel = 4,
+                clientId = "test",
+                properties = MqttProperties(sessionExpiryInterval = 999L),
+            )
+        val bytes = packet.encode(v311)
+        val decoded = decodePacket(bytes, v311) as Connect
+        // Properties should be empty — 3.1.1 doesn't encode them
+        assertEquals(MqttProperties.EMPTY, decoded.properties)
+    }
+
+    // ===== CONNACK (§3.2) =====
+
+    @Test
+    fun connAck311Success() {
+        val packet = ConnAck(sessionPresent = false, reasonCode = ReasonCode.SUCCESS)
+        val decoded = roundTrip311(packet) as ConnAck
+        assertEquals(false, decoded.sessionPresent)
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    @Test
+    fun connAck311SessionPresent() {
+        val packet = ConnAck(sessionPresent = true, reasonCode = ReasonCode.SUCCESS)
+        val decoded = roundTrip311(packet) as ConnAck
+        assertEquals(true, decoded.sessionPresent)
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    @Test
+    fun connAck311ReturnCodes() {
+        // Test all 3.1.1 CONNACK return codes
+        val cases =
+            listOf(
+                ReasonCode.SUCCESS to ReasonCode.SUCCESS,
+                ReasonCode.UNSUPPORTED_PROTOCOL_VERSION to ReasonCode.UNSUPPORTED_PROTOCOL_VERSION,
+                ReasonCode.CLIENT_IDENTIFIER_NOT_VALID to ReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+                ReasonCode.SERVER_UNAVAILABLE to ReasonCode.SERVER_UNAVAILABLE,
+                ReasonCode.BAD_USER_NAME_OR_PASSWORD to ReasonCode.BAD_USER_NAME_OR_PASSWORD,
+                ReasonCode.NOT_AUTHORIZED to ReasonCode.NOT_AUTHORIZED,
+            )
+        for ((input, expected) in cases) {
+            val packet = ConnAck(reasonCode = input)
+            val decoded = roundTrip311(packet) as ConnAck
+            assertEquals(expected, decoded.reasonCode, "CONNACK return code for $input")
+        }
+    }
+
+    // ===== PUBLISH (§3.3) =====
+
+    @Test
+    fun publishQos0V311() {
+        val packet =
+            Publish(
+                topicName = "test/topic",
+                payload = byteArrayOf(1, 2, 3),
+                qos = QoS.AT_MOST_ONCE,
+                retain = false,
+            )
+        val decoded = roundTrip311(packet) as Publish
+        assertEquals("test/topic", decoded.topicName)
+        assertContentEquals(byteArrayOf(1, 2, 3), decoded.payload)
+        assertEquals(QoS.AT_MOST_ONCE, decoded.qos)
+        assertEquals(MqttProperties.EMPTY, decoded.properties)
+    }
+
+    @Test
+    fun publishQos1V311() {
+        val packet =
+            Publish(
+                topicName = "test/topic",
+                payload = byteArrayOf(0xAB.toByte()),
+                qos = QoS.AT_LEAST_ONCE,
+                packetIdentifier = 42,
+            )
+        val decoded = roundTrip311(packet) as Publish
+        assertEquals("test/topic", decoded.topicName)
+        assertEquals(QoS.AT_LEAST_ONCE, decoded.qos)
+        assertEquals(42, decoded.packetIdentifier)
+    }
+
+    @Test
+    fun publishQos2V311() {
+        val packet =
+            Publish(
+                topicName = "important",
+                payload = byteArrayOf(),
+                qos = QoS.EXACTLY_ONCE,
+                packetIdentifier = 1000,
+                retain = true,
+            )
+        val decoded = roundTrip311(packet) as Publish
+        assertEquals(QoS.EXACTLY_ONCE, decoded.qos)
+        assertEquals(1000, decoded.packetIdentifier)
+        assertEquals(true, decoded.retain)
+    }
+
+    // ===== PUBACK (§3.4), PUBREC (§3.5), PUBREL (§3.6), PUBCOMP (§3.7) =====
+
+    @Test
+    fun pubAckV311() {
+        val packet = PubAck(packetIdentifier = 123)
+        val decoded = roundTrip311(packet) as PubAck
+        assertEquals(123, decoded.packetIdentifier)
+        // In 3.1.1 there is no reason code — decoder defaults to SUCCESS
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    @Test
+    fun pubRecV311() {
+        val packet = PubRec(packetIdentifier = 456)
+        val decoded = roundTrip311(packet) as PubRec
+        assertEquals(456, decoded.packetIdentifier)
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    @Test
+    fun pubRelV311() {
+        val packet = PubRel(packetIdentifier = 789)
+        val decoded = roundTrip311(packet) as PubRel
+        assertEquals(789, decoded.packetIdentifier)
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    @Test
+    fun pubCompV311() {
+        val packet = PubComp(packetIdentifier = 101)
+        val decoded = roundTrip311(packet) as PubComp
+        assertEquals(101, decoded.packetIdentifier)
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    // ===== SUBSCRIBE (§3.8) =====
+
+    @Test
+    fun subscribeV311() {
+        val packet =
+            Subscribe(
+                packetIdentifier = 10,
+                subscriptions = listOf(Subscription("test/#", QoS.AT_LEAST_ONCE)),
+            )
+        val decoded = roundTrip311(packet) as Subscribe
+        assertEquals(10, decoded.packetIdentifier)
+        assertEquals(1, decoded.subscriptions.size)
+        assertEquals("test/#", decoded.subscriptions[0].topicFilter)
+        assertEquals(QoS.AT_LEAST_ONCE, decoded.subscriptions[0].maxQos)
+    }
+
+    @Test
+    fun subscribeMultipleTopicsV311() {
+        val packet =
+            Subscribe(
+                packetIdentifier = 20,
+                subscriptions =
+                    listOf(
+                        Subscription("a/b", QoS.AT_MOST_ONCE),
+                        Subscription("c/d", QoS.EXACTLY_ONCE),
+                    ),
+            )
+        val decoded = roundTrip311(packet) as Subscribe
+        assertEquals(2, decoded.subscriptions.size)
+        assertEquals(QoS.AT_MOST_ONCE, decoded.subscriptions[0].maxQos)
+        assertEquals(QoS.EXACTLY_ONCE, decoded.subscriptions[1].maxQos)
+    }
+
+    // ===== SUBACK (§3.9) =====
+
+    @Test
+    fun subAckV311() {
+        val packet =
+            SubAck(
+                packetIdentifier = 10,
+                reasonCodes = listOf(ReasonCode.SUCCESS, ReasonCode.GRANTED_QOS_1),
+            )
+        val decoded = roundTrip311(packet) as SubAck
+        assertEquals(10, decoded.packetIdentifier)
+        assertEquals(2, decoded.reasonCodes.size)
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCodes[0])
+        assertEquals(ReasonCode.GRANTED_QOS_1, decoded.reasonCodes[1])
+    }
+
+    @Test
+    fun subAckFailureV311() {
+        val packet =
+            SubAck(
+                packetIdentifier = 11,
+                reasonCodes = listOf(ReasonCode.UNSPECIFIED_ERROR),
+            )
+        val decoded = roundTrip311(packet) as SubAck
+        // 0x80 on wire → UNSPECIFIED_ERROR
+        assertEquals(ReasonCode.UNSPECIFIED_ERROR, decoded.reasonCodes[0])
+    }
+
+    // ===== UNSUBSCRIBE (§3.10) =====
+
+    @Test
+    fun unsubscribeV311() {
+        val packet =
+            Unsubscribe(
+                packetIdentifier = 30,
+                topicFilters = listOf("a/b", "c/d"),
+            )
+        val decoded = roundTrip311(packet) as Unsubscribe
+        assertEquals(30, decoded.packetIdentifier)
+        assertEquals(listOf("a/b", "c/d"), decoded.topicFilters)
+    }
+
+    // ===== UNSUBACK (§3.11) =====
+
+    @Test
+    fun unsubAckV311() {
+        val packet = UnsubAck(packetIdentifier = 30, reasonCodes = listOf(ReasonCode.SUCCESS))
+        val decoded = roundTrip311(packet) as UnsubAck
+        assertEquals(30, decoded.packetIdentifier)
+        // 3.1.1 UNSUBACK has no return codes; decoder synthesizes SUCCESS
+        assertEquals(listOf(ReasonCode.SUCCESS), decoded.reasonCodes)
+    }
+
+    // ===== PINGREQ (§3.12) / PINGRESP (§3.13) =====
+
+    @Test
+    fun pingReqV311() {
+        val packet = PingReq
+        val decoded = roundTrip311(packet)
+        assertIs<PingReq>(decoded)
+    }
+
+    @Test
+    fun pingRespV311() {
+        val packet = PingResp
+        val decoded = roundTrip311(packet)
+        assertIs<PingResp>(decoded)
+    }
+
+    // ===== DISCONNECT (§3.14) =====
+
+    @Test
+    fun disconnectV311() {
+        val packet = Disconnect()
+        val bytes = packet.encode(v311)
+        // MQTT 3.1.1 DISCONNECT is just 0xE0 0x00
+        assertEquals(2, bytes.size, "3.1.1 DISCONNECT should be exactly 2 bytes")
+        assertEquals(0xE0.toByte(), bytes[0])
+        assertEquals(0x00.toByte(), bytes[1])
+        val decoded = decodePacket(bytes, v311) as Disconnect
+        assertEquals(ReasonCode.SUCCESS, decoded.reasonCode)
+    }
+
+    // ===== AUTH: should throw =====
+
+    @Test
+    fun authThrowsForV311() {
+        assertFailsWith<IllegalArgumentException> {
+            org.meshtastic.mqtt.packet
+                .Auth(reasonCode = ReasonCode.SUCCESS)
+                .encode(v311)
+        }
+    }
+
+    // ===== Return code mapping helpers =====
+
+    @Test
+    fun connAckReturnCodeMapping() {
+        assertEquals(ReasonCode.SUCCESS, reasonCodeFromConnAckReturnCode(0))
+        assertEquals(ReasonCode.UNSUPPORTED_PROTOCOL_VERSION, reasonCodeFromConnAckReturnCode(1))
+        assertEquals(ReasonCode.CLIENT_IDENTIFIER_NOT_VALID, reasonCodeFromConnAckReturnCode(2))
+        assertEquals(ReasonCode.SERVER_UNAVAILABLE, reasonCodeFromConnAckReturnCode(3))
+        assertEquals(ReasonCode.BAD_USER_NAME_OR_PASSWORD, reasonCodeFromConnAckReturnCode(4))
+        assertEquals(ReasonCode.NOT_AUTHORIZED, reasonCodeFromConnAckReturnCode(5))
+        assertEquals(ReasonCode.UNSPECIFIED_ERROR, reasonCodeFromConnAckReturnCode(99))
+    }
+
+    @Test
+    fun connAckReturnCodeFromReasonCodeMapping() {
+        assertEquals(0, connAckReturnCodeFromReasonCode(ReasonCode.SUCCESS))
+        assertEquals(1, connAckReturnCodeFromReasonCode(ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+        assertEquals(2, connAckReturnCodeFromReasonCode(ReasonCode.CLIENT_IDENTIFIER_NOT_VALID))
+        assertEquals(3, connAckReturnCodeFromReasonCode(ReasonCode.SERVER_UNAVAILABLE))
+        assertEquals(4, connAckReturnCodeFromReasonCode(ReasonCode.BAD_USER_NAME_OR_PASSWORD))
+        assertEquals(5, connAckReturnCodeFromReasonCode(ReasonCode.NOT_AUTHORIZED))
+    }
+
+    @Test
+    fun subAckReturnCodeMapping() {
+        assertEquals(ReasonCode.SUCCESS, reasonCodeFromSubAckReturnCode(0x00))
+        assertEquals(ReasonCode.GRANTED_QOS_1, reasonCodeFromSubAckReturnCode(0x01))
+        assertEquals(ReasonCode.GRANTED_QOS_2, reasonCodeFromSubAckReturnCode(0x02))
+        assertEquals(ReasonCode.UNSPECIFIED_ERROR, reasonCodeFromSubAckReturnCode(0x80))
+        assertEquals(ReasonCode.UNSPECIFIED_ERROR, reasonCodeFromSubAckReturnCode(0xFF))
+    }
+
+    @Test
+    fun subAckReturnCodeFromReasonCodeMapping() {
+        assertEquals(0x00, subAckReturnCodeFromReasonCode(ReasonCode.SUCCESS))
+        assertEquals(0x01, subAckReturnCodeFromReasonCode(ReasonCode.GRANTED_QOS_1))
+        assertEquals(0x02, subAckReturnCodeFromReasonCode(ReasonCode.GRANTED_QOS_2))
+        assertEquals(0x80, subAckReturnCodeFromReasonCode(ReasonCode.UNSPECIFIED_ERROR))
+    }
+
+    // ===== Config validation for 3.1.1 =====
+
+    @Test
+    fun configRejectsSessionExpiryForV311() {
+        assertFailsWith<IllegalArgumentException> {
+            MqttConfig(
+                protocolVersion = MqttProtocolVersion.V3_1_1,
+                clientId = "test",
+                sessionExpiryInterval = 60L,
+            )
+        }
+    }
+
+    @Test
+    fun configRejectsAuthForV311() {
+        assertFailsWith<IllegalArgumentException> {
+            MqttConfig(
+                protocolVersion = MqttProtocolVersion.V3_1_1,
+                clientId = "test",
+                authenticationMethod = "SCRAM-SHA-256",
+            )
+        }
+    }
+
+    @Test
+    fun configRejectsPasswordWithoutUsernameForV311() {
+        assertFailsWith<IllegalArgumentException> {
+            MqttConfig(
+                protocolVersion = MqttProtocolVersion.V3_1_1,
+                clientId = "test",
+                password = kotlinx.io.bytestring.ByteString("secret".encodeToByteArray()),
+            )
+        }
+    }
+
+    @Test
+    fun configAllowsPasswordWithUsernameForV311() {
+        val config =
+            MqttConfig(
+                protocolVersion = MqttProtocolVersion.V3_1_1,
+                clientId = "test",
+                username = "user",
+                password = kotlinx.io.bytestring.ByteString("secret".encodeToByteArray()),
+            )
+        assertEquals(MqttProtocolVersion.V3_1_1, config.protocolVersion)
+    }
+
+    // ===== Connection-level tests =====
+
+    @Test
+    fun connectV311Success() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+
+            val connAck = connection.connect(endpoint)
+            assertEquals(ReasonCode.SUCCESS, connAck.reasonCode)
+
+            // Verify the sent CONNECT packet has protocolLevel 4
+            val sentConnect = transport.decodeSentPackets().first() as Connect
+            assertEquals(4, sentConnect.protocolLevel)
+            assertEquals("MQTT", sentConnect.protocolName)
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun connectV311Rejected() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.NOT_AUTHORIZED))
+
+            assertFailsWith<MqttConnectionException> {
+                connection.connect(endpoint)
+            }
+        }
+
+    @Test
+    fun publishQos1V311Connection() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+
+            // Enqueue PUBACK for the publish
+            transport.enqueuePacket(PubAck(packetIdentifier = 1))
+
+            val reasonCode =
+                connection.publish(
+                    MqttMessage(
+                        topic = "test/topic",
+                        payload = kotlinx.io.bytestring.ByteString(byteArrayOf(1, 2, 3)),
+                        qos = QoS.AT_LEAST_ONCE,
+                    ),
+                )
+            assertEquals(ReasonCode.SUCCESS, reasonCode)
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun subscribeV311Connection() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+
+            transport.enqueuePacket(SubAck(packetIdentifier = 1, reasonCodes = listOf(ReasonCode.SUCCESS)))
+
+            val subAck =
+                connection.subscribe(
+                    listOf(Subscription("test/#", QoS.AT_LEAST_ONCE)),
+                )
+            assertEquals(1, subAck.reasonCodes.size)
+            assertEquals(ReasonCode.SUCCESS, subAck.reasonCodes[0])
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun subscribeV311RejectsNoLocal() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+
+            assertFailsWith<IllegalArgumentException> {
+                connection.subscribe(
+                    listOf(Subscription("test/#", QoS.AT_LEAST_ONCE, noLocal = true)),
+                )
+            }
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun subscribeV311RejectsRetainAsPublished() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+
+            assertFailsWith<IllegalArgumentException> {
+                connection.subscribe(
+                    listOf(Subscription("test/#", QoS.AT_LEAST_ONCE, retainAsPublished = true)),
+                )
+            }
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun subscribeV311RejectsRetainHandling() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+
+            assertFailsWith<IllegalArgumentException> {
+                connection.subscribe(
+                    listOf(
+                        Subscription(
+                            "test/#",
+                            QoS.AT_LEAST_ONCE,
+                            retainHandling = RetainHandling.DO_NOT_SEND,
+                        ),
+                    ),
+                )
+            }
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun disconnectV311SendsNoBodyPacket() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+            connection.disconnect()
+
+            // Find the DISCONNECT among sent packets (last packet before close)
+            val sentBytes = transport.sentPackets.last()
+            // MQTT 3.1.1 DISCONNECT is exactly 0xE0 0x00
+            assertEquals(2, sentBytes.size)
+            assertEquals(0xE0.toByte(), sentBytes[0])
+            assertEquals(0x00.toByte(), sentBytes[1])
+        }
+
+    @Test
+    fun receivePublishV311() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val config = v311Config()
+            val connection = MqttConnection(transport, config, this)
+
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            connection.connect(endpoint)
+
+            val incomingJob =
+                launch {
+                    val msg = withTimeout(1000) { connection.incomingMessages.first() }
+                    assertEquals("test/topic", msg.topic)
+                    assertContentEquals(byteArrayOf(0x42), msg.payload.toByteArray())
+                    assertEquals(QoS.AT_MOST_ONCE, msg.qos)
+                }
+
+            transport.enqueuePacket(
+                Publish(
+                    topicName = "test/topic",
+                    payload = byteArrayOf(0x42),
+                    qos = QoS.AT_MOST_ONCE,
+                ),
+            )
+
+            advanceUntilIdle()
+            incomingJob.join()
+
+            connection.disconnect()
+        }
+
+    @Test
+    fun protocolVersionEnum() {
+        assertEquals(4, MqttProtocolVersion.V3_1_1.protocolLevel)
+        assertEquals(5, MqttProtocolVersion.V5_0.protocolLevel)
+        assertTrue(!MqttProtocolVersion.V3_1_1.supportsProperties)
+        assertTrue(MqttProtocolVersion.V5_0.supportsProperties)
+        assertEquals(MqttProtocolVersion.V3_1_1, MqttProtocolVersion.fromProtocolLevel(4))
+        assertEquals(MqttProtocolVersion.V5_0, MqttProtocolVersion.fromProtocolLevel(5))
+        assertFailsWith<IllegalArgumentException> { MqttProtocolVersion.fromProtocolLevel(3) }
+    }
+}

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.io.bytestring.ByteString
 import org.meshtastic.mqtt.packet.ConnAck
 import org.meshtastic.mqtt.packet.Connect
 import org.meshtastic.mqtt.packet.Disconnect
@@ -715,6 +716,73 @@ class Mqtt311Test {
         assertFailsWith<IllegalArgumentException> {
             withAuth.validateV311Compatibility()
         }
+
+        // Should fail — userProperties are 5.0-only
+        val withProps = MqttConfig(clientId = "test", userProperties = listOf("k" to "v"))
+        assertFailsWith<IllegalArgumentException> {
+            withProps.validateV311Compatibility()
+        }
+
+        // Should fail — maximumPacketSize is 5.0-only
+        val withMaxPacket = MqttConfig(clientId = "test", maximumPacketSize = 1024L)
+        assertFailsWith<IllegalArgumentException> {
+            withMaxPacket.validateV311Compatibility()
+        }
+
+        // Should fail — topicAliasMaximum > 0 is 5.0-only
+        val withTopicAlias = MqttConfig(clientId = "test", topicAliasMaximum = 10)
+        assertFailsWith<IllegalArgumentException> {
+            withTopicAlias.validateV311Compatibility()
+        }
+
+        // Should fail — requestResponseInformation is 5.0-only
+        val withRRI = MqttConfig(clientId = "test", requestResponseInformation = true)
+        assertFailsWith<IllegalArgumentException> {
+            withRRI.validateV311Compatibility()
+        }
+
+        // Should fail — receiveMaximum != 65535 is 5.0-only
+        val withRecvMax = MqttConfig(clientId = "test", receiveMaximum = 10)
+        assertFailsWith<IllegalArgumentException> {
+            withRecvMax.validateV311Compatibility()
+        }
+
+        // Should fail — will with 5.0-only properties
+        val withWillDelay =
+            MqttConfig(
+                clientId = "test",
+                will =
+                    WillConfig(
+                        topic = "t",
+                        payload = ByteString(),
+                        willDelayInterval = 60L,
+                    ),
+            )
+        assertFailsWith<IllegalArgumentException> {
+            withWillDelay.validateV311Compatibility()
+        }
+
+        val withWillContentType =
+            MqttConfig(
+                clientId = "test",
+                will =
+                    WillConfig(
+                        topic = "t",
+                        payload = ByteString(),
+                        contentType = "application/json",
+                    ),
+            )
+        assertFailsWith<IllegalArgumentException> {
+            withWillContentType.validateV311Compatibility()
+        }
+
+        // Should pass — will with basic fields only
+        val withBasicWill =
+            MqttConfig(
+                clientId = "test",
+                will = WillConfig(topic = "t", payload = ByteString()),
+            )
+        withBasicWill.validateV311Compatibility()
     }
 
     @Test

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
@@ -682,4 +682,136 @@ class Mqtt311Test {
         assertEquals(MqttProtocolVersion.V5_0, MqttProtocolVersion.fromProtocolLevel(5))
         assertFailsWith<IllegalArgumentException> { MqttProtocolVersion.fromProtocolLevel(3) }
     }
+
+    // ===== Version negotiation =====
+
+    @Test
+    fun negotiateVersionDefaultIsTrue() {
+        val config = MqttConfig(clientId = "test")
+        assertEquals(true, config.negotiateVersion)
+        assertEquals(MqttProtocolVersion.V5_0, config.protocolVersion)
+    }
+
+    @Test
+    fun negotiateVersionCanBeDisabled() {
+        val config = MqttConfig(clientId = "test", negotiateVersion = false)
+        assertEquals(false, config.negotiateVersion)
+    }
+
+    @Test
+    fun v311CompatibilityValidation() {
+        // Should pass — no 5.0-only features
+        val basic = MqttConfig(clientId = "test")
+        basic.validateV311Compatibility()
+
+        // Should fail — sessionExpiryInterval is 5.0-only
+        val withExpiry = MqttConfig(clientId = "test", sessionExpiryInterval = 60L)
+        assertFailsWith<IllegalArgumentException> {
+            withExpiry.validateV311Compatibility()
+        }
+
+        // Should fail — enhanced auth is 5.0-only
+        val withAuth = MqttConfig(clientId = "test", authenticationMethod = "SCRAM")
+        assertFailsWith<IllegalArgumentException> {
+            withAuth.validateV311Compatibility()
+        }
+    }
+
+    @Test
+    fun versionFallbackOnUnsupportedProtocol() =
+        runTest {
+            // Simulate: first transport rejects V5 with UNSUPPORTED_PROTOCOL_VERSION,
+            // second transport accepts V3.1.1
+            val v5Transport = FakeTransport(MqttProtocolVersion.V5_0)
+            val v311Transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val transports = mutableListOf(v5Transport, v311Transport)
+
+            // Enqueue rejection for V5
+            v5Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+            // Enqueue success for V3.1.1
+            v311Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = true,
+                )
+            val client = MqttClient(config, this) { transports.removeAt(0) }
+
+            client.connect(endpoint)
+            advanceUntilIdle()
+
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
+            assertEquals(MqttProtocolVersion.V3_1_1, client.negotiatedProtocolVersion)
+
+            // Verify the V3.1.1 CONNECT used protocolLevel 4
+            val sentConnect = v311Transport.decodeSentPackets().first() as Connect
+            assertEquals(4, sentConnect.protocolLevel)
+
+            client.close()
+        }
+
+    @Test
+    fun noFallbackWhenNegotiateVersionDisabled() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V5_0)
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = false,
+                )
+            val client = MqttClient(config, transport, this)
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+            assertEquals(MqttProtocolVersion.V5_0, client.negotiatedProtocolVersion)
+
+            client.close()
+        }
+
+    @Test
+    fun noFallbackWhenAlreadyV311() =
+        runTest {
+            val transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+
+            val config = v311Config()
+            val client = MqttClient(config, transport, this)
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+
+            client.close()
+        }
+
+    @Test
+    fun noFallbackWhenIncompatibleConfig() =
+        runTest {
+            val v5Transport = FakeTransport(MqttProtocolVersion.V5_0)
+            v5Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+
+            // Config has sessionExpiryInterval — can't fall back to 3.1.1
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = true,
+                    sessionExpiryInterval = 60L,
+                )
+            val client = MqttClient(config, v5Transport, this)
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+            // Should still be V5 — fallback was not attempted
+            assertEquals(MqttProtocolVersion.V5_0, client.negotiatedProtocolVersion)
+
+            client.close()
+        }
 }


### PR DESCRIPTION
## Summary

Add full MQTT 3.1.1 protocol support alongside the existing MQTT 5.0 implementation, with seamless version auto-negotiation so clients connect to any broker without manual configuration.

## Changes

### MQTT 3.1.1 Codec (`feat(codec)`)
- All 15 encoder/decoder functions accept a `version` parameter
- 3.1.1 wire protocol differences: no properties, 1-byte CONNACK return codes, QoS-only SUBSCRIBE options, body-less DISCONNECT, no AUTH packet
- Bidirectional CONNACK/SUBACK return code ↔ reason code mapping
- New `MqttProtocolVersion` public enum (`V3_1_1`, `V5_0`)

### Version Auto-Negotiation (`feat(client)`)
- `negotiateVersion: Boolean = true` config flag — tries V5.0 first, falls back to V3.1.1 on `UNSUPPORTED_PROTOCOL_VERSION`
- `negotiatedProtocolVersion` public property on `MqttClient`
- Comprehensive `validateV311Compatibility()` checks all V5.0-only config fields before fallback
- Auto-reconnect preserves negotiated version

### Critical Bug Fix (`fix(codec)`)
- When a 3.1.1-only broker rejects a V5.0 CONNECT, it sends a **3.1.1-format CONNACK** (2 bytes), not V5.0 (≥3 bytes). The decoder now detects this and decodes correctly, enabling negotiation to work.

### Hardened Validation (`fix(codec)`)
- Expanded `validateV311Compatibility()` to check: userProperties, maximumPacketSize, topicAliasMaximum, requestResponseInformation, receiveMaximum, and all will 5.0 properties
- 3.1.1 CONNACK enforces exact 2-byte body + sessionPresent=0 on non-success
- 3.1.1 SUBSCRIBE enforces reserved bits 2-7 = 0

## Testing

### Unit Tests (48+ new tests in `Mqtt311Test.kt`)
- Encode/decode round-trips for all 3.1.1 packet types
- Config validation (comprehensive V5.0-only field checks)
- Connection state machine with `FakeTransport`
- Version negotiation: fallback success, disabled, already V3.1.1, incompatible config

### Live Broker Validation (6 brokers, 10 scenarios)
| Broker | Protocol | Transport | Result |
|--------|----------|-----------|--------|
| mqtt.meshtastic.org | V5.0 | TLS:8883 | ✅ |
| mqtt.meshtastic.pt | V5→V3.1.1 negotiation | TCP:1883 | ✅ |
| mqtt.meshtastic.liamcottle.net | V5.0 + V3.1.1 | TCP:1883 | ✅ |
| mqtt.meshmap.app | V5.0 + V3.1.1 | TCP:1883 | ✅ |
| broker.emqx.io | V5.0 TCP/TLS + V3.1.1 | TCP:1883, TLS:8883 | ✅ |
| broker.hivemq.com | V5.0 | TCP:1883 | ✅ |

### All checks green
`spotlessCheck` · `detekt` · `jvmTest` · `testAndroidHostTest` · `apiCheck` · `koverVerify` (≥80%)

## Competitor Comparison
- **KMQTT** (292★): Separate class hierarchies per version, NO auto-negotiation
- **ktor-mqtt** (55★): V5.0 only, explicitly doesn't support 3.1.1
- Our approach: single hierarchy + version param + seamless negotiation — unique in the KMP ecosystem