### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-28
+
+### Added
+- **Full MQTT 3.1.1 protocol support** with seamless version auto-negotiation (#36)
+  - All 15 encoder/decoder functions accept a `version` parameter
+  - 3.1.1 wire protocol differences: no properties, 1-byte CONNACK return codes, QoS-only SUBSCRIBE options, body-less DISCONNECT, no AUTH packet
+  - `negotiateVersion: Boolean = true` config flag — tries V5.0 first, falls back to V3.1.1 on `UNSUPPORTED_PROTOCOL_VERSION`
+  - `negotiatedProtocolVersion` public property on `MqttClient`
+  - New `MqttProtocolVersion` public enum (`V3_1_1`, `V5_0`)
+
+### Fixed
+- Correct decoding of 3.1.1-format CONNACK (2 bytes) when a V3.1.1-only broker rejects a V5.0 CONNECT (#36)
+
+### Changed
+- Bump Compose Multiplatform to 1.11.0-beta03, Material3 to 1.11.0-alpha07, Adaptive to 1.3.0-alpha07, compileSdk to 37 (#31)
+- Bump Kotlin to 2.3.21
+- Bump Ktor ecosystem to 3.4.3
+- Bump AGP to 9.2.0
+- Bump Develocity plugin to 4.4.1
+
 ## [0.2.0] - 2026-04-17
 
 ### Changed (BREAKING)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ repositories {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("org.meshtastic:mqtt-client:0.2.0")
+            implementation("org.meshtastic:mqtt-client:0.3.0")
         }
     }
 }
@@ -105,7 +105,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation 'org.meshtastic:mqtt-client:0.2.0'
+                implementation 'org.meshtastic:mqtt-client:0.3.0'
             }
         }
     }
@@ -118,7 +118,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation("org.meshtastic:mqtt-client:0.2.0")
+    implementation("org.meshtastic:mqtt-client:0.3.0")
 }
 ```
 </details>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ android.nonTransitiveRClass=true
 #Picked up automatically by com.vanniktech.maven.publish. Override in CI with -PVERSION_NAME=...
 GROUP=org.meshtastic
 POM_ARTIFACT_ID=mqtt-client
-VERSION_NAME=0.2.0
+VERSION_NAME=0.3.0
 #Compose Desktop — allow Homebrew/OpenJDK vendors for local `packageReleaseDmg` runs.
 #CI uses Temurin via setup-java so this is a no-op there.
 compose.desktop.packaging.checkJdkVendor=false


### PR DESCRIPTION
## 0.3.0 Release

### What's in this release

**New:**
- **Full MQTT 3.1.1 protocol support** with seamless version auto-negotiation (#36)
  - All 15 encoder/decoder functions accept a `version` parameter
  - `negotiateVersion` config flag — tries V5.0 first, falls back to V3.1.1
  - `negotiatedProtocolVersion` and `MqttProtocolVersion` public API additions

**Fixed:**
- Correct decoding of 3.1.1-format CONNACK when a V3.1.1-only broker rejects a V5.0 CONNECT (#36)

**Dependencies:**
- Compose Multiplatform → 1.11.0-beta03, Material3 → 1.11.0-alpha07, Adaptive → 1.3.0-alpha07, compileSdk → 37 (#31)
- Kotlin → 2.3.21, Ktor → 3.4.3, AGP → 9.2.0, Develocity → 4.4.1

### Release checklist
- [x] #36 merged
- [x] #31 merged
- [ ] CI green on this branch
- [ ] Tag `v0.3.0` after merge
- [ ] Publish to Maven (via CI or `./gradlew publishToMavenLocal`)