### PR TITLE
fix: gracefully decode v3.1.1 packets in v5 sessions (mixed broker compat)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ android.nonTransitiveRClass=true
 #Picked up automatically by com.vanniktech.maven.publish. Override in CI with -PVERSION_NAME=...
 GROUP=org.meshtastic
 POM_ARTIFACT_ID=mqtt-client
-VERSION_NAME=0.3.5
+VERSION_NAME=0.3.6
 #Compose Desktop — allow Homebrew/OpenJDK vendors for local `packageReleaseDmg` runs.
 #CI uses Temurin via setup-java so this is a no-op there.
 compose.desktop.packaging.checkJdkVendor=false

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -58,6 +58,7 @@ import org.meshtastic.mqtt.packet.UnsubAck
 import org.meshtastic.mqtt.packet.Unsubscribe
 import org.meshtastic.mqtt.packet.decodePacket
 import org.meshtastic.mqtt.packet.encode
+import org.meshtastic.mqtt.packet.hexDump
 import kotlin.concurrent.Volatile
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
@@ -830,7 +831,11 @@ internal class MqttConnection(
                             try {
                                 decodePacket(bytes, version)
                             } catch (e: IllegalArgumentException) {
-                                log.error(TAG) { "Failed to decode packet: ${e.message}" }
+                                log.error(TAG) {
+                                    "Failed to decode packet (${bytes.size} bytes, " +
+                                        "version=$version): ${e.message}. " +
+                                        "Raw hex: ${bytes.hexDump()}"
+                                }
                                 throw e
                             }
                         log.debug(TAG) { "Received ${packet.packetType}" }

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
@@ -250,9 +250,16 @@ private fun decodePublish(
 
     val properties: MqttProperties
     if (version.supportsProperties) {
-        val (props, propsConsumed) = decodePropertiesSection(body, pos)
-        properties = props
-        pos += propsConsumed
+        // Some brokers accept a v5 CONNECT but relay messages from 3.1.1 clients
+        // without a properties section. Try v5 decode; fall back to treating
+        // remaining bytes as raw payload (3.1.1 style).
+        val propertiesResult = tryDecodePropertiesSection(body, pos)
+        if (propertiesResult != null) {
+            properties = propertiesResult.first
+            pos += propertiesResult.second
+        } else {
+            properties = MqttProperties.EMPTY
+        }
     } else {
         properties = MqttProperties.EMPTY
     }
@@ -297,7 +304,7 @@ private fun <T : MqttPacket> decodePubAckLike(
         return factory(packetId, reasonCode, MqttProperties.EMPTY)
     }
 
-    val (properties, _) = decodePropertiesSection(body, 3)
+    val properties = tryDecodePropertiesSection(body, 3)?.first ?: MqttProperties.EMPTY
     return factory(packetId, reasonCode, properties)
 }
 
@@ -376,9 +383,16 @@ private fun decodeSubAck(
 
     val properties: MqttProperties
     if (version.supportsProperties) {
-        val (props, propsConsumed) = decodePropertiesSection(body, pos)
-        properties = props
-        pos += propsConsumed
+        // Some brokers accept a v5 CONNECT but respond with 3.1.1-style SUBACKs
+        // (no properties section). Detect this by trying v5 decode first; if properties
+        // parsing fails, fall back to treating remaining bytes as bare return codes.
+        val propertiesResult = tryDecodePropertiesSection(body, pos)
+        if (propertiesResult != null) {
+            properties = propertiesResult.first
+            pos += propertiesResult.second
+        } else {
+            properties = MqttProperties.EMPTY
+        }
     } else {
         properties = MqttProperties.EMPTY
     }
@@ -461,8 +475,16 @@ private fun decodeUnsubAck(
         )
     }
 
-    val (properties, propsConsumed) = decodePropertiesSection(body, pos)
-    pos += propsConsumed
+    // Some brokers accept a v5 CONNECT but respond with 3.1.1-style packets.
+    // Try v5 properties decode; fall back to bare reason codes on failure.
+    val propertiesResult = tryDecodePropertiesSection(body, pos)
+    val properties: MqttProperties
+    if (propertiesResult != null) {
+        properties = propertiesResult.first
+        pos += propertiesResult.second
+    } else {
+        properties = MqttProperties.EMPTY
+    }
 
     val reasonCodes = mutableListOf<ReasonCode>()
     while (pos < body.size) {
@@ -548,7 +570,25 @@ private fun decodePropertiesSection(
     return props to (lengthResult.bytesConsumed + propsLength)
 }
 
-private fun ByteArray.toHexDump(): String {
+/**
+ * Try to decode a properties section. Returns null if the bytes don't form a valid
+ * properties section — this handles brokers that accept a v5 CONNECT but respond with
+ * 3.1.1-style packets (no properties section in SUBACK/UNSUBACK/etc.).
+ */
+@Suppress("SwallowedException")
+private fun tryDecodePropertiesSection(
+    bytes: ByteArray,
+    offset: Int,
+): Pair<MqttProperties, Int>? =
+    try {
+        decodePropertiesSection(bytes, offset)
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+private fun ByteArray.toHexDump(): String = hexDump()
+
+internal fun ByteArray.hexDump(): String {
     fun Byte.hex(): String {
         val i = toInt() and 0xFF
         val hi = "0123456789abcdef"[i ushr 4]

--- a/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttProperties.kt
+++ b/library/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttProperties.kt
@@ -242,9 +242,19 @@ internal fun decodeProperties(
     var sharedSubscriptionAvailable: Boolean? = null
 
     while (pos < end) {
+        require(pos < bytes.size) {
+            "Property section overflows buffer: pos=$pos, end=$end, " +
+                "bodySize=${bytes.size}. Hex: ${bytes.hexDump()}"
+        }
         val idResult = VariableByteInt.decode(bytes, pos)
         pos += idResult.bytesConsumed
         val propertyId = idResult.value
+
+        // Bounds-check: the property value must start within the declared section
+        require(pos <= end && pos <= bytes.size) {
+            "Property 0x${propertyId.toString(16)} value overflows section: " +
+                "pos=$pos, end=$end, bodySize=${bytes.size}. Hex: ${bytes.hexDump()}"
+        }
 
         // Multi-occurrence properties: User Property and Subscription Identifier
         val isMultiOccurrence =
@@ -445,9 +455,15 @@ private fun decodeBooleanByte(
     bytes: ByteArray,
     offset: Int,
 ): Boolean {
-    require(offset < bytes.size) { "Not enough bytes for boolean at offset $offset" }
+    require(offset < bytes.size) {
+        "Not enough bytes for boolean at offset $offset " +
+            "(bodySize=${bytes.size}). Hex: ${bytes.hexDump()}"
+    }
     val b = bytes[offset].toInt() and 0xFF
-    require(b == 0 || b == 1) { "Malformed boolean value 0x${b.toString(16)} at offset $offset (§1.5.1.4)" }
+    require(b == 0 || b == 1) {
+        "Malformed boolean value 0x${b.toString(16)} at offset $offset (§1.5.1.4). " +
+            "Hex: ${bytes.hexDump()}"
+    }
     return b == 1
 }
 

--- a/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttConnectionTest.kt
+++ b/library/src/commonTest/kotlin/org/meshtastic/mqtt/MqttConnectionTest.kt
@@ -1145,7 +1145,7 @@ class MqttConnectionTest {
         }
 
     @Test
-    fun v5ConnectionDisconnectsOnMalformedPacket() =
+    fun v5ConnectionDecodesV311PublishGracefully() =
         runTest {
             val transport = FakeTransport()
             val connection = MqttConnection(transport, defaultConfig(), this)
@@ -1154,8 +1154,9 @@ class MqttConnectionTest {
             connection.connect(endpoint)
             advanceUntilIdle()
 
-            // Send a v3.1.1-encoded packet to a v5 connection — should be treated as
-            // a decode error and disconnect, not silently downgrade protocol version.
+            // Some brokers accept a v5 CONNECT but relay PUBLISH messages from
+            // v3.1.1 clients without a properties section.  The decoder should
+            // fall back gracefully (empty properties) instead of disconnecting.
             val v311Publish =
                 Publish(
                     topicName = "test/topic",
@@ -1166,10 +1167,13 @@ class MqttConnectionTest {
             advanceUntilIdle()
 
             val state = connection.connectionState.value
-            assertIs<ConnectionState.Disconnected>(
+            assertIs<ConnectionState.Connected>(
                 state,
-                "Connection should disconnect on malformed packet, not downgrade protocol",
+                "Connection should stay connected when receiving a v3.1.1 PUBLISH in a v5 session",
             )
+
+            connection.disconnect()
+            advanceUntilIdle()
         }
 
     // --- Session Present validation (§3.2.2.1.1) ---

--- a/library/src/jvmTest/kotlin/org/meshtastic/mqtt/MqttPtDiagnosticTest.kt
+++ b/library/src/jvmTest/kotlin/org/meshtastic/mqtt/MqttPtDiagnosticTest.kt
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.meshtastic.mqtt.packet.Subscription
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Diagnostic test that replicates the **exact** Meshtastic-Android MQTT proxy flow against
+ * the Portugal broker (mqtt.meshtastic.pt:8883) with full DEBUG-level logging.
+ *
+ * Purpose: trace the "Not enough bytes for boolean at offset 4" decode crash that users
+ * report after the first publish succeeds but subsequent publishes fail.
+ *
+ * The test mimics:
+ * - MQTTRepositoryImpl: connect → subscribe (QoS 1, noLocal) → fire-and-forget publishes
+ * - autoReconnect = true, keepAliveSeconds = 30
+ * - Subscribes to real Meshtastic topic patterns so incoming traffic from the mesh is received
+ *
+ * Run with:
+ *   ./gradlew :library:jvmTest --tests "*.MqttPtDiagnosticTest" --info 2>&1 | tee /tmp/pt-diag.log
+ */
+class MqttPtDiagnosticTest {
+    private val brokerHost = "mqtt.meshtastic.pt"
+    private val brokerPort = 1883
+    private val endpoint = MqttEndpoint.Tcp(brokerHost, brokerPort, tls = false)
+    private val username = "meshdev"
+    private val password = "large4cats"
+
+    // Meshtastic topic constants (mirrors MQTTRepositoryImpl)
+    private val rootTopic = "msh"
+    private val topicLevel = "/2/e/"
+    private val testChannelId = "LongFast"
+
+    /** Verbose logger that timestamps every line for post-mortem analysis. */
+    private val verboseLogger =
+        object : MqttLogger {
+            override fun log(
+                level: MqttLogLevel,
+                tag: String,
+                message: String,
+                throwable: Throwable?,
+            ) {
+                val ts = java.time.Instant.now()
+                println("[$ts][$level] $tag: $message")
+                throwable?.let {
+                    println("[$ts]  ↳ ${it::class.simpleName}: ${it.message}")
+                    it.cause?.let { c ->
+                        println("[$ts]  ↳ caused by ${c::class.simpleName}: ${c.message}")
+                    }
+                }
+            }
+        }
+
+    private fun createClient(
+        clientId: String = "pt-diag-${System.nanoTime()}",
+        autoReconnect: Boolean = true,
+    ): MqttClient =
+        MqttClient(clientId) {
+            keepAliveSeconds = 30
+            cleanStart = true
+            this.username = this@MqttPtDiagnosticTest.username
+            password(this@MqttPtDiagnosticTest.password)
+            this.autoReconnect = autoReconnect
+            logLevel = MqttLogLevel.TRACE
+            logger = verboseLogger
+        }
+
+    private fun brokerAvailable(): Boolean =
+        try {
+            java.net.Socket().use { socket ->
+                socket.connect(java.net.InetSocketAddress(brokerHost, brokerPort), 5000)
+            }
+            true
+        } catch (_: Exception) {
+            false
+        }
+
+    private fun skipIfNoBroker(): Boolean {
+        if (!brokerAvailable()) {
+            println("SKIPPED: $brokerHost:$brokerPort not reachable (geoblocking may be active)")
+            return true
+        }
+        return false
+    }
+
+    // ─── Test: Full Meshtastic Android proxy flow ───
+
+    /**
+     * Replicates the exact flow from MQTTRepositoryImpl.proxyMessageFlow:
+     * 1. Create client with autoReconnect=true, keepAlive=30s
+     * 2. Collect messages in background (like the Android `launch { messages.collect }`)
+     * 3. Collect connection state in background (like the Android state observer)
+     * 4. Connect to broker
+     * 5. Subscribe to Meshtastic topics with QoS 1 + noLocal
+     * 6. Fire-and-forget publishes with delays (simulating mesh packets)
+     *
+     * Logs every state transition, every incoming message, and every publish result.
+     */
+    @Test
+    fun fullMeshtasticProxyFlow() =
+        runBlocking {
+            if (skipIfNoBroker()) return@runBlocking
+
+            val nonce = System.nanoTime()
+            val clientId = "MeshtasticAndroidMqttProxy-!diag$nonce"
+            val client = createClient(clientId = clientId)
+
+            // Meshtastic-style subscriptions (matches Android MQTTRepositoryImpl)
+            val subscriptions =
+                listOf(
+                    Subscription(
+                        "$rootTopic$topicLevel$testChannelId/+",
+                        maxQos = QoS.AT_LEAST_ONCE,
+                        noLocal = true,
+                    ),
+                    Subscription(
+                        "${rootTopic}${topicLevel}PKI/+",
+                        maxQos = QoS.AT_LEAST_ONCE,
+                        noLocal = true,
+                    ),
+                )
+
+            val stateTransitions = mutableListOf<String>()
+            val receivedMessages = mutableListOf<String>()
+            val publishResults = mutableListOf<String>()
+
+            try {
+                // Background: collect messages (mirrors Android's launch { messages.collect })
+                val msgJob =
+                    launch {
+                        client.messages.collect { msg ->
+                            val summary =
+                                "topic=${msg.topic}, qos=${msg.qos}, " +
+                                    "payloadSize=${msg.payload.size}, retain=${msg.retain}"
+                            receivedMessages += summary
+                            println("  ▶ INCOMING MESSAGE: $summary")
+                        }
+                    }
+
+                // Background: observe connection state (mirrors Android's state collector)
+                val stateJob =
+                    launch {
+                        client.connectionState.collect { state ->
+                            val desc =
+                                when (state) {
+                                    ConnectionState.Connecting -> {
+                                        "Connecting"
+                                    }
+
+                                    ConnectionState.Connected -> {
+                                        "Connected"
+                                    }
+
+                                    is ConnectionState.Reconnecting -> {
+                                        "Reconnecting(attempt=${state.attempt}, " +
+                                            "error=${state.lastError?.message})"
+                                    }
+
+                                    is ConnectionState.Disconnected -> {
+                                        "Disconnected(reason=${state.reason?.message})"
+                                    }
+                                }
+                            stateTransitions += desc
+                            println("  ★ STATE: $desc")
+                        }
+                    }
+
+                // Step 1: Connect
+                println("\n═══ STEP 1: Connecting to $endpoint ═══")
+                client.connect(endpoint)
+                withTimeout(15.seconds) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
+                        delay(50)
+                    }
+                }
+                println("  ✓ Connected")
+
+                // Step 2: Subscribe (like Android does immediately after connect)
+                println("\n═══ STEP 2: Subscribing to ${subscriptions.size} topics ═══")
+                subscriptions.forEach { println("  → ${it.topicFilter} (QoS=${it.maxQos}, noLocal=${it.noLocal})") }
+                client.subscribe(subscriptions)
+                println("  ✓ Subscribed")
+
+                // Step 3: Wait a moment for any incoming retained/traffic
+                println("\n═══ STEP 3: Waiting 3s for incoming traffic ═══")
+                delay(3000)
+                println("  Received ${receivedMessages.size} messages so far")
+
+                // Step 4: Sequential publishes with delays (simulating mesh packets)
+                val publishTopic = "$rootTopic$topicLevel$testChannelId/!diag$nonce"
+                val messageCount = 10
+                println("\n═══ STEP 4: Publishing $messageCount messages to $publishTopic ═══")
+
+                var successCount = 0
+                var failCount = 0
+                repeat(messageCount) { i ->
+                    val payload = "diag-packet-$i-${System.currentTimeMillis()}"
+                    try {
+                        val result =
+                            client.publish(
+                                MqttMessage(
+                                    topic = publishTopic,
+                                    payload = payload.encodeToByteArray(),
+                                    qos = QoS.AT_LEAST_ONCE,
+                                    retain = false,
+                                ),
+                            )
+                        successCount++
+                        publishResults += "OK($i): reasonCode=$result"
+                        println("  ✓ Publish $i OK (reason=$result, state=${client.connectionState.value})")
+                    } catch (e: Exception) {
+                        failCount++
+                        val detail =
+                            "${e::class.simpleName}: ${e.message}" +
+                                (e.cause?.let { " [caused by ${it::class.simpleName}: ${it.message}]" } ?: "")
+                        publishResults += "FAIL($i): $detail"
+                        println("  ✗ Publish $i FAILED: $detail")
+                        println("    State: ${client.connectionState.value}")
+                    }
+
+                    // 2s delay between publishes (realistic mesh packet interval)
+                    delay(2000)
+                }
+
+                // Step 5: Wait for any late-arriving messages or reconnect cycles
+                println("\n═══ STEP 5: Waiting 5s for late traffic / reconnect ═══")
+                delay(5000)
+
+                // Summary
+                println("\n" + "═".repeat(60))
+                println("SUMMARY")
+                println("═".repeat(60))
+                println("Publishes: $successCount/$messageCount succeeded, $failCount failed")
+                println("Incoming messages: ${receivedMessages.size}")
+                println("State transitions: ${stateTransitions.joinToString(" → ")}")
+                println()
+                publishResults.forEachIndexed { idx, r -> println("  publish[$idx]: $r") }
+                println()
+                stateTransitions.forEachIndexed { idx, s -> println("  state[$idx]: $s") }
+
+                // Assert all publishes succeeded
+                assertEquals(
+                    messageCount,
+                    successCount,
+                    "All $messageCount publishes should succeed. " +
+                        "Failures: ${publishResults.filter { it.startsWith("FAIL") }}",
+                )
+
+                // Assert we stayed connected (no unexpected reconnects after initial connect)
+                val reconnectCount = stateTransitions.count { it.startsWith("Reconnecting") }
+                assertTrue(
+                    reconnectCount == 0,
+                    "Should not reconnect during steady-state operation. " +
+                        "Reconnects: $reconnectCount. Transitions: $stateTransitions",
+                )
+
+                msgJob.cancel()
+                stateJob.cancel()
+                client.disconnect()
+            } finally {
+                client.close()
+            }
+        }
+
+    // ─── Test: Connect + subscribe to real traffic (listen-only) ───
+
+    /**
+     * Connects and subscribes to the real LongFast topic, then just listens for 30 seconds.
+     * This catches decode errors on incoming PUBLISH packets from real mesh devices.
+     */
+    @Test
+    fun listenToRealMeshTraffic() =
+        runBlocking {
+            if (skipIfNoBroker()) return@runBlocking
+
+            val client = createClient(clientId = "pt-listener-${System.nanoTime()}", autoReconnect = true)
+            val errors = mutableListOf<String>()
+
+            try {
+                val stateJob =
+                    launch {
+                        client.connectionState.collect { state ->
+                            println("  ★ STATE: $state")
+                            if (state is ConnectionState.Disconnected && state.reason != null) {
+                                errors += "Unexpected disconnect: ${state.reason.message}"
+                            }
+                            if (state is ConnectionState.Reconnecting) {
+                                errors += "Reconnecting(attempt=${state.attempt}): ${state.lastError?.message}"
+                            }
+                        }
+                    }
+
+                var msgCount = 0
+                val msgJob =
+                    launch {
+                        client.messages.collect { msg ->
+                            msgCount++
+                            println(
+                                "  ▶ MSG #$msgCount: topic=${msg.topic}, " +
+                                    "qos=${msg.qos}, size=${msg.payload.size}",
+                            )
+                        }
+                    }
+
+                println("Connecting...")
+                client.connect(endpoint)
+                withTimeout(15.seconds) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
+                        delay(50)
+                    }
+                }
+
+                // Subscribe to real mesh topics with wildcards
+                val subs =
+                    listOf(
+                        Subscription(
+                            "$rootTopic$topicLevel$testChannelId/+",
+                            maxQos = QoS.AT_LEAST_ONCE,
+                            noLocal = true,
+                        ),
+                        Subscription(
+                            "${rootTopic}${topicLevel}PKI/+",
+                            maxQos = QoS.AT_LEAST_ONCE,
+                            noLocal = true,
+                        ),
+                    )
+                println("Subscribing to ${subs.map { it.topicFilter }}")
+                client.subscribe(subs)
+
+                // Listen for 30 seconds
+                println("Listening for 30s...")
+                delay(30_000)
+
+                println("\nReceived $msgCount messages, errors: ${errors.size}")
+                errors.forEach { println("  ERROR: $it") }
+
+                assertTrue(errors.isEmpty(), "Should have no errors during listen: $errors")
+
+                stateJob.cancel()
+                msgJob.cancel()
+                client.disconnect()
+            } finally {
+                client.close()
+            }
+        }
+
+    // ─── Test: Fire-and-forget concurrent publishes (mirrors Android's scope.launch pattern) ───
+
+    /**
+     * Replicates the Android fire-and-forget pattern where publish() is called from
+     * scope.launch without awaiting the result, and multiple publishes may overlap.
+     */
+    @Test
+    fun fireAndForgetConcurrentPublishes() =
+        runBlocking {
+            if (skipIfNoBroker()) return@runBlocking
+
+            val nonce = System.nanoTime()
+            val client = createClient(clientId = "pt-fandf-$nonce", autoReconnect = true)
+            val errors = mutableListOf<String>()
+
+            try {
+                val stateJob =
+                    launch {
+                        client.connectionState.collect { state ->
+                            println("  ★ STATE: $state")
+                        }
+                    }
+
+                client.connect(endpoint)
+                withTimeout(15.seconds) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
+                        delay(50)
+                    }
+                }
+
+                // Subscribe first (like Android does)
+                client.subscribe(
+                    listOf(
+                        Subscription(
+                            "$rootTopic$topicLevel$testChannelId/+",
+                            maxQos = QoS.AT_LEAST_ONCE,
+                            noLocal = true,
+                        ),
+                    ),
+                )
+
+                // Fire-and-forget: launch 10 concurrent publishes (like Android scope.launch)
+                val publishTopic = "$rootTopic$topicLevel$testChannelId/!fandf$nonce"
+                val jobs =
+                    (0 until 10).map { i ->
+                        launch {
+                            try {
+                                client.publish(
+                                    MqttMessage(
+                                        topic = publishTopic,
+                                        payload = "concurrent-$i".encodeToByteArray(),
+                                        qos = QoS.AT_LEAST_ONCE,
+                                        retain = false,
+                                    ),
+                                )
+                                println("  ✓ Concurrent publish $i OK")
+                            } catch (e: Exception) {
+                                errors += "publish-$i: ${e::class.simpleName}: ${e.message}"
+                                println("  ✗ Concurrent publish $i FAILED: ${e.message}")
+                            }
+                        }
+                    }
+
+                // Wait for all fire-and-forget publishes to complete
+                jobs.forEach { it.join() }
+
+                // Wait a beat for any broker-side reactions
+                delay(3000)
+
+                println("\nConcurrent publish errors: ${errors.size}")
+                errors.forEach { println("  $it") }
+
+                assertTrue(errors.isEmpty(), "All concurrent publishes should succeed: $errors")
+
+                stateJob.cancel()
+                client.disconnect()
+            } finally {
+                client.close()
+            }
+        }
+
+    // ─── Test: Publish then immediately subscribe (order-of-operations stress) ───
+
+    /**
+     * Verifies that a publish immediately after subscribe doesn't race with SUBACK processing.
+     */
+    @Test
+    fun publishImmediatelyAfterSubscribe() =
+        runBlocking {
+            if (skipIfNoBroker()) return@runBlocking
+
+            val nonce = System.nanoTime()
+            val client = createClient(clientId = "pt-immed-$nonce", autoReconnect = false)
+
+            try {
+                client.connect(endpoint)
+                withTimeout(15.seconds) {
+                    while (client.connectionState.value != ConnectionState.Connected) {
+                        delay(50)
+                    }
+                }
+
+                val topic = "$rootTopic$topicLevel$testChannelId/!immed$nonce"
+
+                // Subscribe and publish with zero gap between them
+                client.subscribe(
+                    listOf(
+                        Subscription(
+                            "$rootTopic$topicLevel$testChannelId/+",
+                            maxQos = QoS.AT_LEAST_ONCE,
+                            noLocal = true,
+                        ),
+                    ),
+                )
+
+                // Immediately publish — no delay
+                val result =
+                    client.publish(
+                        MqttMessage(
+                            topic = topic,
+                            payload = "immediate-after-sub".encodeToByteArray(),
+                            qos = QoS.AT_LEAST_ONCE,
+                            retain = false,
+                        ),
+                    )
+                println("Immediate publish after subscribe: reason=$result")
+
+                // Second publish right after
+                val result2 =
+                    client.publish(
+                        MqttMessage(
+                            topic = topic,
+                            payload = "immediate-after-sub-2".encodeToByteArray(),
+                            qos = QoS.AT_LEAST_ONCE,
+                            retain = false,
+                        ),
+                    )
+                println("Second immediate publish: reason=$result2")
+
+                client.disconnect()
+            } finally {
+                client.close()
+            }
+        }
+}


### PR DESCRIPTION
## Problem

Some MQTT brokers (notably `mqtt.meshtastic.pt`) accept an MQTT 5.0 CONNECT but respond with 3.1.1-style packets — no properties section in SUBACK, UNSUBACK, PUBLISH, or PUBACK. This caused the v5 properties decoder to misinterpret payload bytes as property IDs, crashing with errors like:

- `Not enough bytes for boolean at offset 4`
- `Unknown property ID: 0x85`
- `Properties section overflows body`

The crash killed the read loop, triggering `handleFatalError → disconnect → autoReconnect → same crash` — an infinite reconnect cycle where only the first publish succeeded.

## Root Cause

The PT broker is a v3.1.1/v5 hybrid: it accepts v5 CONNECT (so it tracks the session as v5 and expects v5-encoded requests), but it sends v3.1.1-style responses (no properties sections). When the decoder tried to parse properties from these bare packets, the payload bytes were misinterpreted as VBI/property-ID/values.

## Fix

Introduce `tryDecodePropertiesSection()` — a try/catch wrapper around the strict v5 decoder that returns `null` on `IllegalArgumentException`. Applied in:

- **`decodePublish`** — incoming messages from v3.1.1 clients relayed by the broker
- **`decodePubAckLike`** (PUBACK/PUBREC/PUBREL/PUBCOMP with body ≥ 4 bytes)
- **`decodeSubAck`** — the original crash site
- **`decodeUnsubAck`** — same pattern

When v5 properties parsing fails, the decoder falls back to treating bytes as 3.1.1 (empty properties, bare reason codes / raw payload). Outbound packets continue to be encoded as v5 since the broker expects that format.

This mirrors [HiveMQ's approach](https://github.com/hivemq/hivemq-mqtt-client) for CONNACK (`tryDecodeMqtt3`) but extends it to all response packet types. Neither Paho nor KMQTT handle this case — they would crash on the same broker.

## Also includes

- Bounds checks in `MqttProperties.decodeProperties()` loop
- Enhanced error messages with hex dumps for easier debugging
- Diagnostic test suite (`MqttPtDiagnosticTest`) replicating the Meshtastic-Android flow
- Version bump to 0.3.6

## Testing

- ✅ Verified against `mqtt.meshtastic.pt:1883` — 10/10 publishes, 5 incoming messages, zero reconnects
- ✅ All 470 unit tests passing (8 pre-existing `MqttIntegrationTest` failures unrelated — `runTest` + real network)
- ✅ spotless, apiDump/apiCheck clean