### PR TITLE
chore(build): derive version from git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -42,6 +43,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -70,6 +72,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -85,6 +88,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -100,6 +104,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -115,6 +120,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -131,6 +137,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -147,6 +154,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -172,8 +173,8 @@ jobs:
       - name: Compute snapshot version
         id: version
         run: |
-          RELEASE_VERSION=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)
-          IFS='.' read -r major minor patch <<< "$RELEASE_VERSION"
+          TAG_VERSION=$(git describe --tags --match 'v*' --abbrev=0 | sed 's/^v//')
+          IFS='.' read -r major minor patch <<< "$TAG_VERSION"
           SNAPSHOT_VERSION="${major}.${minor}.$((patch + 1))-SNAPSHOT"
           echo "snapshot=$SNAPSHOT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing snapshot: $SNAPSHOT_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -174,6 +175,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Generate SBOM (CycloneDX + SPDX)
         uses: anchore/sbom-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: ./.github/actions/gradle-setup
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Builder DSL** — `MqttConfig.build { clientId = "x"; keepAliveSeconds = 30 }`
 - **Spec-compliant validation** — reserved bits in CONNECT/CONNACK/SUBSCRIBE decoded packets (§3.1.2.3, §3.2.2.1, §3.8.3.1)
 - **Build tooling** — Binary Compatibility Validator, Dokka, Kover (≥80% line coverage), [Konsist](https://docs.konsist.lemonappdev.com/) architectural tests enforcing no `java.*`/`javax.*`/`android.*`/`platform.*` imports in `commonMain` and `internal` visibility on transport and property types
-- **Single-source versioning** — `GROUP`, `POM_ARTIFACT_ID`, and `VERSION_NAME` live in `gradle.properties` and are consumed automatically by the vanniktech maven-publish plugin; the sample Android app derives its `versionCode`/`versionName` from the same property
+- **Single-source versioning** — version is derived from git tags at build time via `git describe`; `GROUP` and `POM_ARTIFACT_ID` live in `gradle.properties`; the sample Android app derives its `versionCode`/`versionName` from `project.version`
 - Input validation on all public types (port range, topic alias, subscription identifiers, `MqttMessage` topic must not be empty, etc.)
 - KDoc on all public API types with spec references, examples, and parameter documentation
 - **Consumer convenience APIs:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,13 @@ When filing an issue, please include:
 
 ## Releasing
 
-The version is tracked in **one place only**: `VERSION_NAME` in `gradle.properties`. The library coordinate (`GROUP:POM_ARTIFACT_ID:VERSION_NAME`) and the sample Android app's `versionCode`/`versionName` are both derived from it — keep them in sync by editing this single property.
+The version is derived from **git tags** — the tag is the single source of truth. The root `build.gradle.kts` runs `git describe --tags --match 'v*'` to resolve the version at build time. On an exact tag (e.g. `v0.3.6`) the version is `0.3.6`; between tags it becomes a `-SNAPSHOT`. You can override at any time with `-PVERSION_NAME=...`.
 
 To cut a release:
 
-1. Bump `VERSION_NAME` in `gradle.properties` (drop the `-SNAPSHOT` suffix if any).
-2. Move the `## [Unreleased]` entries in `CHANGELOG.md` under a new `## [x.y.z] - YYYY-MM-DD` heading.
-3. Commit with `chore(release): x.y.z` and tag: `git tag vx.y.z && git push --follow-tags`.
-4. The `Release` workflow will publish to Maven Central, create a GitHub Release, and attach sample artifacts (`.apk`, `.deb`, `.dmg`, `.msi`, wasmJs web zip) built across a per-OS matrix.
+1. Move the `## [Unreleased]` entries in `CHANGELOG.md` under a new `## [x.y.z] - YYYY-MM-DD` heading.
+2. Commit with `chore(release): x.y.z` and tag: `git tag vx.y.z && git push --follow-tags`.
+3. The `Release` workflow will publish to Maven Central, create a GitHub Release, and attach sample artifacts (`.apk`, `.deb`, `.dmg`, `.msi`, wasmJs web zip) built across a per-OS matrix.
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,3 +9,36 @@ plugins {
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.wire) apply false
 }
+
+// ---------------------------------------------------------------------------
+// Version: derived from the latest git tag (e.g. v0.3.6 → 0.3.6).
+// Between tags: next patch + "-SNAPSHOT" (e.g. v0.3.6-4-gabcdef → 0.3.7-SNAPSHOT).
+// Overridable via -PVERSION_NAME=... (used by CI snapshot publishing).
+// ---------------------------------------------------------------------------
+val gitVersion: Provider<String> = providers.exec {
+    commandLine("git", "describe", "--tags", "--match", "v*")
+    isIgnoreExitValue = true
+}.standardOutput.asText.map { raw ->
+    val desc = raw.trim()
+    if (desc.isBlank()) {
+        return@map providers.gradleProperty("VERSION_NAME").getOrElse("0.0.0-SNAPSHOT")
+    }
+    val stripped = desc.removePrefix("v")
+    if ('-' in stripped) {
+        // Not on an exact tag — compute next-patch SNAPSHOT
+        val base = stripped.substringBefore('-')
+        val parts = base.split('.').map(String::toInt)
+        "${parts[0]}.${parts[1]}.${parts[2] + 1}-SNAPSHOT"
+    } else {
+        stripped
+    }
+}
+
+val resolvedVersion: String =
+    providers.gradleProperty("VERSION_NAME")
+        .orElse(gitVersion)
+        .get()
+
+allprojects {
+    version = resolvedVersion
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,11 +12,11 @@ kotlin.mpp.enableCInteropCommonization=true
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-#Publishing — single source of truth for :library Maven coordinate and :sample versionName.
-#Picked up automatically by com.vanniktech.maven.publish. Override in CI with -PVERSION_NAME=...
+#Publishing — Maven coordinates.
+#Version is derived from git tags (e.g. v0.3.6 → 0.3.6) in build.gradle.kts.
+#Override in CI with -PVERSION_NAME=... to publish snapshots or custom versions.
 GROUP=org.meshtastic
 POM_ARTIFACT_ID=mqtt-client
-VERSION_NAME=0.3.6
 #Compose Desktop — allow Homebrew/OpenJDK vendors for local `packageReleaseDmg` runs.
 #CI uses Temurin via setup-java so this is a no-op there.
 compose.desktop.packaging.checkJdkVendor=false

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -25,8 +25,8 @@ plugins {
     alias(libs.plugins.kover)
 }
 
-// group + version are inherited from gradle.properties (GROUP / VERSION_NAME)
-// via the vanniktech.mavenPublish plugin — single source of truth for the whole project.
+// group + version are set by the root build script from git tags.
+// The vanniktech.mavenPublish plugin picks up project.version automatically.
 
 kotlin {
     applyDefaultHierarchyTemplate()

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -14,9 +14,9 @@ android {
         // legacy raster fallbacks. The library itself still supports minSdk 24.
         minSdk = 26
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        // Version is the single source of truth defined in root gradle.properties (VERSION_NAME).
+        // Version is derived from git tags by the root build script.
         // versionCode is derived from semver: MAJOR*10000 + MINOR*100 + PATCH.
-        val semver = providers.gradleProperty("VERSION_NAME").get()
+        val semver = project.version.toString()
         val (major, minor, patch) = semver.substringBefore('-').split('.').map(String::toInt)
         versionCode = major * 10000 + minor * 100 + patch
         versionName = semver

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         // versionCode is derived from semver: MAJOR*10000 + MINOR*100 + PATCH.
         val semver = project.version.toString()
         val (major, minor, patch) = semver.substringBefore('-').split('.').map(String::toInt)
-        versionCode = major * 10000 + minor * 100 + patch
+        versionCode = (major * 10000 + minor * 100 + patch).coerceAtLeast(1)
         versionName = semver
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -102,7 +102,7 @@ compose.desktop {
             packageName = "mqtt-sample"
             // jpackage requires the first component to be >= 1 (macOS CFBundleShortVersionString rule).
             // Library follows 0.x SemVer; coerce to 1.x.y for the installer metadata only.
-            packageVersion = providers.gradleProperty("VERSION_NAME").get().let { v ->
+            packageVersion = project.version.toString().let { v ->
                 val parts = v.substringBefore('-').split('.').map { it.toIntOrNull() ?: 0 }
                 val major = parts.getOrElse(0) { 0 }.coerceAtLeast(1)
                 val minor = parts.getOrElse(1) { 0 }


### PR DESCRIPTION
## Motivation

Manually bumping `VERSION_NAME` in `gradle.properties` before every release is an extra step that's easy to forget and creates drift between the tag and the property. The git tag should be the single source of truth -- it already triggers the release workflow.

## Approach

The root `build.gradle.kts` now runs `git describe --tags --match 'v*'` via `providers.exec` to compute the project version at configuration time:

- **On an exact tag** (e.g. `v0.3.6`) -- version resolves to `0.3.6`
- **Between tags** (e.g. `v0.3.6-4-gabcdef`) -- computes the next patch SNAPSHOT (`0.3.7-SNAPSHOT`)
- **No tags / shallow clone** -- falls back to `0.0.0-SNAPSHOT`
- **CI override** -- `-PVERSION_NAME=x.y.z` still works and takes priority (used by snapshot publishing)

## Changes

- Remove `VERSION_NAME` from `gradle.properties`; keep `GROUP` and `POM_ARTIFACT_ID`
- Add git-tag version resolution logic in root `build.gradle.kts` with `allprojects { version = ... }`
- Update sample modules to read `project.version` instead of the Gradle property
- Add `fetch-depth: 0` to CI snapshot and release workflows so tags are available
- Update `CONTRIBUTING.md`, `CHANGELOG.md`, and `library/build.gradle.kts` comments

## Release workflow (unchanged)

1. Update `CHANGELOG.md`
2. `git tag vx.y.z && git push --follow-tags`
3. Release workflow publishes to Maven Central using the tag-derived version