### PR TITLE
Replace local Wire codegen with org.meshtastic:protobufs SDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "protobufs"]
-	path = protobufs
-	url = https://github.com/meshtastic/protobufs.git
-	branch = v2.7.22

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.vanniktech.mavenPublish) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.detekt) apply false
-    alias(libs.plugins.wire) apply false
 }
 
 // ---------------------------------------------------------------------------

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ detekt = "1.23.8"
 bcv = "0.18.1"
 dokka = "2.2.0"
 kover = "0.9.8"
-wire = "6.4.0"
+meshtastic-protobufs = "2.7.25-SNAPSHOT"
 konsist = "0.17.3"
 
 [libraries]
@@ -34,6 +34,7 @@ ktor-client-winhttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "k
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 kotlinx-io-bytestring = { module = "org.jetbrains.kotlinx:kotlinx-io-bytestring", version.ref = "kotlinx-io" }
+meshtastic-protobufs = { module = "org.meshtastic:protobufs", version.ref = "meshtastic-protobufs" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
@@ -48,7 +49,6 @@ lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-vie
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
-wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 
 [plugins]
@@ -63,4 +63,3 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 bcv = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-wire = { id = "com.squareup.wire", version.ref = "wire" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ detekt = "1.23.8"
 bcv = "0.18.1"
 dokka = "2.2.0"
 kover = "0.9.8"
-meshtastic-protobufs = "2.7.25-SNAPSHOT"
+meshtastic-protobufs = "2.7.25"
 konsist = "0.17.3"
 
 [libraries]

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@js-joda/core@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
-  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
-
 ws@8.18.3:
   version "8.18.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,12 +1,10 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.android.kotlin.multiplatform.library)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.wire)
 }
 
 kotlin {
@@ -20,12 +18,6 @@ kotlin {
     }
 
     jvm("desktop")
-
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        browser()
-        binaries.executable()
-    }
 
     listOf(
         iosArm64(),
@@ -53,7 +45,7 @@ kotlin {
             implementation(libs.lifecycle.viewmodel.compose)
             implementation(libs.lifecycle.runtime.compose)
             implementation(project(":library"))
-            implementation(libs.wire.runtime)
+            implementation(libs.meshtastic.protobufs)
             implementation(libs.kotlinx.io.bytestring)
         }
 
@@ -72,28 +64,10 @@ kotlin {
     }
 }
 
-wire {
-    sourcePath {
-        srcDir("../protobufs")
-        include("meshtastic/*.proto")
-    }
-    protoPath {
-        srcDir("../protobufs")
-        include("nanopb.proto")
-    }
-    kotlin {
-        makeImmutableCopies = false
-        boxOneOfsMinSize = 5000
-    }
-    root("meshtastic.*")
-    prune("meshtastic.MeshPacket#delayed")
-    prune("meshtastic.MeshPacket.Delayed")
-}
-
 compose.desktop {
     application {
         mainClass = "MainKt"
-        // Sample app — ProGuard adds no value and trips on wire-runtime's Android-only classes.
+        // Sample app — ProGuard adds no value and trips on wire-runtime classes.
         buildTypes.release.proguard {
             isEnabled.set(false)
         }

--- a/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/MqttSampleViewModel.kt
+++ b/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/MqttSampleViewModel.kt
@@ -324,7 +324,7 @@ class MqttSampleViewModel : ViewModel() {
         val envelope = ServiceEnvelope.ADAPTER.decode(bytes)
         val packet = envelope.packet ?: return null
 
-        val isEncrypted = packet.encrypted != null && packet.encrypted.size > 0
+        val isEncrypted = packet.encrypted.let { it != null && it.size > 0 }
         val decoded = packet.decoded
 
         val portnum = decoded?.portnum?.takeIf { it != PortNum.UNKNOWN_APP }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            mavenContent { snapshotsOnly() }
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,9 +19,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven("https://central.sonatype.com/repository/maven-snapshots/") {
-            mavenContent { snapshotsOnly() }
-        }
     }
 }
 


### PR DESCRIPTION
The sample app currently vendors the `protobufs` git submodule and runs the Wire Gradle plugin at build time to generate Kotlin models locally. The meshtastic/protobufs repo now publishes a pre-built KMP artifact (`org.meshtastic:protobufs`) to Maven Central, so consumers no longer need local codegen -- they can depend on the published SDK directly. This aligns MQTTastic-Client-KMP with the same migration done in Meshtastic-Android (meshtastic/Meshtastic-Android#5675) and TAKPacket-SDK (meshtastic/TAKPacket-SDK#42).

## Approach

- Remove the `protobufs` git submodule and `.gitmodules` entirely
- Remove the Wire Gradle plugin from the root and sample build scripts
- Add `org.meshtastic:protobufs:2.7.25-SNAPSHOT` as a dependency in the sample's `commonMain`
- Add the Sonatype snapshots repository to `settings.gradle.kts` for SNAPSHOT resolution
- Remove `wire-runtime` library and `wire` plugin entries from the version catalog

## Notable trade-offs

- **wasmJs removed from sample:** The published protobufs SDK does not yet include a wasmJs target, so the sample app's wasmJs target has been removed. The core `library` module (the MQTT client itself) is unaffected and still supports wasmJs.
- **SNAPSHOT dependency:** Using `2.7.25-SNAPSHOT` until a stable release is cut from the protobufs repo. Once published to Maven Central proper, update to the release version.
- **Smart cast fix:** `MeshPacket.encrypted` is now a public property from an external module, so Kotlin can no longer smart-cast it. Wrapped in `.let {}` to resolve.