### PR TITLE
fix(transport): contain TLS pump failures that crash the host app

### DIFF
--- a/library/src/nonWebMain/kotlin/org/meshtastic/mqtt/TcpTransport.kt
+++ b/library/src/nonWebMain/kotlin/org/meshtastic/mqtt/TcpTransport.kt
@@ -28,8 +28,12 @@ import io.ktor.utils.io.ByteWriteChannel
 import io.ktor.utils.io.readByte
 import io.ktor.utils.io.readFully
 import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -48,6 +52,9 @@ internal class TcpTransport : MqttTransport {
     private var readChannel: ByteReadChannel? = null
     private var writeChannel: ByteWriteChannel? = null
     private val sendMutex = Mutex()
+
+    // Parent job for ktor's detached TLS record-pump coroutines (see [connect]).
+    private var tlsJob: Job? = null
 
     override val isConnected: Boolean
         get() = socket?.isClosed == false
@@ -75,7 +82,21 @@ internal class TcpTransport : MqttTransport {
                     try {
                         if (endpoint.tls) {
                             val tlsServerName = endpoint.host.takeUnless { isIpLiteral(it) }
-                            rawSocket.tls(Dispatchers.IO) {
+                            // Ktor launches the TLS record-pump (input/output) coroutines on the
+                            // context passed here. A bare dispatcher leaves them with no parent Job
+                            // and no exception handler, so a write that fails around the handshake —
+                            // e.g. a broken pipe when the peer resets the socket during reconnect
+                            // churn — reaches the thread's default handler and crashes the whole app.
+                            // A SupervisorJob + CoroutineExceptionHandler contains that failure; it
+                            // still closes the channels, which the read loop turns into a reconnect.
+                            val tlsContext =
+                                SupervisorJob() +
+                                    Dispatchers.IO +
+                                    CoroutineName("mqtt-tls") +
+                                    // benign socket teardown
+                                    CoroutineExceptionHandler { _, _ -> }
+                            tlsJob = tlsContext[Job]
+                            rawSocket.tls(tlsContext) {
                                 serverName = tlsServerName
                                 configurePlatformTrust(tlsServerName)
                             }
@@ -101,6 +122,13 @@ internal class TcpTransport : MqttTransport {
                 // Any failure (TCP connect, TLS handshake, channel setup) — close selector to prevent leaks
                 try {
                     socket?.close()
+                } catch (
+                    @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+                ) {
+                    // best-effort
+                }
+                try {
+                    tlsJob?.cancel()
                 } catch (
                     @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
                 ) {
@@ -178,6 +206,13 @@ internal class TcpTransport : MqttTransport {
         try {
             socket?.close()
         } finally {
+            try {
+                tlsJob?.cancel()
+            } catch (
+                @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+            ) {
+                // best-effort
+            }
             socket = null
             readChannel = null
             writeChannel = null


### PR DESCRIPTION
## What
Pass a supervised, exception-handled `CoroutineContext` to `Socket.tls(...)` so a TLS write that fails on a dead socket can no longer crash the embedding app.

## Why
Ktor launches the TLS record-pump (input/output) coroutines on the context passed to `Socket.tls(...)`. `TcpTransport` passed a bare `Dispatchers.IO` — no `Job`, no `CoroutineExceptionHandler` — so those pumps run as *root* coroutines. When the socket dies around the handshake (e.g. a broker resets it during reconnect churn), the `output` coroutine's write throws and, with no handler in scope, the exception reaches the thread's default uncaught handler and **crashes the host app**.

This is the #1 crash on Meshtastic Android 2.7.14 (~520 events / 30d on the shipped build), surfacing as three variants of one root cause, all at `io.ktor.network.tls.TLSClientHandshake$output … (TLSClientHandshake.kt:139)`:
- `io.ktor.utils.io.ByteChannel.flushWriteBuffer` → `NullPointerException`
- `io.ktor.network.sockets.CIOWriterKt$attachForWritingDirectImpl` → `IOException: Broken pipe`
- `io.ktor.utils.io.ByteChannel.getWriteBuffer` → `ClosedWriteChannelException`

## Change
- Build `SupervisorJob() + Dispatchers.IO + CoroutineName("mqtt-tls") + CoroutineExceptionHandler { }` and pass it to `.tls(...)`.
- Track it in `tlsJob`; cancel it in `close()` and on the connect failure path.

## Why it's safe
The failure is still surfaced normally — the dying socket closes the app-facing channels, so `MqttConnection`'s read loop throws → `handleFatalError` → reconnect. We only suppress the *duplicate, fatal* report from the detached pump. Graceful DISCONNECT ordering is preserved (it is written before `close()` cancels `tlsJob`).

## Testing
`spotlessCheck detekt :library:compileKotlinJvm :library:jvmTest apiCheck` all pass. No public API change (`TcpTransport` is `internal`). A true regression test needs a broker that resets mid-handshake (integration-only), so this is verified by reasoning + the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)