### PR TITLE
build: hold Kotlin at 2.3.21 so consumers on 2.3.x can read our klibs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.4.0"
+# Held at 2.3.x: klibs built by Kotlin 2.4 carry ABI version 2.4.0, which the primary
+# consumer (Meshtastic-Android, on Kotlin 2.3.21 until InsertKoinIO/koin#2431 resolves)
+# cannot read. Renovate enforces this via the "Hold Kotlin at 2.3.x" rule in renovate.json.
+kotlin = "2.3.21"
 ktor = "3.5.0"
 coroutines = "1.11.0"
 kotlinx-io = "0.9.0"

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
+      "description": "Hold Kotlin at 2.3.x: 2.4-built klibs carry ABI version 2.4.0, which Meshtastic-Android (Kotlin 2.3.21 until InsertKoinIO/koin#2431 resolves) rejects — see meshtastic/Meshtastic-Android#5763. Drop this rule once Android is on Kotlin 2.4.",
+      "matchPackageNames": ["/^org\\.jetbrains\\.kotlin[.:]/"],
+      "allowedVersions": "<2.4.0"
+    },
+    {
       "description": "Group Kotlin ecosystem dependencies",
       "groupName": "Kotlin ecosystem",
       "matchPackageNames": [


### PR DESCRIPTION
## Why

v0.3.7 was built with Kotlin 2.4.0 (#52), which stamps every published klib with **ABI version 2.4.0**. Kotlin 2.3.x consumers hard-reject those:

```
w: KLIB resolver: Skipping '...mqtt-client-iossimulatorarm64/0.3.7/...': incompatible ABI version '2.4.0'
The current Kotlin compiler can consume libraries having ABI version <= '2.3.0'.
```

Meshtastic-Android is pinned to Kotlin **2.3.21** until the Koin compiler plugin supports 2.4 (InsertKoinIO/koin#2431). Its mqtt-client 0.3.7 bump therefore fails CI (meshtastic/Meshtastic-Android#5763), which blocks the **TLS pump crash fix (#54)** — currently the top production crash in the Android app — from shipping.

## What

- Revert the toolchain to Kotlin 2.3.21 (everything else from v0.3.7 — the protobufs SDK migration #50, the TLS transport fix #54 — stays).
- Add a Renovate `packageRules` hold so the bump can't creep back in. meshtastic/protobufs#944 adds the same guard there.

Kotlin 2.3.21 + CMP 1.11.1 was the CI-green state on main immediately before #52. Verified locally: `spotlessCheck detekt jvmTest apiCheck` (the release gate) plus `:library:compileKotlinIosSimulatorArm64` and `:library:compileKotlinWasmJs` all pass; no kotlin-js-store churn.

## Release plan

After merge, tag **v0.3.8** — Renovate then updates meshtastic/Meshtastic-Android#5763 to 0.3.8 and it goes green.

Drop the hold and re-bump Kotlin once Meshtastic-Android lands meshtastic/Meshtastic-Android#5760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)