### PR TITLE
ci: drop the Kotlin <2.4 Renovate hold

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,6 @@
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
-      "description": "Hold Kotlin at 2.3.x: 2.4-built klibs carry ABI version 2.4.0, which Meshtastic-Android (Kotlin 2.3.21 until InsertKoinIO/koin#2431 resolves) rejects — see meshtastic/Meshtastic-Android#5763. Drop this rule once Android is on Kotlin 2.4.",
-      "matchPackageNames": ["/^org\\.jetbrains\\.kotlin[.:]/"],
-      "allowedVersions": "<2.4.0"
-    },
-    {
       "description": "Group Kotlin ecosystem dependencies",
       "groupName": "Kotlin ecosystem",
       "matchPackageNames": [


### PR DESCRIPTION
The hold (added in #55) kept Renovate from proposing Kotlin 2.4.x because 2.4-built native klibs carry ABI version 2.4.0, which Kotlin 2.3.x consumers hard-reject — and Meshtastic-Android was stuck on 2.3.21 behind the Koin compiler-plugin FIR break.

Meshtastic-Android merged its Kotlin 2.4.0 upgrade today (meshtastic/Meshtastic-Android#5760: kotlin 2.4.0 + mokkery 3.4.1 + koin-plugin 1.0.1), so the hold is obsolete. The rule's own description said to drop it once Android is on 2.4 — this does exactly that. Renovate's existing "Kotlin ecosystem" group will pick up the 2.4.x bump on its next sweep; CI still gates it as usual.

Config validated with renovate-config-validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)