### PR TITLE
refactor(build): split build cache into its own settings script

### DIFF
--- a/gradle/build-cache.settings.gradle
+++ b/gradle/build-cache.settings.gradle
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+def getMeshProperty(String key) {
+    def env = System.getenv(key)
+    if (env) return env
+
+    def currentDir = settingsDir
+    while (currentDir != null) {
+        def localFile = new File(currentDir, "local.properties")
+        if (localFile.exists()) {
+            def props = new Properties()
+            localFile.withInputStream { props.load(it) }
+            if (props.containsKey(key)) return props.getProperty(key)
+        }
+        def configFile = new File(currentDir, "config.properties")
+        if (configFile.exists()) {
+            def props = new Properties()
+            configFile.withInputStream { props.load(it) }
+            if (props.containsKey(key)) return props.getProperty(key)
+        }
+        currentDir = currentDir.parentFile
+    }
+    return null
+}
+
+buildCache {
+    local {
+        enabled = true
+    }
+    remote(HttpBuildCache) {
+        // Some servers have issues with Expect: 100-continue and return 403.
+        useExpectContinue = false
+        def cacheUrl = getMeshProperty("GRADLE_CACHE_URL")?.trim()
+        def cacheUsername = getMeshProperty("GRADLE_CACHE_USERNAME")?.trim()
+        def cachePassword = getMeshProperty("GRADLE_CACHE_PASSWORD")?.trim()
+
+        if (cacheUrl) {
+            logger.lifecycle "MQTTastic Build: Remote cache URL found."
+
+            // Ensure trailing slash for cache servers
+            url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
+
+            if (cacheUsername && cachePassword) {
+                credentials {
+                    username = cacheUsername
+                    password = cachePassword
+                }
+            }
+
+            allowInsecureProtocol = true
+            allowUntrustedServer = true
+
+            // Keep push enabled if credentials are provided.
+            // This naturally disables push for fork PRs which don't have access to secrets.
+            push = (cacheUsername && cachePassword)
+
+            enabled = true
+        } else {
+            enabled = false
+        }
+    }
+}

--- a/gradle/develocity.settings.gradle
+++ b/gradle/develocity.settings.gradle
@@ -15,29 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-def getMeshProperty(String key) {
-    def env = System.getenv(key)
-    if (env) return env
-
-    def currentDir = settingsDir
-    while (currentDir != null) {
-        def localFile = new File(currentDir, "local.properties")
-        if (localFile.exists()) {
-            def props = new Properties()
-            localFile.withInputStream { props.load(it) }
-            if (props.containsKey(key)) return props.getProperty(key)
-        }
-        def configFile = new File(currentDir, "config.properties")
-        if (configFile.exists()) {
-            def props = new Properties()
-            configFile.withInputStream { props.load(it) }
-            if (props.containsKey(key)) return props.getProperty(key)
-        }
-        currentDir = currentDir.parentFile
-    }
-    return null
-}
-
 develocity {
     buildScan {
         capture {
@@ -50,42 +27,5 @@ develocity {
         uploadInBackground = !isCi
         termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
         termsOfUseAgree = "yes"
-    }
-    buildCache {
-        local {
-            enabled = true
-        }
-        remote(HttpBuildCache) {
-            // Some servers have issues with Expect: 100-continue and return 403.
-            useExpectContinue = false
-            def cacheUrl = getMeshProperty("GRADLE_CACHE_URL")?.trim()
-            def cacheUsername = getMeshProperty("GRADLE_CACHE_USERNAME")?.trim()
-            def cachePassword = getMeshProperty("GRADLE_CACHE_PASSWORD")?.trim()
-
-            if (cacheUrl) {
-                println "MQTTastic: Remote cache URL found."
-
-                // Ensure trailing slash for Develocity/GE servers
-                url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
-
-                if (cacheUsername && cachePassword) {
-                    credentials {
-                        username = cacheUsername
-                        password = cachePassword
-                    }
-                }
-
-                allowInsecureProtocol = true
-                allowUntrustedServer = true
-
-                // Keep push enabled if credentials are provided.
-                // This naturally disables push for fork PRs which don't have access to secrets.
-                push = (cacheUsername && cachePassword)
-
-                enabled = true
-            } else {
-                enabled = false
-            }
-        }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,10 @@ plugins {
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
 }
 
-// Shared Develocity and Build Cache configuration
+// Build Cache configuration (HTTP remote cache + local)
+apply(from = "gradle/build-cache.settings.gradle")
+
+// Build Scans — publish in CI only for debugging and performance profiling.
 apply(from = "gradle/develocity.settings.gradle")
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## What

Adopt meshtastic-android's build cache implementation by moving the cache config out of `develocity.settings.gradle` into a dedicated `gradle/build-cache.settings.gradle`.

## Why

Keeps caching concerns separate from build-scan concerns and switches to the standard Gradle cache API, so the build cache no longer depends on the Develocity plugin to function. Mirrors the structure used in `Meshtastic-Android`.

## Changes

- **New `gradle/build-cache.settings.gradle`** — uses the standard top-level `buildCache {}` API (instead of `develocity { buildCache {} }`); keeps the `getMeshProperty` env → `local.properties` → `config.properties` walk-up and the fork-safe `push` gating; uses `logger.lifecycle` instead of `println`.
- **`gradle/develocity.settings.gradle`** — stripped the `buildCache {}` block and the now-unused `getMeshProperty` helper; now only configures `develocity { buildScan {} }`.
- **`settings.gradle.kts`** — applies both scripts (build cache, then build scans).

### Deviation from the source (intentional)

Meshtastic-android applies this file from both its root *and* `build-logic/settings.gradle.kts`, so it carries an `isLogic` check to label the log line. MQTTastic has no `build-logic` included build, so that branch would be dead code here — dropped it and personalized the log to `MQTTastic Build: ...`.

## Verification

- `./gradlew help` evaluates settings cleanly (exit 0), confirming the top-level `buildCache {}` block resolves against the `Settings` object.
- With `GRADLE_CACHE_URL` set, the remote-cache branch evaluates without error and logs `MQTTastic Build: Remote cache URL found.`
- None of the three files are in spotless's scope, so no formatting/license-header impact.

Note: `org.gradle.caching=true` is already set in `gradle.properties`, so local caching is live now and remote activates once `GRADLE_CACHE_URL` is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)