### PR TITLE
fix(deps): bump transitive ws to 8.20.1 (GHSA-58qx-3vcg-4xpx)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnRootExtension
+
 plugins {
     alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.androidApplication) apply false
@@ -40,4 +43,18 @@ val resolvedVersion: String =
 
 allprojects {
     version = resolvedVersion
+}
+
+// ---------------------------------------------------------------------------
+// Security: pin the transitive npm `ws` dependency to a patched version.
+// The wasmJs target's JS dev/test toolchain (webpack-dev-server / karma) pulls
+// in `ws`, which Kotlin otherwise resolves to a version vulnerable to
+// uninitialized-memory disclosure (GHSA-58qx-3vcg-4xpx; fixed in 8.20.1).
+// The wasmJs target uses its own Yarn store (kotlin-js-store/wasm/yarn.lock),
+// so the override targets the Wasm Yarn plugin/extension — not the JS one.
+// After changing this pin, regenerate the lockfile with:
+//   ./gradlew kotlinWasmUpgradeYarnLock
+// ---------------------------------------------------------------------------
+plugins.withType<WasmYarnPlugin> {
+    the<WasmYarnRootExtension>().resolution("ws", "8.20.1")
 }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-ws@8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.18.3, ws@8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==


### PR DESCRIPTION
## What

Pins the transitive npm `ws` dependency to **8.20.1** and regenerates the wasm Yarn lockfile.

## Why

[Dependabot alert #1](https://github.com/meshtastic/MQTTastic-Client-KMP/security/dependabot/1) flags **GHSA-58qx-3vcg-4xpx** — *ws: uninitialized memory disclosure* (medium). The vulnerable range is `>= 8.0.0, < 8.20.1`; the first patched version is `8.20.1`.

`ws` is pulled in transitively by the **wasmJs** target's JS dev/test toolchain (webpack-dev-server / karma) and locked in the Kotlin-managed lockfile `kotlin-js-store/wasm/yarn.lock`, which previously resolved `ws@8.18.3`. There is no direct `package.json` to edit — Kotlin generates the dependency graph.

## Changes

- **`build.gradle.kts`** — add a Yarn `resolution("ws", "8.20.1")` on the **Wasm** Yarn root extension. Kotlin 2.3.21 splits the Yarn plugin per web target, and the wasmJs target uses its own store (`kotlin-js-store/wasm/yarn.lock`), so the override targets `WasmYarnPlugin` / `WasmYarnRootExtension` — not the JS `YarnPlugin`.
- **`kotlin-js-store/wasm/yarn.lock`** — regenerated via `./gradlew kotlinWasmUpgradeYarnLock`; `ws` now resolves to `8.20.1`.

No new direct dependencies — purely a transitive lockfile/resolution pin.

## Verification

- `./gradlew kotlinWasmUpgradeYarnLock` → lockfile resolves `ws@8.20.1`
- `./gradlew wasmJsTest` → ✅ (browser toolchain that uses `ws` still passes)
- `./gradlew spotlessCheck detekt` → ✅

Resolves Dependabot alert #1 (GHSA-58qx-3vcg-4xpx) — auto-closes once the default branch no longer resolves the vulnerable range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)