### PR TITLE
fix(transport): install Android trust manager for IP-literal TLS brokers

### DIFF
--- a/transport-tcp/src/androidMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.android.kt
+++ b/transport-tcp/src/androidMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.android.kt
@@ -31,9 +31,15 @@ import javax.net.ssl.X509TrustManager
  * has domain-specific rules) throws from the standard 2-arg `checkServerTrusted` and
  * requires the 3-arg hostname-aware overload. Ktor's TLS handshake only calls the
  * 2-arg version, so we intercept and route through the extensions API.
+ *
+ * This runs for IP-literal brokers as well as DNS hostnames: the platform's 2-arg
+ * overload throws whenever the config has *any* domain-specific entry, independent of
+ * the target host, so an IP-only broker (a common private-broker setup) hits the same
+ * failure. The [host] — an IP literal or DNS name — is a valid argument for the 3-arg
+ * overload even though an IP must never be sent as the TLS SNI server name.
  */
-internal actual fun TLSConfigBuilder.configurePlatformTrust(serverName: String?) {
-    if (serverName == null) return
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
+    if (host.isBlank()) return
 
     val baseTm =
         (trustManager as? X509TrustManager) ?: run {
@@ -42,7 +48,7 @@ internal actual fun TLSConfigBuilder.configurePlatformTrust(serverName: String?)
             tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
         }
 
-    trustManager = HostnameAwareTrustManager(baseTm, serverName)
+    trustManager = HostnameAwareTrustManager(baseTm, host)
 }
 
 /**

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
@@ -25,9 +25,14 @@ import io.ktor.network.tls.TLSConfigBuilder
  * `NetworkSecurityTrustManager`'s requirement for the 3-arg
  * `checkServerTrusted(chain, authType, hostname)` overload when
  * `network_security_config.xml` contains domain-specific configurations.
+ * The platform throws from the 2-arg overload whenever *any* domain-specific
+ * config is present — regardless of the target host — so this must run for
+ * IP-literal brokers too, not only DNS hostnames.
  *
  * On JVM and native targets, this is a no-op — the platform default suffices.
  *
- * @param serverName the TLS server name (SNI hostname), or `null` for IP literals.
+ * @param host the broker host (DNS name or IP literal) used for trust evaluation.
+ *   Unlike the SNI server name, this is never `null`: an IP literal is a valid
+ *   host for the hostname-aware trust check even though it must not be sent as SNI.
  */
-internal expect fun TLSConfigBuilder.configurePlatformTrust(serverName: String?)
+internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -84,7 +84,7 @@ public class TcpTransport : MqttTransport {
                 socket =
                     try {
                         if (endpoint.tls) {
-                            val tlsServerName = endpoint.host.takeUnless { isIpLiteral(it) }
+                            val tlsServerName = sniServerName(endpoint.host)
                             // Ktor launches the TLS record-pump (input/output) coroutines on the
                             // context passed here. A bare dispatcher leaves them with no parent Job
                             // and no exception handler, so a write that fails around the handshake —
@@ -101,7 +101,10 @@ public class TcpTransport : MqttTransport {
                             tlsJob = tlsContext[Job]
                             rawSocket.tls(tlsContext) {
                                 serverName = tlsServerName
-                                configurePlatformTrust(tlsServerName)
+                                // Configure trust with the real host (DNS name or IP literal),
+                                // not the SNI value: tlsServerName is null for IP literals, but
+                                // Android still needs a host for the hostname-aware trust check.
+                                configurePlatformTrust(endpoint.host)
                             }
                         } else {
                             rawSocket
@@ -233,22 +236,30 @@ public class TcpTransport : MqttTransport {
          * in MqttConnection's read loop. This is a transport-level safety net.
          */
         const val MAX_PACKET_REMAINING_LENGTH = 16 * 1024 * 1024 // 16 MB
-
-        /**
-         * Returns `true` if [host] looks like an IP address literal (IPv4 or IPv6)
-         * rather than a DNS hostname, so that TLS SNI is only sent for DNS names.
-         *
-         * Sending SNI for an IP literal is at best useless and at worst breaks the
-         * TLS handshake (RFC 6066 §3 forbids IP literals in SNI).
-         */
-        fun isIpLiteral(host: String): Boolean {
-            // IPv6: contains colons (e.g. "::1", "2001:db8::1")
-            if (':' in host) return true
-            // IPv4: all characters are digits or dots (e.g. "192.168.1.1")
-            if (host.isNotEmpty() && host.all { it.isDigit() || it == '.' }) return true
-            return false
-        }
     }
+}
+
+/**
+ * Returns the TLS SNI server name to advertise for [host], or `null` for IP literals.
+ *
+ * Sending SNI for an IP literal is at best useless and at worst breaks the TLS
+ * handshake (RFC 6066 §3 forbids IP literals in SNI). This governs *only* SNI — the
+ * platform trust manager is still configured with the raw host (see
+ * `configurePlatformTrust`), so Android's domain-aware `NetworkSecurityTrustManager`
+ * is satisfied even when SNI is suppressed.
+ */
+internal fun sniServerName(host: String): String? = host.takeUnless { isIpLiteral(it) }
+
+/**
+ * Returns `true` if [host] looks like an IP address literal (IPv4 or IPv6)
+ * rather than a DNS hostname.
+ */
+internal fun isIpLiteral(host: String): Boolean {
+    // IPv6: contains colons (e.g. "::1", "2001:db8::1")
+    if (':' in host) return true
+    // IPv4: all characters are digits or dots (e.g. "192.168.1.1")
+    if (host.isNotEmpty() && host.all { it.isDigit() || it == '.' }) return true
+    return false
 }
 
 /**

--- a/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
+++ b/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.tcp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the SNI-vs-trust-host decoupling for TLS connections.
+ *
+ * An IP-literal broker must suppress SNI ([sniServerName] returns `null`, per
+ * RFC 6066 §3) but still pass its raw host to the platform trust manager. The
+ * earlier regression skipped the hostname-aware trust manager whenever SNI was
+ * suppressed, so IP-literal brokers on Android hit
+ * `NetworkSecurityTrustManager`'s 2-arg `checkServerTrusted` and failed with
+ * "Domain specific configurations require that hostname aware
+ * checkServerTrusted(...) is used" (Meshtastic-Android #5894).
+ */
+class TcpTransportTlsTest {
+    @Test
+    fun ipv4LiteralSuppressesSni() {
+        assertNull(sniServerName("192.168.1.50"))
+        assertNull(sniServerName("10.0.0.1"))
+        assertNull(sniServerName("127.0.0.1"))
+    }
+
+    @Test
+    fun ipv6LiteralSuppressesSni() {
+        assertNull(sniServerName("::1"))
+        assertNull(sniServerName("2001:db8::1"))
+    }
+
+    @Test
+    fun dnsHostnameKeepsSni() {
+        assertEquals("broker.example.com", sniServerName("broker.example.com"))
+        assertEquals("mqtt.local", sniServerName("mqtt.local"))
+    }
+
+    @Test
+    fun isIpLiteralClassifiesHosts() {
+        assertTrue(isIpLiteral("192.168.1.1"))
+        assertTrue(isIpLiteral("::1"))
+        assertTrue(isIpLiteral("2001:db8::1"))
+        assertFalse(isIpLiteral("example.com"))
+        assertFalse(isIpLiteral("a1.example.com"))
+        assertFalse(isIpLiteral("mqtt.local"))
+    }
+}

--- a/transport-tcp/src/jvmMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.jvm.kt
+++ b/transport-tcp/src/jvmMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.jvm.kt
@@ -19,6 +19,6 @@ package org.meshtastic.mqtt.transport.tcp
 import io.ktor.network.tls.TLSConfigBuilder
 
 /** JVM does not require hostname-aware trust manager configuration. */
-internal actual fun TLSConfigBuilder.configurePlatformTrust(serverName: String?) {
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
     // No-op: JVM's default X509TrustManager handles the 2-arg checkServerTrusted correctly.
 }

--- a/transport-tcp/src/nativeMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.native.kt
+++ b/transport-tcp/src/nativeMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.native.kt
@@ -19,6 +19,6 @@ package org.meshtastic.mqtt.transport.tcp
 import io.ktor.network.tls.TLSConfigBuilder
 
 /** Native targets use platform TLS (SecureTransport / OpenSSL) — no custom trust manager needed. */
-internal actual fun TLSConfigBuilder.configurePlatformTrust(serverName: String?) {
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
     // No-op: native TLSConfigBuilder does not expose a trustManager property.
 }


### PR DESCRIPTION
## Description

Connecting to a private MQTT broker over TLS **by IP address** fails on Android with a confusing platform error:

> TLS handshake failed: Domain specific configurations require that hostname aware checkServerTrusted(X509Certificate[], String, String) is used

**Why:** ktor's CIO TLS engine only calls the 2-arg `X509TrustManager.checkServerTrusted(chain, authType)` ([KTOR-2243](https://youtrack.jetbrains.com/issue/KTOR-2243)). On Android, when the consuming app's `network_security_config.xml` contains **any** `<domain-config>` block, the platform swaps in a `NetworkSecurityTrustManager` that throws from the 2-arg overload — regardless of the target host — and demands the 3-arg hostname-aware overload.

`5591751` already addressed this with `HostnameAwareTrustManager`, but only installed it when a TLS **SNI server name** was present. SNI is intentionally `null` for IP literals (RFC 6066 §3 forbids IPs in SNI), so `configurePlatformTrust` returned early and ktor fell back to the throwing platform default. A private broker reached by LAN IP — the common self-signed-cert setup — therefore still failed.

The defect was surfaced by the recent migration off OkHttp (whose trust manager calls the 3-arg overload) to ktor CIO. Diagnosis credit to @Olli-LUT on the linked issue.

This fix decouples the **SNI server name** (correctly `null` for IPs) from the **trust-evaluation host** (always the real host). The hostname-aware trust manager is now installed for IP-literal brokers too, routing through `X509TrustManagerExtensions` so the platform's domain-aware requirement is satisfied.

> Note: this does not auto-trust self-signed certificates. After this fix an untrusted self-signed broker fails with a *meaningful* `Trust anchor for certification path not found` instead of the misleading internal error; to connect, the broker's CA must be installed in Android's user trust store.

## Changes

All in the `:transport-tcp` module:

- `configurePlatformTrust(serverName: String?)` → `configurePlatformTrust(host: String)` across the `expect` and all three `actual`s (android / jvm / native). The non-null `String` is a compile-time guard against re-passing the nullable SNI value.
- Android `actual` now installs `HostnameAwareTrustManager` for any non-blank host (IP literal or DNS name), not only when SNI is present.
- `TcpTransport` call site passes `endpoint.host` for trust evaluation while still suppressing SNI for IPs.
- Extracted `sniServerName()` / `isIpLiteral()` to top-level `internal` functions and added `commonTest`'s `TcpTransportTlsTest` covering the SNI-vs-trust-host decoupling (IPv4/IPv6 suppress SNI; DNS keeps it).

## Testing

- [x] `spotlessCheck` + `detekt` pass
- [x] `:transport-tcp:allTests` passes (JVM + macOS + iOS native), incl. new `TcpTransportTlsTest` (4/4)
- [x] `:transport-tcp:compileCommonMainKotlinMetadata` + Android target compile/assemble pass (expect/actual contract validated for all targets)
- [x] New/updated tests cover the changes

## Related Issues

Addresses meshtastic/Meshtastic-Android#5894 (an app-side `mqtt-client` version bump is required to ship the fix to users).
