### PR TITLE
build(android): use android {} block, drop deprecated androidLibrary {}

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ Honor the server's Receive Maximum property — do not exceed the allowed number
   - `mqtt-client-bom` (a `java-platform` BOM pinning the above to one version)
 - Supported project targets: JVM, Android, iOS (iosArm64, iosSimulatorArm64), macOS (macosArm64), Linux (linuxX64, linuxArm64), Windows (mingwX64), wasmJs (`:transport-tcp` omits wasmJs).
 - The vanniktech `maven-publish` plugin auto-creates per-target publications (e.g., `mqtt-client-core-jvm`, `mqtt-client-core-iosarm64`) and a root `kotlinMultiplatform` publication per module.
-- **Android publishing** requires the `androidLibrary {}` block (Android Gradle KMP Library Plugin) in each library module's `build.gradle.kts`. Configure `namespace`, `compileSdk`, and `minSdk` inside it. Without this, Android artifacts will not be published.
+- **Android publishing** requires the `android {}` block (Android Gradle KMP Library Plugin, `com.android.kotlin.multiplatform.library`) in each library module's `build.gradle.kts`. Configure `namespace`, `compileSdk`, and `minSdk` inside it. Without this, Android artifacts will not be published. (The older `androidLibrary {}` block name is deprecated since AGP 9.1.0-alpha09 — use `android {}` on AGP 8.12+.)
 - For Apple platforms, Maven publishes `.klib` artifacts. If XCFramework distribution is needed separately, that is a distinct build step (`assembleXCFramework`), not part of Maven publishing.
 
 <git_and_prs>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 // :core holds all protocol logic — packets, codec, client, connection, properties, and the
 // MqttTransport / MqttTransportFactory SPI. It has zero dependency on any transport module.
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.meshtastic.mqtt"
         compileSdk =
             libs.versions.android.compileSdk

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -10,8 +10,7 @@ plugins {
 kotlin {
     jvmToolchain(17)
 
-    @Suppress("DEPRECATION")
-    androidLibrary {
+    android {
         namespace = "org.meshtastic.mqtt.sample.shared"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()

--- a/transport-tcp/build.gradle.kts
+++ b/transport-tcp/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 // Raw-TCP (optionally TLS) transport via ktor-network. Not available on the browser (wasmJs),
 // so this module deliberately omits the wasmJs target the convention plugin would otherwise allow.
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.meshtastic.mqtt.transport.tcp"
         compileSdk =
             libs.versions.android.compileSdk

--- a/transport-ws/build.gradle.kts
+++ b/transport-ws/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 // Binary-WebSocket transport via ktor-client-websockets. Available on every target including the
 // browser (wasmJs) — the only transport that runs there. One Ktor engine is wired per platform.
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.meshtastic.mqtt.transport.ws"
         compileSdk =
             libs.versions.android.compileSdk


### PR DESCRIPTION
The `com.android.kotlin.multiplatform.library` plugin's `androidLibrary {}` block is **deprecated since AGP 9.1.0-alpha09** (we're on 9.2.1) and will be removed in a future AGP. `android {}` is the replacement on AGP 8.12+ with an identical inner DSL.

## Changes
- Rename `androidLibrary {}` → `android {}` in `core`, `transport-tcp`, `transport-ws`, and `sample`
- Drop the `@Suppress("DEPRECATION")` in `sample` that was masking the warning
- Update `AGENTS.md`, which was instructing the deprecated block

Consistent with `meshtastic-sdk` and `protobufs`, which already use `android {}` on the same AGP 9.2.1.

## Verification
`./gradlew :core:help :transport-tcp:help :transport-ws:help --warning-mode all` configures cleanly, no deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)