### PR TITLE
ci: disable CodeQL java-kotlin leg until CodeQL supports Kotlin 2.4.10

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,8 +28,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - language: java-kotlin
-            build-mode: manual
+          # java-kotlin is temporarily disabled: CodeQL <= 2.26.1 rejects
+          # Kotlin 2.4.10 ("Kotlin version 2.4.10 is too recent"), so the
+          # traced build fails and no analysis ever runs. Support (ceiling
+          # 2.4.20) is already merged upstream and ships with the next CLI
+          # release, which codeql-action@v4 picks up automatically.
+          # Once a CodeQL CLI newer than 2.26.1 is out, uncomment to
+          # re-enable and verify Analyze (java-kotlin) goes green.
+          # - language: java-kotlin
+          #   build-mode: manual
           - language: actions
             build-mode: none
 


### PR DESCRIPTION
## Why

Since Kotlin 2.4.10 landed (#75/#76), the CodeQL `Analyze (java-kotlin)` job fails on every push and PR:

```
> Task :core:compileKotlinJvm FAILED
Kotlin version 2.4.10 is too recent. CodeQL currently supports versions below 2.4.10
```

CodeQL CLI **2.26.0 and 2.26.1** (released today, 2026-07-16) both cap Kotlin support below 2.4.10, so the traced build fails before any analysis runs — the leg burns CI minutes and paints main red for zero signal.

## What

Comment out the `java-kotlin` matrix leg (rather than `continue-on-error`, so nothing shows as failed while it cannot possibly work). The `actions` leg keeps running, as does the weekly schedule.

## Re-enabling

Upstream support is already merged on github/codeql main (version ceiling there is now 2.4.20) and ships in the next CLI release; `codeql-action@v4` floats and picks up new default bundles automatically. When a CLI newer than 2.26.1 is out: uncomment the leg and verify `Analyze (java-kotlin)` goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled Java and Kotlin CodeQL analysis due to compatibility issues with the current Kotlin version.
  * Added comments documenting the limitation and relevant upstream support guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->