### PR TITLE
fix(deps): bump transitive ws to 8.21.0 (memory-exhaustion DoS)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,13 +81,14 @@ kover {
 // ---------------------------------------------------------------------------
 // Security: pin the transitive npm `ws` dependency to a patched version.
 // The wasmJs target's JS dev/test toolchain (webpack-dev-server / karma) pulls
-// in `ws`, which Kotlin otherwise resolves to a version vulnerable to
-// uninitialized-memory disclosure (GHSA-58qx-3vcg-4xpx; fixed in 8.20.1).
+// in `ws`, which Kotlin otherwise resolves to a vulnerable version:
+//   - uninitialized-memory disclosure (GHSA-58qx-3vcg-4xpx; fixed in 8.20.1)
+//   - memory-exhaustion DoS via tiny fragments   (fixed in 8.21.0)
 // The wasmJs target uses its own Yarn store (kotlin-js-store/wasm/yarn.lock),
 // so the override targets the Wasm Yarn plugin/extension — not the JS one.
 // After changing this pin, regenerate the lockfile with:
 //   ./gradlew kotlinWasmUpgradeYarnLock
 // ---------------------------------------------------------------------------
 plugins.withType<WasmYarnPlugin> {
-    the<WasmYarnRootExtension>().resolution("ws", "8.20.1")
+    the<WasmYarnRootExtension>().resolution("ws", "8.21.0")
 }

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-ws@8.20.1:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.20.1, ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==


### PR DESCRIPTION
Raises the existing wasm test-harness `ws` resolution floor 8.20.1 → 8.21.0, clearing **Dependabot alert #2** (high — memory-exhaustion DoS from tiny fragments/data chunks, fixed in 8.21.0). Same mechanism as #59, which introduced the pin.

Test-scope only — `ws` comes in via webpack-dev-server/karma for the wasmJs test harness and is not part of any published artifact.

Verified locally: `kotlinWasmUpgradeYarnLock` regenerates cleanly; `./gradlew wasmJsBrowserTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)