### PR TITLE
docs: correct stale Kotlin version references (2.3.20 -> 2.4.10)

### DIFF
--- a/.github/skills/mqtt-kmp/SKILL.md
+++ b/.github/skills/mqtt-kmp/SKILL.md
@@ -6,7 +6,7 @@ description: 'MQTTastic Client KMP — Kotlin Multiplatform MQTT 5.0 client libr
 # MQTTastic Client KMP
 
 ## Project Facts
-- **Language:** Kotlin 2.3.20 (Multiplatform)
+- **Language:** Kotlin 2.4.10 (Multiplatform)
 - **Build:** Gradle Kotlin DSL, version catalog at `gradle/libs.versions.toml`
 - **Targets:** jvm, android, iosArm64, iosSimulatorArm64, macosArm64, linuxX64, linuxArm64, mingwX64, wasmJs
 - **Dependencies:** Ktor 3.4.2, kotlinx-coroutines 1.10.2, kotlinx-io-bytestring 0.8.2 (zero external deps beyond these)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ You are an expert Kotlin Multiplatform engineer working on MQTTastic-Client-KMP,
 
 <context_and_memory>
 - **Project:** `org.meshtastic:mqtt-client-core` plus per-transport modules (`-transport-tcp`, `-transport-ws`) and a `-bom` — production-grade MQTT 5.0 and 3.1.1 client for Kotlin Multiplatform (JVM, Android, iOS, macOS, Linux, Windows, wasmJs).
-- **Stack:** Kotlin 2.3.20, Gradle 9.3.0, Ktor 3.4.2, kotlinx-coroutines 1.10.2, kotlinx-io-bytestring 0.8.2. Zero external deps beyond these.
+- **Stack:** Kotlin 2.4.10, Gradle 9.6.1, Ktor 3.5.1, kotlinx-coroutines 1.11.0, kotlinx-io-bytestring 0.9.1. Zero external deps beyond these.
 - **Reference Spec:** [OASIS MQTT 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html) and [OASIS MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) — consult for byte-level packet layouts, property definitions, and reason codes.
 </context_and_memory>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="docs/images/app-icon.png" alt="MQTTastic app icon" align="right" width="128" height="128" />
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.meshtastic/mqtt-client-core?label=Maven%20Central)](https://central.sonatype.com/artifact/org.meshtastic/mqtt-client-core)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-7f52ff.svg?logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.10-7f52ff.svg?logo=kotlin)](https://kotlinlang.org)
 [![License](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE)
 [![CI](https://github.com/meshtastic/MQTTastic-Client-KMP/actions/workflows/ci.yml/badge.svg)](https://github.com/meshtastic/MQTTastic-Client-KMP/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/meshtastic/MQTTastic-Client-KMP/graph/badge.svg)](https://codecov.io/gh/meshtastic/MQTTastic-Client-KMP)

--- a/core/README.md
+++ b/core/README.md
@@ -170,7 +170,7 @@ for the full coverage table.
 
 ## Compatibility
 
-- Kotlin **2.3.20** or newer.
+- Kotlin **2.4.10** or newer.
 - JDK **17+** for JVM/Android consumers (source/target compiled against 17).
 - Ktor **3.4.x** on the classpath for consumers who want to share the HTTP client.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 agp = "9.3.0"
-# Held at 2.3.x: klibs built by Kotlin 2.4 carry ABI version 2.4.0, which the primary
-# consumer (Meshtastic-Android, on Kotlin 2.3.21 until InsertKoinIO/koin#2431 resolves)
-# cannot read. Renovate enforces this via the "Hold Kotlin at 2.3.x" rule in renovate.json.
+# Kotlin 2.4.10 — matches the primary consumer (Meshtastic-Android is also on 2.4.10),
+# so the klib ABI 2.4.0 emitted here is readable downstream. This was previously held at
+# 2.3.x while that consumer sat on Kotlin 2.3.21; that hold no longer applies.
 kotlin = "2.4.10"
 ktor = "3.5.1"
 coroutines = "1.11.0"


### PR DESCRIPTION
## Summary

Corrects pervasive Kotlin-version doc drift. The repo builds on **Kotlin 2.4.10** (`gradle/libs.versions.toml`), but the README badge, `AGENTS.md`, `core/README.md`, and the mqtt-kmp SKILL all still said **2.3.20**, and the catalog carried a **self-contradictory comment** claiming Kotlin was "held at 2.3.x" enforced by a Renovate rule that doesn't exist.

## Why the "hold" is obsolete

The comment's rationale was that Meshtastic-Android (on Kotlin 2.3.21) couldn't read klibs with ABI 2.4.0. That's resolved: **Meshtastic-Android is now on Kotlin 2.4.10** (`gradle/libs.versions.toml:24`), matching this repo, and neither repo's `renovate.json` contains a "hold Kotlin" rule. So 2.4.10 is correct and the docs were simply stale.

## What changed

- **README** badge, **AGENTS.md** stack line, **core/README.md**, **`.github/skills/mqtt-kmp/SKILL.md`**: `2.3.20` → `2.4.10`. The AGENTS stack line was also refreshed to the actual versions (Gradle 9.6.1, Ktor 3.5.1, coroutines 1.11.0, kotlinx-io-bytestring 0.9.1).
- **`gradle/libs.versions.toml`**: replaced the false "held at 2.3.x / Renovate enforces" comment with an accurate note.

Left intentionally: the historical "macosX64 deprecated in Kotlin 2.3.20" line in `AGENTS.md` (it states *when* the target was deprecated, not the current stack).

## Notes for reviewers

Docs/comment only — no code or build changes. Part of the `org.meshtastic` KMP standard-alignment effort. Separate follow-ups for this repo: add tests for `transport-ws` (currently zero), enable `explicitApi()` (currently Konsist-only), and extend BCV to the klib surface (JVM-only today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
