### PR TITLE
chore(build): add .editorconfig and pin the Gradle wrapper checksum

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,45 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+indent_size = 4
+max_line_length = 120
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_packages_to_use_import_on_demand = unset
+# ktlint
+ktlint_standard = enabled
+ktlint_standard_filename = disabled
+ktlint_standard_no-wildcard-imports = enabled
+ktlint_standard_function-naming = enabled
+ktlint_function_naming_ignore_when_annotated_with = Composable
+ktlint_experimental = disabled
+ktlint_code_style = intellij_idea
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = off
+
+[Makefile]
+indent_style = tab
+
+[*.{sh,bash}]
+indent_size = 2
+
+[gradle/wrapper/**]
+charset = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+indent_style = unset
+indent_size = unset

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -7,3 +7,4 @@ retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14


### PR DESCRIPTION
Adds .editorconfig (matching the org standard) and pins distributionSha256Sum on the Gradle wrapper (9.6.1-bin, from Gradle's published checksum) so a tampered wrapper download is rejected. No library or functional changes.