### PR TITLE
chore: add CODEOWNERS (solo maintainer)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS — review routing.
+# Solo maintainer for now; expand to GitHub teams as they form.
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @jamesarich


### PR DESCRIPTION
Adds a CODEOWNERS file routing review requests to the maintainer (solo @handle for now; expand to teams later). Community-health completeness.