### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
     name: Test JVM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: build/reports/kover/report.xml
           flags: jvm
@@ -69,7 +69,7 @@ jobs:
     name: Test Native Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
     name: Test Native macOS
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -101,7 +101,7 @@ jobs:
     name: Test wasmJs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -117,7 +117,7 @@ jobs:
     name: Test Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -134,7 +134,7 @@ jobs:
     name: API Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -147,7 +147,7 @@ jobs:
       # klibs and needs the Kotlin/Native toolchain. Cache ~/.konan to avoid
       # re-downloading it every run.
       - name: Cache Konan (Kotlin/Native toolchain)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test-jvm, test-native-linux, test-native-macos, test-wasm, test-windows, api-check]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0
@@ -180,7 +180,7 @@ jobs:
     needs: [build]
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,18 +42,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 21
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Cache Gradle
         if: matrix.language == 'java-kotlin'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -63,7 +63,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -76,6 +76,6 @@ jobs:
           ./gradlew compileKotlinJvm --no-daemon --no-build-cache --stacktrace
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/gradle-setup
         with:
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew dokkaGeneratePublicationHtml --stacktrace
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build/dokka/html
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.ver.outputs.ref }}
           submodules: true
@@ -103,7 +103,7 @@ jobs:
 
       - name: Attest Maven artifacts
         if: inputs.dry_run != true
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: maven-staging/**/*
 
@@ -142,7 +142,7 @@ jobs:
         # branch, not the release tag. For an existing release (e.g. one
         # created manually after a failed run) this updates it in place.
         if: inputs.dry_run != true
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ steps.ver.outputs.version }}
           generate_release_notes: true
@@ -179,7 +179,7 @@ jobs:
             web_zip: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.publish.outputs.ref }}
           submodules: true
@@ -222,7 +222,7 @@ jobs:
 
       - name: Attach to GitHub Release
         if: steps.collect.outputs.count != '0'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ needs.publish.outputs.version }}
           files: release-assets/*
@@ -230,7 +230,7 @@ jobs:
 
       - name: Attest sample artifacts
         if: steps.collect.outputs.count != '0'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: release-assets/*
 
@@ -244,14 +244,14 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.publish.outputs.ref }}
           submodules: true
           fetch-depth: 0
 
       - name: Generate SBOM (CycloneDX + SPDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: cyclonedx-json
           output-file: sbom.cdx.json
@@ -259,7 +259,7 @@ jobs:
           upload-release-assets: true
 
       - name: Generate SBOM (SPDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: spdx-json
           output-file: sbom.spdx.json
@@ -270,7 +270,7 @@ jobs:
         # anchore/sbom-action only auto-uploads release assets on tag/release
         # events; on workflow_dispatch (recovery/backfill) attach explicitly.
         if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ needs.publish.outputs.version }}
           files: |
@@ -279,7 +279,7 @@ jobs:
           fail_on_unmatched_files: false
 
       - name: Attest build provenance for release assets
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             sbom.cdx.json


### PR DESCRIPTION
## What

SHA-pin all mutable-tag third-party GitHub Actions in the build workflows to full commit SHAs, per standard §5.3 supply-chain hardening.

## Why

Mutable tags (`@v7`, `@v4`, …) can be silently repointed at malicious commits. Pinning to a 40-char commit SHA makes each action reference immutable. The human-readable version is preserved in a trailing `# vX.Y.Z` comment so Renovate can continue to bump them.

## Changes

Pinned refs across the build workflows:

- **ci.yml** — `actions/checkout` `@v7`→`3d3c42e5…` (v7.0.1), `codecov/codecov-action` `@v7`→`fb8b3582…` (v7.0.0), `actions/cache` `@v6`→`55cc8345…` (v6.1.0)
- **docs.yml** — `actions/checkout` (v7.0.1), `actions/upload-pages-artifact` `@v5`→`fc324d35…` (v5.0.0), `actions/deploy-pages` `@v5`→`cd2ce8fc…` (v5.0.0)
- **release.yml** — `actions/checkout` (v7.0.1), `actions/attest-build-provenance` `@v4`→`0f67c3f4…` (v4.1.1), `softprops/action-gh-release` `@v3`→`3d0d9888…` (v3.0.2), `anchore/sbom-action` `@v0`→`e22c3899…` (v0.24.0)
- **codeql.yml** — `actions/checkout` (v7.0.1), `actions/setup-java` `@v5`→`03ad4de0…` (v5.6.0), `actions/cache` (v6.1.0), `github/codeql-action/init` and `/analyze` `@v4`→`e0647621…` (v4.37.2, matching the file's already-pinned `upload-sarif`)

Local composite refs (`./.github/actions/gradle-setup`) and already-pinned refs (all of scorecard.yml) are untouched.

## Verification

`grep -rnE 'uses: [a-zA-Z].*@v[0-9]' .github/workflows/` returns no matches — every third-party ref now ends in a 40-char SHA. Diff is 30 insertions / 30 deletions, each a pure ref swap with indentation unchanged.