### PR TITLE
chore: docs and governance hygiene

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: meshtastic
 open_collective: meshtastic

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security advisory
+    url: https://github.com/meshtastic/mqttastic-client-kmp/security/advisories/new
+    about: Don't file public issues for security problems. Use a private security advisory.
+  - name: Meshtastic community
+    url: https://meshtastic.org/docs/community/
+    about: General Meshtastic questions belong in the community channels.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: dep-review-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ repositories {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(platform("org.meshtastic:mqtt-client-bom:0.3.0"))
+            implementation(platform("org.meshtastic:mqtt-client-bom:0.5.0"))
             implementation("org.meshtastic:mqtt-client-core")
             // Pick the transport(s) you actually use:
             implementation("org.meshtastic:mqtt-client-transport-tcp") // TCP/TLS — every target except browser
@@ -121,7 +121,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation platform('org.meshtastic:mqtt-client-bom:0.3.0')
+                implementation platform('org.meshtastic:mqtt-client-bom:0.5.0')
                 implementation 'org.meshtastic:mqtt-client-core'
                 implementation 'org.meshtastic:mqtt-client-transport-tcp'
                 implementation 'org.meshtastic:mqtt-client-transport-ws'
@@ -137,7 +137,7 @@ kotlin {
 
 ```kotlin
 dependencies {
-    implementation(platform("org.meshtastic:mqtt-client-bom:0.3.0"))
+    implementation(platform("org.meshtastic:mqtt-client-bom:0.5.0"))
     implementation("org.meshtastic:mqtt-client-core")
     implementation("org.meshtastic:mqtt-client-transport-tcp")
 }
@@ -381,7 +381,7 @@ fun MqttScreen(viewModel: MqttViewModel) {
 
 ### Version alignment
 
-The library uses **Ktor 3.4.2** and **kotlinx-coroutines 1.10.2**. If your project uses the same versions, no conflicts will arise. Pin versions in your `libs.versions.toml` to avoid Gradle resolution surprises.
+The library uses **Ktor 3.5.1** and **kotlinx-coroutines 1.11.0**. If your project uses the same versions, no conflicts will arise. Pin versions in your `libs.versions.toml` to avoid Gradle resolution surprises.
 
 ## MQTT 5.0 Coverage
 

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "platformAutomerge": true,
   "automergeStrategy": "squash",
   "rebaseWhen": "conflicted",
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "Group Kotlin ecosystem dependencies",


### PR DESCRIPTION
Standard-compliance hygiene fixes, batched into one PR.

- **README.md (§6.3):** bump `org.meshtastic:mqtt-client-bom` pin `0.3.0` -> `0.5.0` in all 3 install snippets; correct the version-alignment text to **Ktor 3.5.1** and **kotlinx-coroutines 1.11.0** (matching `gradle/libs.versions.toml`).
- **.github/FUNDING.yml (§8.4):** add `github: meshtastic` (kept `open_collective: meshtastic`).
- **.github/ISSUE_TEMPLATE/config.yml (§8.4):** add the missing config — `blank_issues_enabled: false` plus security-advisory and community contact links.
- **renovate.json (§5.6):** add top-level `vulnerabilityAlerts: { enabled: true }` (JSON validated).
- **.github/workflows/dependency-review.yml (§5.7):** add SHA-pinned Dependency Review workflow (new file; no other workflow files touched).