### PR TITLE
feat(transport): add TLS trust hook to TcpTransportFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,42 @@ val config = MqttConfig(
 
 Log levels from most to least verbose: `TRACE` → `DEBUG` → `INFO` → `WARN` → `ERROR` → `NONE`.
 
+### Custom TLS trust
+
+By default the TCP transport validates the broker certificate against the platform CA store. To
+reach a broker behind a private or self-signed CA, pass a TLS customisation lambda to
+`TcpTransportFactory`. It runs against ktor's `TLSConfigBuilder`:
+
+```kotlin
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+
+val client = MqttClient("my-client") {
+    transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager }
+}
+client.connect(MqttEndpoint.parse("mqtts://broker.internal:8883"))
+```
+
+The hook is applied after the SNI server name is resolved and before platform trust is configured.
+On Android that ordering matters: your trust manager is *wrapped* by the hostname-aware trust
+manager rather than replacing it, so certificate hostname verification still happens.
+
+This scopes the extra trust to the MQTT connection alone. It replaces the app-wide workaround of
+adding `<certificates src="user"/>` to `network_security_config.xml`, which would affect every
+HTTPS connection the app makes.
+
+The hook composes with transport selection as usual:
+
+```kotlin
+transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager } +
+    WebSocketTransportFactory()
+```
+
+`TLSConfigBuilder` comes from `io.ktor:ktor-network-tls`, exposed transitively by
+`mqtt-client-transport-tcp` — no extra dependency needed. The WebSocket transport has no equivalent
+hook yet. `trustManager` specifically is available on the JVM and Android actuals of
+`TLSConfigBuilder`; on Apple, Linux, and Windows targets the hook still runs, but `TLSConfigBuilder`
+exposes a different set of properties there.
+
 ## Android / KMP Integration
 
 The library is designed as a drop-in MQTT client for KMP projects. Consumer ProGuard/R8 rules are bundled automatically.

--- a/README.md
+++ b/README.md
@@ -348,23 +348,30 @@ client.connect(MqttEndpoint.parse("mqtts://broker.internal:8883"))
 ```
 
 The hook is applied after the SNI server name is resolved and before platform trust is configured.
-On Android that ordering matters: your trust manager is *wrapped* by the hostname-aware trust
-manager rather than replacing it, so your trust anchors remain subject to the platform's
-domain-specific `network_security_config.xml` rules, certificate pinning, and Certificate
-Transparency policy instead of replacing that policy wholesale.
+On Android that ordering means your trust manager is reached through the hostname-aware
+`checkServerTrusted(chain, authType, hostname)` overload, which the platform requires whenever
+`network_security_config.xml` holds any domain-specific configuration — rather than being discarded
+in favour of the platform wrapper.
 
-Be clear about what the wrapping does *not* buy you. Android's hostname-aware
-`checkServerTrusted(chain, authType, hostname)` uses the hostname to look up that policy — it does
-not perform RFC 6125 subject-name matching. That check comes from ktor and only runs when the SNI
+Be clear about what that does *not* buy you. Installing your own trust manager **replaces the
+platform's trust decision**: your anchors are used instead of the platform's, and
+`network_security_config.xml` anchors, certificate pinning, and Certificate Transparency policy are
+then enforced only insofar as your manager enforces them itself. Those platform policies apply as
+before only if you leave `trustManager` unset. The wrapping preserves the hostname-aware *call
+path*, not the platform's *policy*.
+
+RFC 6125 subject-name matching is separate again. Android's 3-arg overload uses the hostname for
+policy lookup, not for subject-name matching; that check comes from ktor and only runs when the SNI
 server name is set, so it is absent for IP-literal brokers such as `mqtts://192.168.1.50:8883`. On
-JVM and native targets there is no platform trust wrapping at all, so ktor's SNI-gated
-subject-name check is the only peer-identity verification beyond chain validation. If your trust
-manager accepts any chain, nothing else will stop a mismatched certificate.
+JVM and native targets there is no platform trust wrapping at all, so ktor's SNI-gated subject-name
+check is the only peer-identity verification beyond chain validation. If your trust manager accepts
+any chain, nothing else will stop a mismatched certificate.
 
-On Android the trust manager you install must be one the platform can wrap: obtain it from a
-`TrustManagerFactory` initialised with a `KeyStore` containing your CA, rather than hand-writing an
-`X509TrustManager`. A hand-written one that implements only the two-arg `checkServerTrusted` cannot
-be wrapped and the handshake fails with an `IllegalArgumentException` explaining this.
+On Android the manager must be one `X509TrustManagerExtensions` can wrap: either obtained from a
+`TrustManagerFactory` initialised with a `KeyStore` containing your CA, or declaring the three-arg
+`checkServerTrusted(chain, authType, host)` that the platform looks up reflectively. A hand-written
+`X509TrustManager` implementing only the two-arg overload cannot be wrapped, and the handshake fails
+with an `IllegalArgumentException` explaining this.
 
 This scopes the extra trust to the MQTT connection alone. It replaces the app-wide workaround of
 adding `<certificates src="user"/>` to `network_security_config.xml`, which would affect every

--- a/README.md
+++ b/README.md
@@ -349,7 +349,22 @@ client.connect(MqttEndpoint.parse("mqtts://broker.internal:8883"))
 
 The hook is applied after the SNI server name is resolved and before platform trust is configured.
 On Android that ordering matters: your trust manager is *wrapped* by the hostname-aware trust
-manager rather than replacing it, so certificate hostname verification still happens.
+manager rather than replacing it, so your trust anchors remain subject to the platform's
+domain-specific `network_security_config.xml` rules, certificate pinning, and Certificate
+Transparency policy instead of replacing that policy wholesale.
+
+Be clear about what the wrapping does *not* buy you. Android's hostname-aware
+`checkServerTrusted(chain, authType, hostname)` uses the hostname to look up that policy — it does
+not perform RFC 6125 subject-name matching. That check comes from ktor and only runs when the SNI
+server name is set, so it is absent for IP-literal brokers such as `mqtts://192.168.1.50:8883`. On
+JVM and native targets there is no platform trust wrapping at all, so ktor's SNI-gated
+subject-name check is the only peer-identity verification beyond chain validation. If your trust
+manager accepts any chain, nothing else will stop a mismatched certificate.
+
+On Android the trust manager you install must be one the platform can wrap: obtain it from a
+`TrustManagerFactory` initialised with a `KeyStore` containing your CA, rather than hand-writing an
+`X509TrustManager`. A hand-written one that implements only the two-arg `checkServerTrusted` cannot
+be wrapped and the handshake fails with an `IllegalArgumentException` explaining this.
 
 This scopes the extra trust to the MQTT connection alone. It replaces the app-wide workaround of
 adding `<certificates src="user"/>` to `network_security_config.xml`, which would affect every

--- a/docs/superpowers/plans/2026-07-25-tls-trust-hook.md
+++ b/docs/superpowers/plans/2026-07-25-tls-trust-hook.md
@@ -494,10 +494,10 @@ class TcpTransportTrustManagerTest {
     }
 
     @Test
-    fun hookSeesBuilderBeforePlatformTrustRuns() {
-        // The hook reads trustManager before configurePlatformTrust has touched it. On the
-        // JVM that means null; the assertion of record is that the lambda observed the
-        // builder at all and that its own write then took effect.
+    fun hookWriteToTrustManagerTakesEffect() {
+        // The lambda runs against the live builder and its write survives the rest of
+        // applyMqttTls. This does not assert the hook/platform-trust ordering — on the JVM
+        // configurePlatformTrust is a no-op, so that ordering is not observable here.
         var ranWithBuilder = false
         val builder = TLSConfigBuilder()
         builder.applyMqttTls("broker.example.com") {
@@ -510,8 +510,8 @@ class TcpTransportTrustManagerTest {
     }
 
     @Test
-    fun factoryHookIsHandedToEveryTransportItCreates() {
-        // Guards against the factory dropping the lambda on the floor in create().
+    fun factoryDoesNotInvokeHookAtCreateTime() {
+        // The hook belongs to the handshake, not to transport construction.
         var invocations = 0
         val factory = TcpTransportFactory { invocations++ }
         // create() must not run the hook — that happens during the handshake.

--- a/docs/superpowers/plans/2026-07-25-tls-trust-hook.md
+++ b/docs/superpowers/plans/2026-07-25-tls-trust-hook.md
@@ -571,7 +571,7 @@ Document the hook where a consumer hitting the issue #102 problem will actually 
 In `transport-tcp/Module.md`, insert between the existing code fence (ends line 13) and the
 "Available on JVM, Android, …" paragraph (line 15):
 
-```markdown
+````markdown
 ### Trusting a private CA
 
 If the broker's certificate is issued by a private or self-signed CA that is not in the platform
@@ -587,14 +587,14 @@ The lambda is applied after the SNI server name is set and before platform trust
 on Android a trust manager installed here is still wrapped in the hostname-aware delegate rather
 than replacing it. The added trust applies only to this MQTT connection — unlike Android's
 app-wide `network_security_config.xml` trust anchors.
-```
+````
 
 - [ ] **Step 2: Add the README section**
 
 In `README.md`, insert immediately before line 335 (`## Android / KMP Integration`), after the
 "Log levels from most to least verbose…" line that closes the Logging section:
 
-```markdown
+````markdown
 ### Custom TLS trust
 
 By default the TCP transport validates the broker certificate against the platform CA store. To
@@ -611,8 +611,10 @@ client.connect(MqttEndpoint.parse("mqtts://broker.internal:8883"))
 ```
 
 The hook is applied after the SNI server name is resolved and before platform trust is configured.
-On Android that ordering matters: your trust manager is *wrapped* by the hostname-aware trust
-manager rather than replacing it, so certificate hostname verification still happens.
+On Android that ordering means your trust manager is reached through the hostname-aware
+`checkServerTrusted(chain, authType, hostname)` overload rather than being discarded. Note that
+installing your own trust manager replaces the platform's trust decision — see the shipped
+`README.md` section for the full statement of what that does and does not preserve.
 
 This scopes the extra trust to the MQTT connection alone. It replaces the app-wide workaround of
 adding `<certificates src="user"/>` to `network_security_config.xml`, which would affect every
@@ -628,7 +630,7 @@ transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager 
 `TLSConfigBuilder` comes from `io.ktor:ktor-network-tls`, exposed transitively by
 `mqtt-client-transport-tcp` — no extra dependency needed. The WebSocket transport has no equivalent
 hook yet.
-```
+````
 
 - [ ] **Step 3: Verify the docs build**
 

--- a/docs/superpowers/plans/2026-07-25-tls-trust-hook.md
+++ b/docs/superpowers/plans/2026-07-25-tls-trust-hook.md
@@ -1,0 +1,689 @@
+# TLS Trust Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a caller customise TLS trust for the MQTT TCP socket alone by passing a `TLSConfigBuilder.() -> Unit` lambda to `TcpTransportFactory`.
+
+**Architecture:** The TLS setup currently inlined in `TcpTransport.connect` moves into one internal extension function, `TLSConfigBuilder.applyMqttTls(host, configureTls)`. That function is both the single production call site and the unit-test target. It applies `serverName` first, then the caller's lambda, then `configurePlatformTrust(host)` — in that order, so that a caller-assigned `trustManager` gets *wrapped* by Android's `HostnameAwareTrustManager` rather than replacing it. The lambda is stored on `TcpTransportFactory` and handed to each `TcpTransport` it creates.
+
+**Tech Stack:** Kotlin 2.4.10 Multiplatform, Gradle 9.6.1, ktor-network + ktor-network-tls 3.5.1, `kotlin.test`, binary-compatibility-validator (klib + JVM dumps), detekt, spotless/ktlint, kover.
+
+Spec: `docs/superpowers/specs/2026-07-25-tls-trust-hook-design.md`. Issue: [#102](https://github.com/meshtastic/MQTTastic-Client-KMP/issues/102).
+
+## Global Constraints
+
+- Module touched: `:transport-tcp` only. No changes to `:core`, `:transport-ws`, or `:bom`.
+- Never import `java.*` or `android.*` in `commonMain` or `commonTest`. `trustManager` is a JVM/Android-only property of `TLSConfigBuilder` — any test touching it belongs in `jvmTest`.
+- Zero new dependencies. `ktor-network-tls` is already declared; only its configuration scope changes.
+- Every new/modified `.kt` file needs the GPL-3.0 header from `config/spotless/copyright.kt`. `spotlessApply` will insert it.
+- Public API additions must be `public` and reflected in **both** `transport-tcp/api/jvm/transport-tcp.api` and `transport-tcp/api/transport-tcp.klib.api` via `./gradlew apiDump`.
+- Both new constructor parameters are defaulted (`= null`) so existing source and compiled callers keep working.
+- Commit format: Conventional Commits, `<type>(<scope>): <subject>`, imperative, no period, subject under 50 chars. Scope for this work: `transport`.
+- Final gate before handing off: `./gradlew spotlessCheck detekt allTests apiCheck koverVerify` must pass.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt` | Existing `expect fun configurePlatformTrust`. Gains the new `applyMqttTls` orchestrator — it belongs beside the platform-trust declaration it sequences, not in the transport. | Modify |
+| `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt` | Transport + factory. Gains the constructor parameters; its inline `tls {}` body shrinks to one `applyMqttTls` call. | Modify |
+| `transport-tcp/build.gradle.kts` | Promote `ktor-network-tls` from `implementation` to `api`. | Modify |
+| `transport-tcp/api/jvm/transport-tcp.api` | JVM ABI baseline. | Regenerate |
+| `transport-tcp/api/transport-tcp.klib.api` | Native/common ABI baseline. | Regenerate |
+| `transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt` | Existing SNI guard tests. Gains `applyMqttTls` ordering/invocation tests. | Modify |
+| `transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt` | Factory-level tests: the hook-carrying factory still `supports`/`create`s correctly and composes with `+`. | Create |
+| `transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt` | JVM-only proof that a lambda-assigned `trustManager` reaches ktor's real builder state. | Create |
+| `transport-tcp/Module.md` | Dokka module doc — private-CA snippet. | Modify |
+| `README.md` | New `### Custom TLS trust` section before `## Android / KMP Integration`. | Modify |
+
+Task 1 delivers the seam and its common tests. Task 2 wires the public API, the build change, and the ABI dumps. Task 3 adds the JVM trust-manager proof. Task 4 documents. Tasks 2 and 3 each depend on the one before; a reviewer can reject any of them independently.
+
+---
+
+### Task 1: The `applyMqttTls` seam
+
+Extract the TLS configuration into one internal function with the correct ordering, and cover it in `commonTest`. No public API change yet — `TcpTransport` calls the new function with a `null` lambda, so behaviour is identical to today.
+
+**Files:**
+- Modify: `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt` (append after line 38)
+- Modify: `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt:102-108`
+- Test: `transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt`
+
+**Interfaces:**
+- Consumes: existing `internal fun sniServerName(host: String): String?` and `internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)`, both already in this package.
+- Produces: `internal fun TLSConfigBuilder.applyMqttTls(host: String, configureTls: (TLSConfigBuilder.() -> Unit)? = null)`. Task 2 calls this with a non-null lambda.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these four tests inside the existing `class TcpTransportTlsTest` in
+`transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt`
+(before the closing brace). Also add `import io.ktor.network.tls.TLSConfigBuilder` to the import
+block — the existing imports are `kotlin.test.*` assertions only.
+
+```kotlin
+    @Test
+    fun applyMqttTlsSetsSniForDnsHost() {
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com")
+        assertEquals("broker.example.com", builder.serverName)
+    }
+
+    @Test
+    fun applyMqttTlsSuppressesSniForIpLiteral() {
+        val ipv4 = TLSConfigBuilder()
+        ipv4.applyMqttTls("192.168.1.50")
+        assertNull(ipv4.serverName)
+
+        val ipv6 = TLSConfigBuilder()
+        ipv6.applyMqttTls("2001:db8::1")
+        assertNull(ipv6.serverName)
+    }
+
+    @Test
+    fun applyMqttTlsInvokesCallerHookExactlyOnce() {
+        var calls = 0
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") { calls++ }
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun applyMqttTlsRunsCallerHookAfterServerNameIsSet() {
+        // The hook must observe serverName already assigned, so a caller can read or
+        // override it. This also pins the hook ahead of configurePlatformTrust, which
+        // on Android wraps whatever trustManager the hook installed.
+        var observed: String? = "not-yet-run"
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") { observed = serverName }
+        assertEquals("broker.example.com", observed)
+    }
+
+    @Test
+    fun applyMqttTlsWithoutHookStillSetsSni() {
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("mqtt.local", configureTls = null)
+        assertEquals("mqtt.local", builder.serverName)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+./gradlew :transport-tcp:jvmTest --tests "org.meshtastic.mqtt.transport.tcp.TcpTransportTlsTest"
+```
+
+Expected: compilation failure — `Unresolved reference: applyMqttTls`. A compile error is the
+correct "fail" signal for a Kotlin TDD cycle; do not proceed until you have seen it.
+
+- [ ] **Step 3: Implement `applyMqttTls`**
+
+Append to `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt`,
+after the existing `configurePlatformTrust` declaration:
+
+```kotlin
+/**
+ * Applies the MQTT TLS configuration to this [TLSConfigBuilder] in the one correct order.
+ *
+ * This is the single call site for TLS setup, so the ordering below cannot drift:
+ *
+ * 1. [serverName] — the SNI value, `null` for IP literals (RFC 6066 §3 forbids them).
+ * 2. [configureTls] — the caller's hook, so it can read or override the SNI value and
+ *    install its own trust manager (e.g. a private CA).
+ * 3. [configurePlatformTrust] — reads whatever trust manager is now on the builder and,
+ *    on Android, wraps it in a hostname-aware delegate.
+ *
+ * Step 2 must precede step 3. Reversing them would let a caller-supplied trust manager
+ * *replace* Android's `HostnameAwareTrustManager`, silently dropping the platform's 3-arg
+ * `checkServerTrusted` hostname verification. Running the caller first composes instead:
+ * a private-CA trust manager is still subject to the hostname check.
+ *
+ * @param host the broker host (DNS name or IP literal), used for both SNI and trust evaluation.
+ * @param configureTls optional caller customisation; `null` preserves the default behaviour.
+ */
+internal fun TLSConfigBuilder.applyMqttTls(
+    host: String,
+    configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) {
+    serverName = sniServerName(host)
+    configureTls?.invoke(this)
+    configurePlatformTrust(host)
+}
+```
+
+- [ ] **Step 4: Route `TcpTransport.connect` through the seam**
+
+In `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt`,
+replace this block (currently lines 102-108):
+
+```kotlin
+                            rawSocket.tls(tlsContext) {
+                                serverName = tlsServerName
+                                // Configure trust with the real host (DNS name or IP literal),
+                                // not the SNI value: tlsServerName is null for IP literals, but
+                                // Android still needs a host for the hostname-aware trust check.
+                                configurePlatformTrust(endpoint.host)
+                            }
+```
+
+with:
+
+```kotlin
+                            rawSocket.tls(tlsContext) { applyMqttTls(endpoint.host) }
+```
+
+Then delete the now-unused local `val tlsServerName = sniServerName(endpoint.host)` on the
+preceding line (currently line 87) — `applyMqttTls` computes the SNI value itself. Leave the
+`sniServerName` and `isIpLiteral` top-level functions in place; they are still used by
+`applyMqttTls` and by the existing tests.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+./gradlew :transport-tcp:jvmTest --tests "org.meshtastic.mqtt.transport.tcp.TcpTransportTlsTest"
+```
+
+Expected: PASS, 9 tests (4 pre-existing SNI tests + 5 new).
+
+- [ ] **Step 6: Verify no other target regressed and the code is clean**
+
+```bash
+./gradlew :transport-tcp:allTests :transport-tcp:detekt
+./gradlew spotlessApply
+```
+
+Expected: all green. `spotlessApply` may reformat; that is fine.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt \
+        transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt \
+        transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
+git commit -m "refactor(transport): extract applyMqttTls TLS seam"
+```
+
+---
+
+### Task 2: Public `configureTls` hook on the factory and transport
+
+Expose the lambda, promote the ktor TLS dependency so consumers can name `TLSConfigBuilder`, and regenerate the ABI baselines.
+
+**Files:**
+- Modify: `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt` (class declarations at lines 52 and 271)
+- Modify: `transport-tcp/build.gradle.kts:44-49`
+- Modify: `transport-tcp/api/jvm/transport-tcp.api`, `transport-tcp/api/transport-tcp.klib.api`
+- Test: `transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt` (create)
+
+**Interfaces:**
+- Consumes: `applyMqttTls(host, configureTls)` from Task 1.
+- Produces: `public class TcpTransportFactory(configureTls: (TLSConfigBuilder.() -> Unit)? = null)` and `public class TcpTransport(configureTls: (TLSConfigBuilder.() -> Unit)? = null)`. Task 3 constructs `TcpTransportFactory { … }` and Task 4 documents it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt`:
+
+```kotlin
+package org.meshtastic.mqtt.transport.tcp
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.meshtastic.mqtt.MqttEndpoint
+import org.meshtastic.mqtt.plus
+
+/**
+ * Covers the caller-supplied TLS hook on [TcpTransportFactory] (issue #102).
+ *
+ * The hook itself is only exercised during a real TLS handshake, so these tests pin the
+ * surrounding contract: the factory still selects the right endpoints, still produces a
+ * [TcpTransport], and still composes with other factories via `+`.
+ */
+class TcpTransportFactoryTlsTest {
+    @Test
+    fun factoryWithTlsHookStillSupportsOnlyTcpEndpoints() {
+        val factory = TcpTransportFactory { serverName = "override.example.com" }
+        assertTrue(factory.supports(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true)))
+        assertFalse(factory.supports(MqttEndpoint.WebSocket("wss://broker.example.com/mqtt")))
+    }
+
+    @Test
+    fun factoryWithTlsHookCreatesTcpTransport() {
+        val factory = TcpTransportFactory { serverName = "override.example.com" }
+        val transport = factory.create(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true))
+        assertIs<TcpTransport>(transport)
+        assertFalse(transport.isConnected)
+    }
+
+    @Test
+    fun noArgFactoryStillWorks() {
+        val factory = TcpTransportFactory()
+        assertTrue(factory.supports(MqttEndpoint.Tcp("broker.example.com", 1883, tls = false)))
+        assertIs<TcpTransport>(factory.create(MqttEndpoint.Tcp("broker.example.com", 1883, tls = false)))
+    }
+
+    @Test
+    fun factoryWithTlsHookComposesWithPlus() {
+        val combined = TcpTransportFactory { serverName = "override.example.com" } + TcpTransportFactory()
+        assertTrue(combined.supports(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true)))
+        assertIs<TcpTransport>(combined.create(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true)))
+    }
+}
+```
+
+Note on the `+` test: it combines two TCP factories rather than pulling in
+`WebSocketTransportFactory`, because `:transport-tcp` must not depend on `:transport-ws`. That
+still exercises `plus`, which is what needs covering here.
+
+Both endpoint signatures used above are verified against
+`core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttTransport.kt:81-111` —
+`MqttEndpoint.Tcp(host, port = 1883, tls = false)` and
+`MqttEndpoint.WebSocket(url, protocols = listOf("mqtt"))`. `plus` is a top-level operator
+extension declared at `core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttTransportFactory.kt:51`,
+which is why it needs its own `import org.meshtastic.mqtt.plus`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+./gradlew :transport-tcp:jvmTest --tests "org.meshtastic.mqtt.transport.tcp.TcpTransportFactoryTlsTest"
+```
+
+Expected: compilation failure — `Too many arguments for public constructor TcpTransportFactory()`,
+because the factory does not accept a lambda yet.
+
+- [ ] **Step 3: Add the constructor parameters**
+
+In `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt`,
+add the import:
+
+```kotlin
+import io.ktor.network.tls.TLSConfigBuilder
+```
+
+Change the `TcpTransport` declaration (currently line 52) from `public class TcpTransport : MqttTransport {` to:
+
+```kotlin
+public class TcpTransport(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransport {
+```
+
+Extend its KDoc (currently lines 45-51) with a `@param`:
+
+```kotlin
+ * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] during the TLS
+ *   handshake, after the SNI server name is set and before platform trust is configured.
+ *   Use it to trust a private or self-signed CA for this connection only. Ignored for
+ *   non-TLS endpoints.
+```
+
+Pass it through at the `tls` call site — the line written in Task 1 Step 4 becomes:
+
+```kotlin
+                            rawSocket.tls(tlsContext) { applyMqttTls(endpoint.host, configureTls) }
+```
+
+Then replace the whole `TcpTransportFactory` declaration (currently lines 265-275) with:
+
+```kotlin
+/**
+ * [MqttTransportFactory] that builds a [TcpTransport] for [MqttEndpoint.Tcp] endpoints.
+ *
+ * Add `org.meshtastic:mqtt-client-transport-tcp` and pass an instance to
+ * [org.meshtastic.mqtt.MqttConfig.Builder.transportFactory].
+ *
+ * To trust a broker whose certificate chain is not in the platform CA store — a private or
+ * self-signed CA — supply [configureTls]. The scope is this MQTT connection only, unlike
+ * Android's app-wide `network_security_config.xml` trust anchors:
+ *
+ * ```kotlin
+ * transportFactory = TcpTransportFactory { trustManager = myTrustManager } + WebSocketTransportFactory()
+ * ```
+ *
+ * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport
+ *   this factory creates. It runs after the SNI server name is set and before platform trust
+ *   is configured, so on Android a trust manager installed here is still wrapped in the
+ *   hostname-aware delegate rather than replacing it.
+ */
+public class TcpTransportFactory(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransportFactory {
+    override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.Tcp
+
+    override fun create(endpoint: MqttEndpoint): MqttTransport = TcpTransport(configureTls)
+}
+```
+
+- [ ] **Step 4: Promote the ktor TLS dependency**
+
+In `transport-tcp/build.gradle.kts`, change the `commonMain.dependencies` block (lines 44-48) to:
+
+```kotlin
+        commonMain.dependencies {
+            api(project(":core"))
+            implementation(libs.ktor.network)
+            // api, not implementation: TLSConfigBuilder appears in TcpTransportFactory's
+            // public constructor signature, so consumers need it on their compile classpath.
+            api(libs.ktor.network.tls)
+        }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+./gradlew :transport-tcp:jvmTest --tests "org.meshtastic.mqtt.transport.tcp.TcpTransportFactoryTlsTest"
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Confirm `apiCheck` fails, then regenerate the baselines**
+
+```bash
+./gradlew :transport-tcp:apiCheck
+```
+
+Expected: FAIL — the dumps do not yet list the new constructors. Seeing this failure first
+confirms the ABI change is real and being tracked. Then:
+
+```bash
+./gradlew :transport-tcp:apiDump
+git diff transport-tcp/api/
+```
+
+Inspect the diff and confirm all three of the following, which together prove the
+binary-compatibility claim in the spec:
+
+1. `transport-tcp/api/jvm/transport-tcp.api` gains
+   `public fun <init> (Lkotlin/jvm/functions/Function1;)V` and a synthetic
+   `<init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V`
+   for both `TcpTransport` and `TcpTransportFactory`.
+2. The existing `public fun <init> ()V` lines are **still present** for both classes. This is the
+   zero-arg constructor Kotlin emits for an all-defaults constructor — its survival is what keeps
+   already-compiled `TcpTransportFactory()` callers linking. If either disappeared, stop: the
+   change is binary-breaking and needs revisiting.
+3. `transport-tcp/api/transport-tcp.klib.api` gains
+   `constructor <init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder, kotlin.Unit>? = ...)`
+   for both classes.
+
+Note the klib dump header lists only `[iosArm64, iosSimulatorArm64, linuxArm64, linuxX64, macosArm64, mingwX64]`. On a Linux host, BCV skips the Apple targets and trusts the committed dump. If the diff drops the Apple entries from the header or the declarations, do not commit that — regenerate on a macOS host, per the comment in `transport-tcp/build.gradle.kts:52-62`.
+
+- [ ] **Step 7: Verify the full module and re-check the API**
+
+```bash
+./gradlew spotlessApply
+./gradlew :transport-tcp:allTests :transport-tcp:detekt :transport-tcp:apiCheck
+```
+
+Expected: all green, `apiCheck` now passing against the regenerated dumps.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt \
+        transport-tcp/build.gradle.kts \
+        transport-tcp/api/ \
+        transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt
+git commit -m "feat(transport): add TLS trust hook to TcpTransportFactory"
+```
+
+---
+
+### Task 3: JVM proof that the hook reaches ktor's builder
+
+The `commonTest` suite cannot touch `trustManager` — it exists only on the JVM/Android actuals of `TLSConfigBuilder`. This task proves in `jvmTest` that a trust manager installed by the caller's lambda is genuinely present on the builder ktor will use, rather than on a discarded copy.
+
+**Files:**
+- Test: `transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt` (create)
+
+**Interfaces:**
+- Consumes: `applyMqttTls` (Task 1) and the public hook (Task 2).
+- Produces: nothing consumed by later tasks.
+
+`:transport-tcp` has no `src/jvmTest` directory yet — creating the file creates the source set. The `mqtt.kmp.library` convention plugin already declares the `jvm` target, so no build-file change is required and `kotlin.test` is already available to it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt`:
+
+```kotlin
+package org.meshtastic.mqtt.transport.tcp
+
+import io.ktor.network.tls.TLSConfigBuilder
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+/**
+ * JVM-only checks that the caller's TLS hook mutates the same [TLSConfigBuilder] ktor
+ * consumes, using `trustManager` — a property that exists only on the JVM and Android
+ * actuals of [TLSConfigBuilder], and so cannot be asserted from `commonTest`.
+ *
+ * On the JVM, `configurePlatformTrust` is a no-op, so a hook-installed trust manager should
+ * survive `applyMqttTls` untouched. On Android it is deliberately *not* preserved by
+ * identity — it gets wrapped in a hostname-aware delegate. That wrapping needs the
+ * `X509TrustManagerExtensions` framework class and is therefore out of unit-test scope.
+ */
+class TcpTransportTrustManagerTest {
+    private object FakeTrustManager : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+
+        override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    @Test
+    fun hookInstalledTrustManagerSurvivesApplyMqttTls() {
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") { trustManager = FakeTrustManager }
+        assertSame(FakeTrustManager, builder.trustManager)
+    }
+
+    @Test
+    fun hookInstalledTrustManagerSurvivesForIpLiteralHost() {
+        // SNI is suppressed for IP literals, but the hook must still be applied — the
+        // earlier SNI/trust coupling bug (Meshtastic-Android #5894) was exactly this
+        // class of mistake.
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("192.168.1.50") { trustManager = FakeTrustManager }
+        assertSame(FakeTrustManager, builder.trustManager)
+    }
+
+    @Test
+    fun hookSeesBuilderBeforePlatformTrustRuns() {
+        // The hook reads trustManager before configurePlatformTrust has touched it. On the
+        // JVM that means null; the assertion of record is that the lambda observed the
+        // builder at all and that its own write then took effect.
+        var ranWithBuilder = false
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") {
+            ranWithBuilder = true
+            trustManager = FakeTrustManager
+        }
+        assertNotNull(builder.trustManager)
+        assertSame(FakeTrustManager, builder.trustManager)
+        kotlin.test.assertTrue(ranWithBuilder)
+    }
+
+    @Test
+    fun factoryHookIsHandedToEveryTransportItCreates() {
+        // Guards against the factory dropping the lambda on the floor in create().
+        var invocations = 0
+        val factory = TcpTransportFactory { invocations++ }
+        // create() must not run the hook — that happens during the handshake.
+        factory.create(org.meshtastic.mqtt.MqttEndpoint.Tcp("broker.example.com", 8883, tls = true))
+        kotlin.test.assertEquals(0, invocations)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+./gradlew :transport-tcp:jvmTest --tests "org.meshtastic.mqtt.transport.tcp.TcpTransportTrustManagerTest"
+```
+
+Expected: FAIL. If Tasks 1 and 2 are complete these should actually pass on the first run — that
+is acceptable here, because this task is a regression guard over already-built behaviour rather
+than a driver of new code. What matters is that you run them and see the result. If instead you
+get a compile error about `builder.trustManager` being unresolved, the file has landed in the
+wrong source set — confirm the path is `src/jvmTest`, not `src/commonTest`.
+
+- [ ] **Step 3: Verify the whole module and lint the new source set**
+
+```bash
+./gradlew spotlessApply
+./gradlew :transport-tcp:allTests :transport-tcp:detekt
+```
+
+Expected: all green. `detekt` now covers `jvmTest` too; if it flags the fully-qualified
+`org.meshtastic.mqtt.MqttEndpoint.Tcp` call or the `kotlin.test.` prefixes, hoist those to imports.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt
+git commit -m "test(transport): cover TLS hook trust manager on JVM"
+```
+
+---
+
+### Task 4: Documentation
+
+Document the hook where a consumer hitting the issue #102 problem will actually look.
+
+**Files:**
+- Modify: `transport-tcp/Module.md`
+- Modify: `README.md` (insert before line 335, `## Android / KMP Integration`)
+
+**Interfaces:**
+- Consumes: the public API from Task 2.
+- Produces: nothing.
+
+`AGENTS.md` needs no change — its public-surface list already covers transport modules generically ("Transport modules add `TcpTransport`/`TcpTransportFactory`…").
+
+- [ ] **Step 1: Extend the Dokka module doc**
+
+In `transport-tcp/Module.md`, insert between the existing code fence (ends line 13) and the
+"Available on JVM, Android, …" paragraph (line 15):
+
+```markdown
+### Trusting a private CA
+
+If the broker's certificate is issued by a private or self-signed CA that is not in the platform
+trust store, pass a TLS customisation lambda. It receives ktor's `TLSConfigBuilder`:
+
+```kotlin
+val client = MqttClient("sensor") {
+    transportFactory = TcpTransportFactory { trustManager = myTrustManager }
+}
+```
+
+The lambda is applied after the SNI server name is set and before platform trust configuration, so
+on Android a trust manager installed here is still wrapped in the hostname-aware delegate rather
+than replacing it. The added trust applies only to this MQTT connection — unlike Android's
+app-wide `network_security_config.xml` trust anchors.
+```
+
+- [ ] **Step 2: Add the README section**
+
+In `README.md`, insert immediately before line 335 (`## Android / KMP Integration`), after the
+"Log levels from most to least verbose…" line that closes the Logging section:
+
+```markdown
+### Custom TLS trust
+
+By default the TCP transport validates the broker certificate against the platform CA store. To
+reach a broker behind a private or self-signed CA, pass a TLS customisation lambda to
+`TcpTransportFactory`. It runs against ktor's `TLSConfigBuilder`:
+
+```kotlin
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+
+val client = MqttClient("my-client") {
+    transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager }
+}
+client.connect(MqttEndpoint.parse("mqtts://broker.internal:8883"))
+```
+
+The hook is applied after the SNI server name is resolved and before platform trust is configured.
+On Android that ordering matters: your trust manager is *wrapped* by the hostname-aware trust
+manager rather than replacing it, so certificate hostname verification still happens.
+
+This scopes the extra trust to the MQTT connection alone. It replaces the app-wide workaround of
+adding `<certificates src="user"/>` to `network_security_config.xml`, which would affect every
+HTTPS connection the app makes.
+
+The hook composes with transport selection as usual:
+
+```kotlin
+transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager } +
+    WebSocketTransportFactory()
+```
+
+`TLSConfigBuilder` comes from `io.ktor:ktor-network-tls`, exposed transitively by
+`mqtt-client-transport-tcp` — no extra dependency needed. The WebSocket transport has no equivalent
+hook yet.
+```
+
+- [ ] **Step 3: Verify the docs build**
+
+```bash
+./gradlew :transport-tcp:dokkaGeneratePublicationHtml
+```
+
+Expected: BUILD SUCCESSFUL. Nested code fences inside a Markdown block are the usual failure
+mode here — if Dokka warns about unparsed content in `Module.md`, check the fence nesting.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add transport-tcp/Module.md README.md
+git commit -m "docs(transport): document the TLS trust hook"
+```
+
+---
+
+### Task 5: Full baseline verification
+
+**Files:** none modified (unless a gate fails).
+
+- [ ] **Step 1: Run the complete gate**
+
+```bash
+./gradlew spotlessCheck detekt allTests apiCheck koverVerify
+```
+
+Expected: BUILD SUCCESSFUL. Notes on the two gates most likely to complain:
+
+- `koverVerify` enforces ≥80% coverage. The new code is one small function plus two constructor
+  parameters, all directly covered, so coverage should rise rather than fall. If it fails, read
+  `./gradlew koverHtmlReport` output before adding any test.
+- `apiCheck` must pass against the dumps committed in Task 2. If it fails here but passed then,
+  something after Task 2 changed the ABI — re-run `apiDump` and inspect the diff rather than
+  accepting it blindly.
+
+- [ ] **Step 2: Confirm the default path is genuinely unchanged**
+
+Read the final `TcpTransport.connect` TLS block and confirm that with `configureTls == null` the
+sequence is exactly `serverName = sniServerName(host)` then `configurePlatformTrust(host)` — the
+same two operations, in the same order, as before this change. This is the no-regression claim for
+every existing consumer; verify it by reading, not by assuming.
+
+- [ ] **Step 3: Report**
+
+State the gate output verbatim. If any gate failed, say so with its output rather than describing
+the work as complete.
+
+---
+
+## Notes for the implementer
+
+- **Why the ordering is the crux.** Issue #102 asks for the hook to run *after* `configurePlatformTrust`, while also asking that a caller trust manager compose with Android's hostname checking. Those are mutually exclusive. `PlatformTls.android.kt:44-51` reads `trustManager` off the builder and wraps whatever it finds, so composition requires the caller to have written first. The spec resolves this in favour of composition. Do not "fix" the order to match the issue text.
+- **`TLSConfigBuilder` is instantiable in `commonTest`.** It is an `expect` class with a public no-arg constructor and a common `serverName` property — verified against the ktor 3.5.1 klib. Only `trustManager` is JVM/Android-only.
+- **Do not add a `host` parameter to the lambda**, a second post-platform-trust seam, a WebSocket equivalent, or any `MqttConfig`-level plumbing. All four are explicitly out of scope in the spec.
+- **PR wording:** title `feat(transport): add TLS trust hook to TcpTransportFactory`, body closing with `Fixes #102`, and a note that `ktor-network-tls` is now an `api` dependency of `mqtt-client-transport-tcp` — that is the one thing a consumer might notice on upgrade.

--- a/docs/superpowers/specs/2026-07-25-tls-trust-hook-design.md
+++ b/docs/superpowers/specs/2026-07-25-tls-trust-hook-design.md
@@ -1,0 +1,157 @@
+# TLS trust configuration hook for the TCP transport
+
+Design for [issue #102](https://github.com/meshtastic/MQTTastic-Client-KMP/issues/102).
+
+## Problem
+
+A caller cannot influence TLS trust for the TCP transport. Connecting to a broker whose
+certificate chain is anchored in a private or self-signed CA — the common self-hosted case —
+is therefore impossible without replacing the transport wholesale.
+
+As of 0.5.0 there is no seam:
+
+- `TcpTransportFactory` is `final` with a no-arg constructor; `TcpTransport` is `final` too.
+- `MqttConfig.Builder` exposes no TLS property.
+- `MqttEndpoint.Tcp(host, port, tls: Boolean)` carries only an on/off flag.
+- ktor's `TLSConfigBuilder` is configured in a private lambda inside `TcpTransport.connect`
+  (`transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt:102-108`),
+  so it never reaches the caller.
+
+The only workaround available to an Android consumer is to opt the *entire app* into trusting
+user-installed CAs via `network_security_config.xml`, which applies to every HTTPS connection
+the app makes rather than just the MQTT socket. The alternative — reimplementing
+`MqttTransport` + `MqttTransportFactory` in the application — duplicates packet framing and
+reconnect handling in every consumer that needs custom trust.
+
+## Approach
+
+Add an optional TLS-customisation lambda to `TcpTransportFactory`, threaded through to
+`TcpTransport`. This is option 1 from the issue.
+
+The issue's option 2 (a unified `MqttConfig.Builder.tlsConfig {}`) was rejected: it would pull
+ktor TLS types into `:core`, breaking the transport-free boundary that ADR-0006 establishes and
+that `core/build.gradle.kts`'s `verifyModuleBoundary` check plus the Konsist suite enforce.
+There is also no shared lambda type to unify on — `:transport-ws` configures a ktor `HttpClient`
+and never touches `TLSConfigBuilder`. Option 3 (making `TcpTransport` `open`) was rejected as a
+strictly worse version of option 1.
+
+## Public API
+
+```kotlin
+public class TcpTransportFactory(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransportFactory {
+    override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.Tcp
+
+    override fun create(endpoint: MqttEndpoint): MqttTransport = TcpTransport(configureTls)
+}
+
+public class TcpTransport(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransport
+```
+
+Both parameters are defaulted, so existing call sites are untouched. The hook composes with the
+existing factory `+` operator:
+
+```kotlin
+transportFactory = TcpTransportFactory { trustManager = myTrustManager } + WebSocketTransportFactory()
+```
+
+`TcpTransport`'s constructor parameter is public for symmetry and for callers who construct the
+transport directly, but the factory is the intended entry point.
+
+## The seam
+
+The TLS setup currently inlined in `TcpTransport.connect` moves into a single internal function:
+
+```kotlin
+internal fun TLSConfigBuilder.applyMqttTls(
+    host: String,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+) {
+    serverName = sniServerName(host)
+    configureTls?.invoke(this)      // caller first…
+    configurePlatformTrust(host)    // …so Android wraps their trustManager, not the reverse
+}
+```
+
+`connect` then calls `applyMqttTls(endpoint.host, configureTls)` inside `rawSocket.tls(tlsContext) { … }`.
+
+### Ordering: caller lambda runs *before* `configurePlatformTrust`
+
+This corrects a contradiction in the issue text, which asks for the hook to run *after* the
+platform defaults while also stating that a caller-supplied trust manager would "compose with
+Android's hostname-aware checking rather than bypass it." Only one of those is achievable.
+
+`configurePlatformTrust` on Android
+(`transport-tcp/src/androidMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.android.kt:41-52`)
+reads `trustManager` off the builder, falling back to the platform default, and wraps whatever it
+finds in `HostnameAwareTrustManager`. Composition therefore requires the caller's assignment to
+already be present — i.e. the caller's lambda must run first. Running it last would replace
+`HostnameAwareTrustManager` outright and silently drop Android's 3-arg hostname verification.
+
+Running the caller first delivers the intended behaviour: a private-CA trust manager is still
+subject to the platform's hostname-aware check.
+
+Ordering is enforced structurally rather than by convention — `applyMqttTls` is the only place the
+order can be expressed, so there is no second call site to drift.
+
+`serverName` remains first and is not exposed for override beyond what the lambda can already do;
+a caller may reassign it inside the lambda if they need to.
+
+## Build and compatibility
+
+- `transport-tcp/build.gradle.kts`: `libs.ktor.network.tls` moves from `implementation` to `api`.
+  A public signature now names `TLSConfigBuilder`, so consumers need it on their compile classpath.
+  `libs.ktor.network` stays `implementation`.
+- `./gradlew apiDump` regenerates `transport-tcp/api/transport-tcp.klib.api` and the JVM dump.
+  Both are committed.
+- Binary compatibility holds. Kotlin emits a zero-arg constructor for an all-defaults constructor,
+  so already-compiled callers of `TcpTransportFactory()` keep linking.
+- No change to `:core`, `:transport-ws`, or the BOM.
+
+## Testing
+
+Extends the pure-function style already in
+`transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt`.
+`TLSConfigBuilder` is directly instantiable in common code, so no broker or socket is needed.
+
+`commonTest`:
+
+- `applyMqttTls` sets `serverName` to the host for a DNS name and to `null` for IPv4 and IPv6
+  literals — the existing SNI-suppression guarantee, now asserted through the new entry point.
+- The lambda is invoked exactly once (recorder counter).
+- A `null` lambda is a no-op and leaves `serverName` behaviour unchanged.
+- `TcpTransportFactory { }` still reports `supports()` correctly, `create()` returns a
+  `TcpTransport`, and the instance composes with `WebSocketTransportFactory` via `+`.
+
+`jvmTest`:
+
+- A `trustManager` assigned inside the lambda is still the builder's `trustManager` afterwards.
+  JVM's `configurePlatformTrust` is a no-op, so this proves the hook reaches ktor's real builder
+  state rather than a discarded copy.
+
+Not covered: the Android wrapping order. `X509TrustManagerExtensions` is an Android framework
+class, so asserting that a caller's manager ends up inside `HostnameAwareTrustManager` requires an
+instrumentation test. That is out of scope; the single-call-site structure of `applyMqttTls` is the
+mitigation.
+
+Existing `koverVerify` (≥80%), `detekt`, `spotlessCheck`, and `apiCheck` gates all apply.
+
+## Documentation
+
+- `transport-tcp/Module.md` — a private-CA usage snippet, and a note that the caller's
+  configuration is applied before platform trust so Android hostname verification is preserved.
+- `README.md` TLS section — a pointer to the hook, framed as the replacement for the app-wide
+  `<certificates src="user"/>` workaround.
+- `AGENTS.md` — no change needed; the public-surface list already covers transport modules
+  generically via "Transport modules add `TcpTransport`/`TcpTransportFactory`…".
+
+## Out of scope (YAGNI)
+
+- No `host` parameter on the lambda — a factory can close over whatever it needs.
+- No second, post-platform-trust seam.
+- No WebSocket equivalent. `:transport-ws` would need a differently-typed `HttpClient` hook; it can
+  be added later without disturbing this API.
+- No `MqttConfig`-level plumbing or transport-neutral trust abstraction in `:core`.

--- a/transport-tcp/Module.md
+++ b/transport-tcp/Module.md
@@ -12,5 +12,23 @@ val client = MqttClient("sensor") {
 client.connect(MqttEndpoint.Tcp("broker.example.com", port = 8883, tls = true))
 ```
 
+### Trusting a private CA
+
+If the broker's certificate is issued by a private or self-signed CA that is not in the platform
+trust store, pass a TLS customisation lambda. It receives ktor's `TLSConfigBuilder`:
+
+```kotlin
+val client = MqttClient("sensor") {
+    transportFactory = TcpTransportFactory { trustManager = myTrustManager }
+}
+```
+
+The lambda is applied after the SNI server name is set and before platform trust configuration, so
+on Android a trust manager installed here is still wrapped in the hostname-aware delegate rather
+than replacing it. The added trust applies only to this MQTT connection — unlike Android's
+app-wide `network_security_config.xml` trust anchors. `trustManager` itself is available on the
+JVM and Android actuals of `TLSConfigBuilder`; on Apple, Linux, and Windows the lambda still runs,
+but `TLSConfigBuilder` exposes a different set of properties there.
+
 Available on JVM, Android, iOS, macOS, Linux, and Windows. Not available on the browser (wasmJs) —
 use `mqtt-client-transport-ws` there.

--- a/transport-tcp/Module.md
+++ b/transport-tcp/Module.md
@@ -24,8 +24,14 @@ val client = MqttClient("sensor") {
 ```
 
 The lambda is applied after the SNI server name is set and before platform trust configuration, so
-on Android a trust manager installed here is still wrapped in the hostname-aware delegate rather
-than replacing it. The added trust applies only to this MQTT connection — unlike Android's
+on Android a trust manager installed here is wrapped in the hostname-aware delegate rather than
+replacing it: the trust anchors you add stay subject to the platform's domain-specific
+`network_security_config.xml` rules, certificate pinning, and Certificate Transparency policy. That
+is all the wrapping buys — RFC 6125 subject-name matching comes from ktor and only when the SNI
+server name is set, so it does not happen for IP-literal brokers, and the platform policy checks do
+not happen at all on JVM or native targets. On Android the trust manager must be one the platform
+can wrap (obtained from a `TrustManagerFactory`, not hand-implemented) or the handshake fails.
+The added trust applies only to this MQTT connection — unlike Android's
 app-wide `network_security_config.xml` trust anchors. `trustManager` itself is available on the
 JVM and Android actuals of `TLSConfigBuilder`; on Apple, Linux, and Windows the lambda still runs,
 but `TLSConfigBuilder` exposes a different set of properties there.

--- a/transport-tcp/Module.md
+++ b/transport-tcp/Module.md
@@ -12,7 +12,7 @@ val client = MqttClient("sensor") {
 client.connect(MqttEndpoint.Tcp("broker.example.com", port = 8883, tls = true))
 ```
 
-### Trusting a private CA
+## Trusting a private CA
 
 If the broker's certificate is issued by a private or self-signed CA that is not in the platform
 trust store, pass a TLS customisation lambda. It receives ktor's `TLSConfigBuilder`:
@@ -23,18 +23,29 @@ val client = MqttClient("sensor") {
 }
 ```
 
-The lambda is applied after the SNI server name is set and before platform trust configuration, so
-on Android a trust manager installed here is wrapped in the hostname-aware delegate rather than
-replacing it: the trust anchors you add stay subject to the platform's domain-specific
-`network_security_config.xml` rules, certificate pinning, and Certificate Transparency policy. That
-is all the wrapping buys — RFC 6125 subject-name matching comes from ktor and only when the SNI
-server name is set, so it does not happen for IP-literal brokers, and the platform policy checks do
-not happen at all on JVM or native targets. On Android the trust manager must be one the platform
-can wrap (obtained from a `TrustManagerFactory`, not hand-implemented) or the handshake fails.
-The added trust applies only to this MQTT connection — unlike Android's
-app-wide `network_security_config.xml` trust anchors. `trustManager` itself is available on the
-JVM and Android actuals of `TLSConfigBuilder`; on Apple, Linux, and Windows the lambda still runs,
-but `TLSConfigBuilder` exposes a different set of properties there.
+The lambda is applied after the SNI server name is set and before platform trust configuration. On
+Android that ordering means the trust manager on the builder is reached through the hostname-aware
+`checkServerTrusted(chain, authType, hostname)` overload, which the platform requires whenever
+`network_security_config.xml` holds any domain-specific configuration.
+
+Be precise about what that does *not* buy you. Installing your own trust manager **replaces the
+platform's trust decision**: your anchors are used instead of the platform's, and
+`network_security_config.xml` anchors, certificate pinning, and Certificate Transparency policy are
+then enforced only insofar as your manager enforces them itself. Those platform policies apply as
+before only if you leave `trustManager` unset. Wrapping preserves the hostname-aware *call path*,
+not the platform's *policy*. RFC 6125 subject-name matching is separate again — it comes from ktor
+and only when the SNI server name is set, so it does not happen for IP-literal brokers, and no
+platform wrapping happens at all on JVM or native targets.
+
+On Android the manager must be one `X509TrustManagerExtensions` can wrap: either obtained from a
+`TrustManagerFactory`, or declaring the three-arg `checkServerTrusted(chain, authType, host)` that
+the platform looks up reflectively. Otherwise the handshake fails with an `IllegalArgumentException`
+explaining this.
+
+The added trust applies only to this MQTT connection — unlike Android's app-wide
+`network_security_config.xml` trust anchors. `trustManager` itself is available on the JVM and
+Android actuals of `TLSConfigBuilder`; on Apple, Linux, and Windows the lambda still runs, but
+`TLSConfigBuilder` exposes a different set of properties there.
 
 Available on JVM, Android, iOS, macOS, Linux, and Windows. Not available on the browser (wasmJs) —
 use `mqtt-client-transport-ws` there.

--- a/transport-tcp/api/jvm/transport-tcp.api
+++ b/transport-tcp/api/jvm/transport-tcp.api
@@ -1,6 +1,8 @@
 public final class org/meshtastic/mqtt/transport/tcp/TcpTransport : org/meshtastic/mqtt/MqttTransport {
 	public static final field MAX_PACKET_REMAINING_LENGTH I
 	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun connect (Lorg/meshtastic/mqtt/MqttEndpoint;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun isConnected ()Z
@@ -10,6 +12,8 @@ public final class org/meshtastic/mqtt/transport/tcp/TcpTransport : org/meshtast
 
 public final class org/meshtastic/mqtt/transport/tcp/TcpTransportFactory : org/meshtastic/mqtt/MqttTransportFactory {
 	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Lorg/meshtastic/mqtt/MqttEndpoint;)Lorg/meshtastic/mqtt/MqttTransport;
 	public fun supports (Lorg/meshtastic/mqtt/MqttEndpoint;)Z
 }

--- a/transport-tcp/api/transport-tcp.klib.api
+++ b/transport-tcp/api/transport-tcp.klib.api
@@ -7,7 +7,7 @@
 
 // Library unique name: <MQTTastic-Client-KMP:transport-tcp>
 final class org.meshtastic.mqtt.transport.tcp/TcpTransport : org.meshtastic.mqtt/MqttTransport { // org.meshtastic.mqtt.transport.tcp/TcpTransport|null[0]
-    constructor <init>() // org.meshtastic.mqtt.transport.tcp/TcpTransport.<init>|<init>(){}[0]
+    constructor <init>(kotlin/Function1<io.ktor.network.tls/TLSConfigBuilder, kotlin/Unit>? = ...) // org.meshtastic.mqtt.transport.tcp/TcpTransport.<init>|<init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder,kotlin.Unit>?){}[0]
 
     final val isConnected // org.meshtastic.mqtt.transport.tcp/TcpTransport.isConnected|{}isConnected[0]
         final fun <get-isConnected>(): kotlin/Boolean // org.meshtastic.mqtt.transport.tcp/TcpTransport.isConnected.<get-isConnected>|<get-isConnected>(){}[0]
@@ -19,7 +19,7 @@ final class org.meshtastic.mqtt.transport.tcp/TcpTransport : org.meshtastic.mqtt
 }
 
 final class org.meshtastic.mqtt.transport.tcp/TcpTransportFactory : org.meshtastic.mqtt/MqttTransportFactory { // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory|null[0]
-    constructor <init>() // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.<init>|<init>(){}[0]
+    constructor <init>(kotlin/Function1<io.ktor.network.tls/TLSConfigBuilder, kotlin/Unit>? = ...) // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.<init>|<init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder,kotlin.Unit>?){}[0]
 
     final fun create(org.meshtastic.mqtt/MqttEndpoint): org.meshtastic.mqtt/MqttTransport // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.create|create(org.meshtastic.mqtt.MqttEndpoint){}[0]
     final fun supports(org.meshtastic.mqtt/MqttEndpoint): kotlin/Boolean // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.supports|supports(org.meshtastic.mqtt.MqttEndpoint){}[0]

--- a/transport-tcp/api/transport-tcp.klib.api
+++ b/transport-tcp/api/transport-tcp.klib.api
@@ -7,6 +7,7 @@
 
 // Library unique name: <MQTTastic-Client-KMP:transport-tcp>
 final class org.meshtastic.mqtt.transport.tcp/TcpTransport : org.meshtastic.mqtt/MqttTransport { // org.meshtastic.mqtt.transport.tcp/TcpTransport|null[0]
+    constructor <init>() // org.meshtastic.mqtt.transport.tcp/TcpTransport.<init>|<init>(){}[0]
     constructor <init>(kotlin/Function1<io.ktor.network.tls/TLSConfigBuilder, kotlin/Unit>? = ...) // org.meshtastic.mqtt.transport.tcp/TcpTransport.<init>|<init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder,kotlin.Unit>?){}[0]
 
     final val isConnected // org.meshtastic.mqtt.transport.tcp/TcpTransport.isConnected|{}isConnected[0]
@@ -19,6 +20,7 @@ final class org.meshtastic.mqtt.transport.tcp/TcpTransport : org.meshtastic.mqtt
 }
 
 final class org.meshtastic.mqtt.transport.tcp/TcpTransportFactory : org.meshtastic.mqtt/MqttTransportFactory { // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory|null[0]
+    constructor <init>() // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.<init>|<init>(){}[0]
     constructor <init>(kotlin/Function1<io.ktor.network.tls/TLSConfigBuilder, kotlin/Unit>? = ...) // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.<init>|<init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder,kotlin.Unit>?){}[0]
 
     final fun create(org.meshtastic.mqtt/MqttEndpoint): org.meshtastic.mqtt/MqttTransport // org.meshtastic.mqtt.transport.tcp/TcpTransportFactory.create|create(org.meshtastic.mqtt.MqttEndpoint){}[0]

--- a/transport-tcp/build.gradle.kts
+++ b/transport-tcp/build.gradle.kts
@@ -44,7 +44,9 @@ kotlin {
         commonMain.dependencies {
             api(project(":core"))
             implementation(libs.ktor.network)
-            implementation(libs.ktor.network.tls)
+            // api, not implementation: TLSConfigBuilder appears in TcpTransportFactory's
+            // public constructor signature, so consumers need it on their compile classpath.
+            api(libs.ktor.network.tls)
         }
     }
 }

--- a/transport-tcp/src/androidMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.android.kt
+++ b/transport-tcp/src/androidMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.android.kt
@@ -37,6 +37,19 @@ import javax.net.ssl.X509TrustManager
  * the target host, so an IP-only broker (a common private-broker setup) hits the same
  * failure. The [host] — an IP literal or DNS name — is a valid argument for the 3-arg
  * overload even though an IP must never be sent as the TLS SNI server name.
+ *
+ * **Constraint on caller-supplied trust managers.** Whatever [X509TrustManager] is on the
+ * builder must be one Android can wrap for hostname-aware checking. In practice that means it
+ * must come from a [TrustManagerFactory] (which yields the platform's `TrustManagerImpl`), or
+ * it must itself declare a `checkServerTrusted(X509Certificate[], String, String)` method.
+ * A hand-written `X509TrustManager` that implements only the two-arg overloads cannot be
+ * wrapped, and this function throws [IllegalArgumentException] rather than silently dropping
+ * Android's policy checks. To trust a private CA, load it into a [KeyStore] and initialise a
+ * [TrustManagerFactory] with that store.
+ *
+ * Note that the hostname passed to the 3-arg overload drives network-security-config lookup,
+ * certificate pinning, and Certificate Transparency policy — it does **not** perform RFC 6125
+ * subject-name matching. That comes from ktor and only when the SNI server name is set.
  */
 internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
     if (host.isBlank()) return
@@ -48,7 +61,20 @@ internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
             tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
         }
 
-    trustManager = HostnameAwareTrustManager(baseTm, host)
+    trustManager =
+        try {
+            HostnameAwareTrustManager(baseTm, host)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException(
+                "Android cannot wrap the configured X509TrustManager (${baseTm::class.java.name}) " +
+                    "for hostname-aware certificate checking. The trust manager must either be " +
+                    "obtained from TrustManagerFactory (which yields the platform TrustManagerImpl) " +
+                    "or declare checkServerTrusted(X509Certificate[], String, String). To trust a " +
+                    "private CA, load it into a KeyStore and initialise a TrustManagerFactory with " +
+                    "that KeyStore instead of hand-implementing X509TrustManager.",
+                e,
+            )
+        }
 }
 
 /**

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
@@ -42,25 +42,39 @@ internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)
  *
  * This is the single call site for TLS setup, so the ordering below cannot drift:
  *
- * 1. [serverName] — the SNI value, `null` for IP literals (RFC 6066 §3 forbids them).
+ * 1. `serverName` — the SNI value, `null` for IP literals (RFC 6066 §3 forbids them).
  * 2. [configureTls] — the caller's hook, so it can read or override the SNI value and
  *    install its own trust manager (e.g. a private CA).
  * 3. [configurePlatformTrust] — reads whatever trust manager is now on the builder and,
  *    on Android, wraps it in a hostname-aware delegate.
  *
  * Step 2 must precede step 3. Reversing them would let a caller-supplied trust manager
- * *replace* Android's `HostnameAwareTrustManager`, silently dropping the platform's 3-arg
- * `checkServerTrusted` hostname verification. Running the caller first composes instead:
- * a private-CA trust manager is still subject to the hostname check.
+ * *replace* Android's `HostnameAwareTrustManager`, so the caller's trust anchors would no
+ * longer be evaluated against the platform's domain-specific `network_security_config.xml`
+ * rules, certificate pinning, or Certificate Transparency policy. Running the caller first
+ * composes instead: a private-CA trust manager stays subject to those platform checks.
+ *
+ * Note what this ordering does *not* provide. RFC 6125 subject-name matching (verifying the
+ * certificate actually names the host being contacted) comes from ktor, which performs it only
+ * when `serverName` is non-`null` — so it is absent for IP-literal brokers. Android's 3-arg
+ * `checkServerTrusted(chain, authType, hostname)` uses the hostname for config lookup, pinning,
+ * and CT policy, not for subject-name matching. On JVM and native targets
+ * [configurePlatformTrust] is a no-op, so no platform policy check happens there at all.
+ *
+ * The hook may read or replace `serverName`, but setting it to `null` disables ktor's
+ * subject-name verification entirely — the only name matching this transport has on JVM and
+ * native — so do not do that unless you verify the peer identity yourself.
  *
  * @param host the broker host (DNS name or IP literal), used for both SNI and trust evaluation.
  * @param configureTls optional caller customisation; `null` preserves the default behaviour.
+ * @param platformTrust test seam for [configurePlatformTrust]; production callers use the default.
  */
 internal fun TLSConfigBuilder.applyMqttTls(
     host: String,
     configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+    platformTrust: TLSConfigBuilder.(String) -> Unit = { configurePlatformTrust(it) },
 ) {
     serverName = sniServerName(host)
     configureTls?.invoke(this)
-    configurePlatformTrust(host)
+    platformTrust(host)
 }

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
@@ -36,3 +36,31 @@ import io.ktor.network.tls.TLSConfigBuilder
  *   host for the hostname-aware trust check even though it must not be sent as SNI.
  */
 internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)
+
+/**
+ * Applies the MQTT TLS configuration to this [TLSConfigBuilder] in the one correct order.
+ *
+ * This is the single call site for TLS setup, so the ordering below cannot drift:
+ *
+ * 1. [serverName] — the SNI value, `null` for IP literals (RFC 6066 §3 forbids them).
+ * 2. [configureTls] — the caller's hook, so it can read or override the SNI value and
+ *    install its own trust manager (e.g. a private CA).
+ * 3. [configurePlatformTrust] — reads whatever trust manager is now on the builder and,
+ *    on Android, wraps it in a hostname-aware delegate.
+ *
+ * Step 2 must precede step 3. Reversing them would let a caller-supplied trust manager
+ * *replace* Android's `HostnameAwareTrustManager`, silently dropping the platform's 3-arg
+ * `checkServerTrusted` hostname verification. Running the caller first composes instead:
+ * a private-CA trust manager is still subject to the hostname check.
+ *
+ * @param host the broker host (DNS name or IP literal), used for both SNI and trust evaluation.
+ * @param configureTls optional caller customisation; `null` preserves the default behaviour.
+ */
+internal fun TLSConfigBuilder.applyMqttTls(
+    host: String,
+    configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) {
+    serverName = sniServerName(host)
+    configureTls?.invoke(this)
+    configurePlatformTrust(host)
+}

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
@@ -48,18 +48,26 @@ internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)
  * 3. [configurePlatformTrust] — reads whatever trust manager is now on the builder and,
  *    on Android, wraps it in a hostname-aware delegate.
  *
- * Step 2 must precede step 3. Reversing them would let a caller-supplied trust manager
- * *replace* Android's `HostnameAwareTrustManager`, so the caller's trust anchors would no
- * longer be evaluated against the platform's domain-specific `network_security_config.xml`
- * rules, certificate pinning, or Certificate Transparency policy. Running the caller first
- * composes instead: a private-CA trust manager stays subject to those platform checks.
+ * Step 2 must precede step 3. What step 3 provides is the call path: whatever trust manager is
+ * on the builder is reached through Android's hostname-aware
+ * `checkServerTrusted(chain, authType, hostname)` overload, which `NetworkSecurityTrustManager`
+ * requires whenever `network_security_config.xml` holds any domain-specific configuration.
+ * Reversing the two steps would discard that wrapper, leaving ktor's 2-arg call to hit the bare
+ * manager.
  *
- * Note what this ordering does *not* provide. RFC 6125 subject-name matching (verifying the
- * certificate actually names the host being contacted) comes from ktor, which performs it only
- * when `serverName` is non-`null` — so it is absent for IP-literal brokers. Android's 3-arg
- * `checkServerTrusted(chain, authType, hostname)` uses the hostname for config lookup, pinning,
- * and CT policy, not for subject-name matching. On JVM and native targets
- * [configurePlatformTrust] is a no-op, so no platform policy check happens there at all.
+ * Be precise about what this ordering does *not* provide. Installing a trust manager via
+ * [configureTls] *replaces the platform's trust decision*: that manager's anchors are used
+ * instead of the platform's, and `network_security_config.xml` anchors, certificate pinning,
+ * and Certificate Transparency policy are then enforced only insofar as that manager enforces
+ * them itself. Those platform policies apply as they did before only when the caller leaves
+ * `trustManager` unset. Wrapping preserves the hostname-aware *call path*, not the platform's
+ * *policy*.
+ *
+ * RFC 6125 subject-name matching (verifying the certificate actually names the host being
+ * contacted) is separate again: it comes from ktor, which performs it only when `serverName` is
+ * non-`null` — so it is absent for IP-literal brokers. Android's 3-arg overload uses the
+ * hostname for config lookup, pinning, and CT policy, not for subject-name matching. On JVM and
+ * native targets [configurePlatformTrust] is a no-op, so no platform wrapping happens at all.
  *
  * The hook may read or replace `serverName`, but setting it to `null` disables ktor's
  * subject-name verification entirely — the only name matching this transport has on JVM and

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -58,6 +58,8 @@ import org.meshtastic.mqtt.packet.VariableByteInt
 public class TcpTransport(
     internal val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
 ) : MqttTransport {
+    public constructor() : this(null)
+
     private var socket: Socket? = null
     private var selectorManager: SelectorManager? = null
     private var readChannel: ByteReadChannel? = null
@@ -279,14 +281,18 @@ internal fun isIpLiteral(host: String): Boolean {
  *
  * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport
  *   this factory creates. It runs after the SNI server name is set and before platform trust
- *   is configured, so on Android a trust manager installed here is wrapped in the
- *   hostname-aware delegate rather than replacing it — the caller's trust anchors stay subject
- *   to the platform's network-security-config, pinning, and Certificate Transparency policy.
- *   That wrapping is Android-only and is not subject-name matching; see [applyMqttTls].
+ *   is configured, so on Android a trust manager installed here is reached through the
+ *   hostname-aware `checkServerTrusted` overload rather than bypassing it. Note that installing
+ *   a trust manager replaces the platform's trust decision — network-security-config anchors,
+ *   pinning, and Certificate Transparency policy then hold only insofar as that manager enforces
+ *   them. The wrapping is Android-only and is not subject-name matching; see [applyMqttTls] for
+ *   the full picture before relying on it.
  */
 public class TcpTransportFactory(
     private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
 ) : MqttTransportFactory {
+    public constructor() : this(null)
+
     override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.Tcp
 
     override fun create(endpoint: MqttEndpoint): MqttTransport = TcpTransport(configureTls)

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -84,7 +84,6 @@ public class TcpTransport : MqttTransport {
                 socket =
                     try {
                         if (endpoint.tls) {
-                            val tlsServerName = sniServerName(endpoint.host)
                             // Ktor launches the TLS record-pump (input/output) coroutines on the
                             // context passed here. A bare dispatcher leaves them with no parent Job
                             // and no exception handler, so a write that fails around the handshake —
@@ -99,13 +98,7 @@ public class TcpTransport : MqttTransport {
                                     // benign socket teardown
                                     CoroutineExceptionHandler { _, _ -> }
                             tlsJob = tlsContext[Job]
-                            rawSocket.tls(tlsContext) {
-                                serverName = tlsServerName
-                                // Configure trust with the real host (DNS name or IP literal),
-                                // not the SNI value: tlsServerName is null for IP literals, but
-                                // Android still needs a host for the hostname-aware trust check.
-                                configurePlatformTrust(endpoint.host)
-                            }
+                            rawSocket.tls(tlsContext) { applyMqttTls(endpoint.host) }
                         } else {
                             rawSocket
                         }

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -22,6 +22,7 @@ import io.ktor.network.sockets.aSocket
 import io.ktor.network.sockets.isClosed
 import io.ktor.network.sockets.openReadChannel
 import io.ktor.network.sockets.openWriteChannel
+import io.ktor.network.tls.TLSConfigBuilder
 import io.ktor.network.tls.tls
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
@@ -48,8 +49,15 @@ import org.meshtastic.mqtt.packet.VariableByteInt
  * TCP is stream-oriented, so [receive] must reconstruct MQTT packet boundaries by
  * parsing the fixed header and Variable Byte Integer remaining length from the byte
  * stream, then reading exactly that many payload bytes.
+ *
+ * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] during the TLS
+ *   handshake, after the SNI server name is set and before platform trust is configured.
+ *   Use it to trust a private or self-signed CA for this connection only. Ignored for
+ *   non-TLS endpoints.
  */
-public class TcpTransport : MqttTransport {
+public class TcpTransport(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransport {
     private var socket: Socket? = null
     private var selectorManager: SelectorManager? = null
     private var readChannel: ByteReadChannel? = null
@@ -98,7 +106,7 @@ public class TcpTransport : MqttTransport {
                                     // benign socket teardown
                                     CoroutineExceptionHandler { _, _ -> }
                             tlsJob = tlsContext[Job]
-                            rawSocket.tls(tlsContext) { applyMqttTls(endpoint.host) }
+                            rawSocket.tls(tlsContext) { applyMqttTls(endpoint.host, configureTls) }
                         } else {
                             rawSocket
                         }
@@ -260,9 +268,24 @@ internal fun isIpLiteral(host: String): Boolean {
  *
  * Add `org.meshtastic:mqtt-client-transport-tcp` and pass an instance to
  * [org.meshtastic.mqtt.MqttConfig.Builder.transportFactory].
+ *
+ * To trust a broker whose certificate chain is not in the platform CA store — a private or
+ * self-signed CA — supply [configureTls]. The scope is this MQTT connection only, unlike
+ * Android's app-wide `network_security_config.xml` trust anchors:
+ *
+ * ```kotlin
+ * transportFactory = TcpTransportFactory { trustManager = myTrustManager } + WebSocketTransportFactory()
+ * ```
+ *
+ * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport
+ *   this factory creates. It runs after the SNI server name is set and before platform trust
+ *   is configured, so on Android a trust manager installed here is still wrapped in the
+ *   hostname-aware delegate rather than replacing it.
  */
-public class TcpTransportFactory : MqttTransportFactory {
+public class TcpTransportFactory(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransportFactory {
     override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.Tcp
 
-    override fun create(endpoint: MqttEndpoint): MqttTransport = TcpTransport()
+    override fun create(endpoint: MqttEndpoint): MqttTransport = TcpTransport(configureTls)
 }

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -56,7 +56,7 @@ import org.meshtastic.mqtt.packet.VariableByteInt
  *   non-TLS endpoints.
  */
 public class TcpTransport(
-    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+    internal val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
 ) : MqttTransport {
     private var socket: Socket? = null
     private var selectorManager: SelectorManager? = null
@@ -279,8 +279,10 @@ internal fun isIpLiteral(host: String): Boolean {
  *
  * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport
  *   this factory creates. It runs after the SNI server name is set and before platform trust
- *   is configured, so on Android a trust manager installed here is still wrapped in the
- *   hostname-aware delegate rather than replacing it.
+ *   is configured, so on Android a trust manager installed here is wrapped in the
+ *   hostname-aware delegate rather than replacing it — the caller's trust anchors stay subject
+ *   to the platform's network-security-config, pinning, and Certificate Transparency policy.
+ *   That wrapping is Android-only and is not subject-name matching; see [applyMqttTls].
  */
 public class TcpTransportFactory(
     private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,

--- a/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt
+++ b/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.tcp
+
+import org.meshtastic.mqtt.MqttEndpoint
+import org.meshtastic.mqtt.plus
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Covers the caller-supplied TLS hook on [TcpTransportFactory] (issue #102).
+ *
+ * The hook itself is only exercised during a real TLS handshake, so these tests pin the
+ * surrounding contract: the factory still selects the right endpoints, still produces a
+ * [TcpTransport], and still composes with other factories via `+`.
+ */
+class TcpTransportFactoryTlsTest {
+    @Test
+    fun factoryWithTlsHookStillSupportsOnlyTcpEndpoints() {
+        val factory = TcpTransportFactory { serverName = "override.example.com" }
+        assertTrue(factory.supports(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true)))
+        assertFalse(factory.supports(MqttEndpoint.WebSocket("wss://broker.example.com/mqtt")))
+    }
+
+    @Test
+    fun factoryWithTlsHookCreatesTcpTransport() {
+        val factory = TcpTransportFactory { serverName = "override.example.com" }
+        val transport = factory.create(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true))
+        assertIs<TcpTransport>(transport)
+        assertFalse(transport.isConnected)
+    }
+
+    @Test
+    fun noArgFactoryStillWorks() {
+        val factory = TcpTransportFactory()
+        assertTrue(factory.supports(MqttEndpoint.Tcp("broker.example.com", 1883, tls = false)))
+        assertIs<TcpTransport>(factory.create(MqttEndpoint.Tcp("broker.example.com", 1883, tls = false)))
+    }
+
+    @Test
+    fun factoryWithTlsHookComposesWithPlus() {
+        val combined = TcpTransportFactory { serverName = "override.example.com" } + TcpTransportFactory()
+        assertTrue(combined.supports(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true)))
+        assertIs<TcpTransport>(combined.create(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true)))
+    }
+}

--- a/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt
+++ b/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportFactoryTlsTest.kt
@@ -16,11 +16,14 @@
  */
 package org.meshtastic.mqtt.transport.tcp
 
+import io.ktor.network.tls.TLSConfigBuilder
 import org.meshtastic.mqtt.MqttEndpoint
 import org.meshtastic.mqtt.plus
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -44,6 +47,23 @@ class TcpTransportFactoryTlsTest {
         val transport = factory.create(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true))
         assertIs<TcpTransport>(transport)
         assertFalse(transport.isConnected)
+    }
+
+    @Test
+    fun factoryForwardsTlsHookToCreatedTransport() {
+        // Guards against create() silently dropping configureTls: the transport must hold the
+        // very lambda instance the factory was constructed with.
+        val hook: TLSConfigBuilder.() -> Unit = { serverName = "override.example.com" }
+        val transport = TcpTransportFactory(hook).create(MqttEndpoint.Tcp("broker.example.com", 8883, tls = true))
+        assertIs<TcpTransport>(transport)
+        assertSame(hook, transport.configureTls)
+    }
+
+    @Test
+    fun noArgFactoryLeavesTlsHookNull() {
+        val transport = TcpTransportFactory().create(MqttEndpoint.Tcp("broker.example.com", 1883, tls = false))
+        assertIs<TcpTransport>(transport)
+        assertNull(transport.configureTls)
     }
 
     @Test

--- a/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
+++ b/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.mqtt.transport.tcp
 
+import io.ktor.network.tls.TLSConfigBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -61,5 +62,49 @@ class TcpTransportTlsTest {
         assertFalse(isIpLiteral("example.com"))
         assertFalse(isIpLiteral("a1.example.com"))
         assertFalse(isIpLiteral("mqtt.local"))
+    }
+
+    @Test
+    fun applyMqttTlsSetsSniForDnsHost() {
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com")
+        assertEquals("broker.example.com", builder.serverName)
+    }
+
+    @Test
+    fun applyMqttTlsSuppressesSniForIpLiteral() {
+        val ipv4 = TLSConfigBuilder()
+        ipv4.applyMqttTls("192.168.1.50")
+        assertNull(ipv4.serverName)
+
+        val ipv6 = TLSConfigBuilder()
+        ipv6.applyMqttTls("2001:db8::1")
+        assertNull(ipv6.serverName)
+    }
+
+    @Test
+    fun applyMqttTlsInvokesCallerHookExactlyOnce() {
+        var calls = 0
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") { calls++ }
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun applyMqttTlsRunsCallerHookAfterServerNameIsSet() {
+        // The hook must observe serverName already assigned, so a caller can read or
+        // override it. This also pins the hook ahead of configurePlatformTrust, which
+        // on Android wraps whatever trustManager the hook installed.
+        var observed: String? = "not-yet-run"
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") { observed = serverName }
+        assertEquals("broker.example.com", observed)
+    }
+
+    @Test
+    fun applyMqttTlsWithoutHookStillSetsSni() {
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("mqtt.local", configureTls = null)
+        assertEquals("mqtt.local", builder.serverName)
     }
 }

--- a/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
+++ b/transport-tcp/src/commonTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTlsTest.kt
@@ -102,6 +102,33 @@ class TcpTransportTlsTest {
     }
 
     @Test
+    fun applyMqttTlsRunsCallerHookBeforePlatformTrust() {
+        // Security-relevant ordering: the caller hook must run BEFORE platform trust
+        // configuration. Reversed, a caller-supplied trust manager would replace Android's
+        // hostname-aware wrapper instead of being wrapped by it, dropping the platform's
+        // network-security-config, pinning, and CT policy checks. The platformTrust seam
+        // makes that order observable on every target.
+        val order = mutableListOf<String>()
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls(
+            host = "broker.example.com",
+            configureTls = { order += "callerHook" },
+            platformTrust = { order += "platformTrust" },
+        )
+        assertEquals(listOf("callerHook", "platformTrust"), order)
+    }
+
+    @Test
+    fun applyMqttTlsPassesTrustHostToPlatformTrustEvenWhenSniSuppressed() {
+        // IP literals suppress SNI but must still reach the platform trust hook with the raw host.
+        var trustHost: String? = null
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls(host = "192.168.1.50", platformTrust = { trustHost = it })
+        assertNull(builder.serverName)
+        assertEquals("192.168.1.50", trustHost)
+    }
+
+    @Test
     fun applyMqttTlsWithoutHookStillSetsSni() {
         val builder = TLSConfigBuilder()
         builder.applyMqttTls("mqtt.local", configureTls = null)

--- a/transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt
+++ b/transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.tcp
+
+import io.ktor.network.tls.TLSConfigBuilder
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+/**
+ * JVM-only checks that the caller's TLS hook mutates the same [TLSConfigBuilder] ktor
+ * consumes, using `trustManager` — a property that exists only on the JVM and Android
+ * actuals of [TLSConfigBuilder], and so cannot be asserted from `commonTest`.
+ *
+ * On the JVM, `configurePlatformTrust` is a no-op, so a hook-installed trust manager should
+ * survive `applyMqttTls` untouched. On Android it is deliberately *not* preserved by
+ * identity — it gets wrapped in a hostname-aware delegate. That wrapping needs the
+ * `X509TrustManagerExtensions` framework class and is therefore out of unit-test scope.
+ */
+class TcpTransportTrustManagerTest {
+    private object FakeTrustManager : X509TrustManager {
+        override fun checkClientTrusted(
+            chain: Array<out X509Certificate>,
+            authType: String,
+        ) = Unit
+
+        override fun checkServerTrusted(
+            chain: Array<out X509Certificate>,
+            authType: String,
+        ) = Unit
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    @Test
+    fun hookInstalledTrustManagerSurvivesApplyMqttTls() {
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") { trustManager = FakeTrustManager }
+        assertSame(FakeTrustManager, builder.trustManager)
+    }
+
+    @Test
+    fun hookInstalledTrustManagerSurvivesForIpLiteralHost() {
+        // SNI is suppressed for IP literals, but the hook must still be applied — the
+        // earlier SNI/trust coupling bug (Meshtastic-Android #5894) was exactly this
+        // class of mistake.
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("192.168.1.50") { trustManager = FakeTrustManager }
+        assertSame(FakeTrustManager, builder.trustManager)
+    }
+
+    @Test
+    fun hookWriteToTrustManagerTakesEffect() {
+        // The lambda runs against the live builder and its write survives the rest of
+        // applyMqttTls. This does not assert the hook/platform-trust ordering — on the JVM
+        // configurePlatformTrust is a no-op, so that ordering is not observable here.
+        var ranWithBuilder = false
+        val builder = TLSConfigBuilder()
+        builder.applyMqttTls("broker.example.com") {
+            ranWithBuilder = true
+            trustManager = FakeTrustManager
+        }
+        assertNotNull(builder.trustManager)
+        assertSame(FakeTrustManager, builder.trustManager)
+        kotlin.test.assertTrue(ranWithBuilder)
+    }
+
+    @Test
+    fun factoryDoesNotInvokeHookAtCreateTime() {
+        // The hook belongs to the handshake, not to transport construction.
+        var invocations = 0
+        val factory = TcpTransportFactory { invocations++ }
+        // create() must not run the hook — that happens during the handshake.
+        factory.create(
+            org.meshtastic.mqtt.MqttEndpoint
+                .Tcp("broker.example.com", 8883, tls = true),
+        )
+        kotlin.test.assertEquals(0, invocations)
+    }
+}


### PR DESCRIPTION
## Description

There is currently no way for a caller to influence TLS trust for the TCP transport, so connecting to a broker whose certificate chain is anchored in a private or self-signed CA is impossible without replacing the transport wholesale. On Android the only workaround is opting the *entire app* into user-installed CAs via `network_security_config.xml`, which affects every HTTPS connection the app makes.

This adds an optional TLS-customisation lambda to `TcpTransportFactory` — issue option 1. Options 2 (`MqttConfig.Builder.tlsConfig {}`) and 3 (`open` class) were rejected: option 2 would pull ktor TLS types into `:core`, breaking the transport-free boundary from ADR-0006 that `verifyModuleBoundary` and the Konsist suite enforce, and there is no shared lambda type to unify on since `:transport-ws` configures an `HttpClient` and never touches `TLSConfigBuilder`.

```kotlin
transportFactory = TcpTransportFactory { trustManager = myTrustManager } + WebSocketTransportFactory()
```

### Ordering: the caller's hook runs *before* platform trust

This intentionally differs from the ordering suggested in #102, which is self-contradictory — it asks for the hook to run *after* `configurePlatformTrust` while also expecting a caller-supplied manager to compose with Android's hostname-aware checking. Only one is achievable. `configurePlatformTrust` reads `trustManager` off the builder and wraps whatever it finds, so composition requires the caller to have written first. Running it last would replace `HostnameAwareTrustManager` outright.

Ordering is enforced structurally: `applyMqttTls` is the single place it can be expressed.

## Changes

- `TcpTransportFactory(configureTls: (TLSConfigBuilder.() -> Unit)? = null)` and the same parameter on `TcpTransport`. Both defaulted, so existing source and already-compiled callers are unaffected.
- New internal `TLSConfigBuilder.applyMqttTls(host, configureTls, platformTrust)` — the single TLS call site: SNI, then the caller's hook, then platform trust. `platformTrust` is a defaulted test seam that makes the ordering assertable from `commonTest`.
- **`ktor-network-tls` promoted from `implementation` to `api`** in `:transport-tcp`, since `TLSConfigBuilder` now appears in a public constructor signature. Consumers get it transitively — no new dependency line needed. This is the one thing to notice on upgrade.
- ABI dumps regenerated, and the change is additive on **both** JVM and Native. `TcpTransport` and `TcpTransportFactory` each carry an explicit `constructor() : this(null)` so the klib dump keeps `constructor <init>()` alongside the new `Function1` overload; the JVM dump keeps its pre-existing `<init> ()V`.

  <sub>An earlier revision of this PR asserted that the klib dump necessarily *replaces* the no-arg signature, as something inherent to how Kotlin/Native resolves default arguments. That was wrong — see [this thread](https://github.com/meshtastic/MQTTastic-Client-KMP/pull/103#discussion_r3652991380). Adding the explicit constructor fixes it, and does not collide with the constructor Kotlin synthesises for an all-defaults primary constructor.</sub>
- On Android, a trust manager that `X509TrustManagerExtensions` cannot wrap now fails with an actionable message naming the `TrustManagerFactory` requirement, instead of an opaque `IllegalArgumentException` from inside every handshake. It fails closed — no silent fallback to an unwrapped manager.
- Docs in `README.md` and `transport-tcp/Module.md` state precisely what the ordering does and does not buy (see below).

### Documentation correction worth reviewing closely

The security claim in these docs was wrong twice, and both corrections are in the branch. Reviewers should read the shipped wording rather than trusting this summary.

**First**, an early draft claimed that because the caller's manager is wrapped rather than replaced, "certificate hostname verification still happens." Android's 3-arg `checkServerTrusted` uses the hostname for network-security-config lookup, pinning, and CT policy — not RFC 6125 subject-name matching. That matching is ktor's `verifyHostnameInCertificate`, gated on `serverName != null`, so it is absent for IP-literal brokers (where SNI is suppressed per RFC 6066 §3), and platform policy checks are absent entirely on JVM and native where `configurePlatformTrust` is a no-op.

**Second**, the replacement wording still overclaimed, and review caught it: it said a caller's trust anchors "stay subject to" NSC, pinning, and CT policy. They do not. Installing a trust manager **replaces the platform's trust decision** — that manager's anchors are used instead of the platform's, and those policies hold only insofar as it enforces them itself. They apply as before only when `trustManager` is left unset. What the ordering preserves is the hostname-aware *call path*, not the platform's *policy*.

Relatedly, "the manager must come from `TrustManagerFactory`, not hand-implemented" was too strong: `X509TrustManagerExtensions` reflectively accepts any manager declaring the three-arg `checkServerTrusted(chain, authType, host)`.

## Testing

- [x] `./gradlew spotlessCheck detekt allTests apiCheck koverVerify` passes
- [x] New/updated tests cover the changes

`commonTest`: `applyMqttTls` sets SNI for DNS hosts and `null` for IPv4/IPv6 literals; invokes the hook exactly once; is a no-op when `null`; **runs the hook before platform trust** (verified by swapping the two statements and confirming the test fails); `TcpTransportFactory.create()` forwards the same lambda instance (`assertSame`) and leaves it `null` for the no-arg factory; the factory composes via `+`.

`jvmTest` (new source set): a lambda-assigned `trustManager` survives `applyMqttTls` for both DNS and IP-literal hosts, proving the hook reaches ktor's real builder rather than a discarded copy. This lives in `jvmTest` because `trustManager` exists only on the JVM/Android actuals of `TLSConfigBuilder`.

Not covered: Android's actual wrapping order. `X509TrustManagerExtensions` is a framework class, so asserting it needs an instrumentation test.

### Note for maintainers, unrelated to this PR

`./gradlew detekt` — the gate documented in `AGENTS.md` — reports `NO-SOURCE` for every KMP module; the real analysis lives in per-source-set tasks. Running `:transport-tcp:detektMetadataCommonMain` directly fails with 11 weighted issues, all in pre-existing code (`TcpTransport.kt:113,128` `TooGenericExceptionCaught`; `:174-181` `MagicNumber`; `:182,192` `UseRequire`; `:258` `ReturnCount`). None come from this branch, but the documented gate has been giving false assurance. Happy to file a separate issue.

## Related Issues

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS trust for MQTT TCP connections, including support for private or self-signed certificate authorities.
  * Added guidance for configuring custom trust managers and platform-specific behavior.
  * Preserved correct SNI and hostname verification handling for DNS names and IP addresses.

* **Documentation**
  * Added setup examples, configuration details, limitations, and transport-composition guidance.

* **Bug Fixes**
  * Added clearer errors when supplied Android trust managers cannot support hostname-aware validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
