### PR TITLE
fix(sample): restore missing wasmJs browser target

### DIFF
--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@js-joda/core@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
+  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+
 ws@8.20.1, ws@8.21.0:
   version "8.21.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"

--- a/sample/README.md
+++ b/sample/README.md
@@ -81,7 +81,8 @@ sample/
 └── src/
     ├── commonMain/kotlin/.../sample/
     │   ├── App.kt                    # Shared Compose UI
-    │   └── MqttSampleViewModel.kt    # State management
+    │   ├── MqttSampleViewModel.kt    # State management
+    │   └── PlatformTransport.kt      # expect: which transports this platform has
     ├── androidMain/
     │   ├── kotlin/.../MainActivity.kt
     │   ├── AndroidManifest.xml

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -28,6 +28,14 @@ kotlin {
         }
     }
 
+    // Browser demo. `binaries.executable()` is what creates the
+    // `wasmJsBrowserDistribution` task the release workflow zips up.
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        binaries.executable()
+    }
+
     sourceSets {
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -44,21 +52,30 @@ kotlin {
             implementation(libs.lifecycle.viewmodel.compose)
             implementation(libs.lifecycle.runtime.compose)
             implementation(project(":core"))
-            // The sample parses arbitrary broker URIs (tcp:// or ws://), so it pulls in both
-            // transports and combines their factories. A real consumer would depend on only the
-            // transport(s) it actually uses.
-            implementation(project(":transport-tcp"))
+            // `:transport-ws` is the only transport that builds for the browser, so it is the
+            // one every target shares. `:transport-tcp` has no wasmJs variant (raw TCP sockets
+            // are unavailable in a browser) and is therefore added per non-web target below.
+            // `platformTransportFactory()` combines whatever is available on each platform.
             implementation(project(":transport-ws"))
             implementation(libs.meshtastic.protobufs)
             implementation(libs.kotlinx.io.bytestring)
         }
 
+        androidMain.dependencies {
+            implementation(project(":transport-tcp"))
+        }
+
         val desktopMain by getting
         desktopMain.dependencies {
+            implementation(project(":transport-tcp"))
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.core)
             // Provides Dispatchers.Main on JVM desktop (Swing/AWT EDT).
             implementation(libs.kotlinx.coroutines.swing)
+        }
+
+        iosMain.dependencies {
+            implementation(project(":transport-tcp"))
         }
 
         commonTest.dependencies {

--- a/sample/src/androidMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.android.kt
+++ b/sample/src/androidMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.android.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.sample
+
+import org.meshtastic.mqtt.MqttTransportFactory
+import org.meshtastic.mqtt.plus
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
+
+internal actual fun platformTransportFactory(): MqttTransportFactory =
+    TcpTransportFactory() + WebSocketTransportFactory()

--- a/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/MqttSampleViewModel.kt
+++ b/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/MqttSampleViewModel.kt
@@ -34,9 +34,6 @@ import org.meshtastic.mqtt.MqttLogLevel
 import org.meshtastic.mqtt.MqttLogger
 import org.meshtastic.mqtt.MqttMessage
 import org.meshtastic.mqtt.QoS
-import org.meshtastic.mqtt.plus
-import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
-import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
 import org.meshtastic.proto.PortNum
 import org.meshtastic.proto.ServiceEnvelope
 
@@ -183,7 +180,7 @@ class MqttSampleViewModel : ViewModel() {
             try {
                 val endpoint = MqttEndpoint.parse(s.brokerUri)
                 val newClient = MqttClient(s.clientId) {
-                    transportFactory = TcpTransportFactory() + WebSocketTransportFactory()
+                    transportFactory = platformTransportFactory()
                     username = s.username.ifBlank { null }
                     s.password.ifBlank { null }?.let { password(it) }
                     logger = MqttLogger.println()

--- a/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.kt
+++ b/sample/src/commonMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.sample
+
+import org.meshtastic.mqtt.MqttTransportFactory
+
+/**
+ * The set of transports usable on the current platform, combined into one factory.
+ *
+ * Android, desktop (JVM) and iOS get `TcpTransportFactory() + WebSocketTransportFactory()`,
+ * so the sample accepts `tcp://`, `tls://`, `ws://` and `wss://` broker URIs. The browser
+ * (wasmJs) target gets WebSockets only — `:transport-tcp` has no wasmJs variant because raw
+ * TCP sockets are not reachable from a browser sandbox.
+ */
+internal expect fun platformTransportFactory(): MqttTransportFactory

--- a/sample/src/desktopMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.desktop.kt
+++ b/sample/src/desktopMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.desktop.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.sample
+
+import org.meshtastic.mqtt.MqttTransportFactory
+import org.meshtastic.mqtt.plus
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
+
+internal actual fun platformTransportFactory(): MqttTransportFactory =
+    TcpTransportFactory() + WebSocketTransportFactory()

--- a/sample/src/iosMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.ios.kt
+++ b/sample/src/iosMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.ios.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.sample
+
+import org.meshtastic.mqtt.MqttTransportFactory
+import org.meshtastic.mqtt.plus
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
+
+internal actual fun platformTransportFactory(): MqttTransportFactory =
+    TcpTransportFactory() + WebSocketTransportFactory()

--- a/sample/src/wasmJsMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.wasmJs.kt
+++ b/sample/src/wasmJsMain/kotlin/org/meshtastic/mqtt/sample/PlatformTransport.wasmJs.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.sample
+
+import org.meshtastic.mqtt.MqttTransportFactory
+import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
+
+/**
+ * WebSockets only. A browser cannot open a raw TCP socket, so `:transport-tcp` publishes no
+ * wasmJs variant — the sample needs a `ws://` or `wss://` broker URI when run in the browser.
+ */
+internal actual fun platformTransportFactory(): MqttTransportFactory = WebSocketTransportFactory()


### PR DESCRIPTION
## What broke

`release.yml`'s `sample-artifacts` job builds the linux-x64 leg with **one** Gradle invocation:

```
:sample:androidApp:assembleRelease
:sample:packageReleaseDistributionForCurrentOS
:sample:wasmJsBrowserDistribution
```

`:sample:wasmJsBrowserDistribution` did not exist, because `sample/build.gradle.kts` declared no `wasmJs` target. Gradle fails at **task-selection** time, before running anything — so the whole job died and the release lost the `.apk` **and** the `.deb`, not just the wasm zip. v0.6.0's GitHub Release shows the damage: only `.dmg`, `.msi` and SBOMs.

`sample/src/wasmJsMain/` was fully populated the whole time (`Main.kt` with `ComposeViewport`, `index.html`, favicons) — an orphaned source set with no compilation. The target was almost certainly dropped when the library split into per-transport modules: `MqttSampleViewModel` referenced `TcpTransportFactory` from `commonMain`, and `:transport-tcp` deliberately omits wasmJs (a browser cannot open a raw TCP socket), so a wasmJs target could not have compiled as the code stood.

## What changed

Took the "properly restore it" path rather than deleting the task from the workflow.

- **`sample/build.gradle.kts`** — add `wasmJs { browser(); binaries.executable() }`, matching the idiom in `transport-ws/build.gradle.kts`. `binaries.executable()` is the part that registers `wasmJsBrowserDistribution`.
- **`sample/build.gradle.kts`** — move `implementation(project(":transport-tcp"))` off `commonMain` and onto `androidMain`, `desktopMain` and `iosMain`. `:core` and `:transport-ws` stay in `commonMain` — both support wasmJs.
- **`PlatformTransport.kt` (new, commonMain + 4 actuals)** — `internal expect fun platformTransportFactory(): MqttTransportFactory`. Android/desktop/iOS return `TcpTransportFactory() + WebSocketTransportFactory()`; wasmJs returns `WebSocketTransportFactory()` alone. Four small explicit `actual` files, no hand-wired `dependsOn` intermediate source set.
- **`MqttSampleViewModel.kt`** — calls `platformTransportFactory()`; the three transport imports are gone from common code. No behaviour change on any existing platform.
- **`kotlin-js-store/wasm/yarn.lock`** — regenerated via `kotlinWasmUpgradeYarnLock`. Compose's wasm target pulls in `@js-joda/core`; purely additive, and the existing `ws@8.21.0` security pin is untouched.
- **`sample/README.md`** — one line for the new file. The README already documented wasmJs as a supported target and already told browser users to switch to a `ws://` URI, so no other doc change was needed.

`kotlinx-browser` was **not** needed — `kotlinx.browser.document` resolves transitively through Compose on Kotlin 2.4.10 / CMP 1.11.1.

The UI is untouched. The default broker URI stays `tls://mqtt.meshtastic.org:8883` (asserted by a `commonTest` test); in the browser you switch it to `ws://`/`wss://`, exactly as the README already says.

## Verification (local, macOS, JDK 21)

| Command | Result |
| --- | --- |
| `:sample:wasmJsBrowserDistribution` | **BUILD SUCCESSFUL** — output at `sample/build/dist/wasmJs/productionExecutable`, the exact path the workflow's zip step `cd`s into, containing `index.html`, `sample.js` (the filename `index.html` references), both `.wasm` blobs and the favicons |
| `:sample:androidApp:assembleRelease` | **BUILD SUCCESSFUL** — `androidApp-release-unsigned.apk` (10.8 MB) at the workflow's `artifact_glob` path |
| `:sample:packageReleaseDistributionForCurrentOS` | **BUILD SUCCESSFUL** — `mqtt-sample-1.6.0.dmg` on this macOS host, proving the task graph the linux `.deb` leg uses |
| `:sample:compileKotlinDesktop :sample:compileKotlinWasmJs` | **BUILD SUCCESSFUL** |
| `:sample:compileKotlinIosArm64 :sample:compileKotlinIosSimulatorArm64` | **BUILD SUCCESSFUL** |
| `spotlessCheck detekt` | **BUILD SUCCESSFUL** |
| `:sample:desktopTest` | **BUILD SUCCESSFUL** |
| `:sample:wasmJsBrowserTest` | **BUILD SUCCESSFUL** — `tests="7" failures="0" errors="0"` |

That last one is new surface worth flagging: `ci.yml`'s `test-wasm` job runs `./gradlew wasmJsBrowserTest` unscoped, so the sample's `commonTest` now also executes in headless Chrome. All 7 existing tests pass there.

One thing I could **not** verify locally: `:sample:linkReleaseFrameworkIosArm64` OOMs (`Java heap space`) on this machine. I confirmed it fails identically on unmodified `origin/main`, so it is pre-existing and environmental — this box pins `org.gradle.jvmargs=-Xmx2048M` and Compose's iOS release framework link needs more. Neither `ci.yml` nor `release.yml` builds iOS release frameworks; `ci.yml` links only the debug test binary, which passes here with a larger heap.