### PR TITLE
feat(transport): add TLS trust hook to WebSocketTransportFactory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ check; see `core/build.gradle.kts` `verifyModuleBoundary`). Everything in `:core
                                         integration tests (testImplementation project(":transport-tcp"))
 :transport-tcp             commonMain (TcpTransport) + jvm/android/native PlatformTls expect/actual.
                            Targets: jvm, android, apple (ios/macos), linux, mingw — NO wasmJs.
-:transport-ws              commonMain (WebSocketTransport) + per-platform Ktor engine deps.
-                           Targets: all, incl. wasmJs.
+:transport-ws              commonMain (WebSocketTransport) + cioMain (CIO engine + TLS trust hook)
+                           + per-platform Ktor engine deps. Targets: all, incl. wasmJs.
 :bom (mqtt-client-bom)     java-platform BOM pinning every artifact to one version.
 build-logic/convention     mqtt.kmp.library + mqtt.publishing convention plugins (shared KMP target
                            set + per-module publishing coordinates derived from the module name).
@@ -52,8 +52,11 @@ build-logic/convention     mqtt.kmp.library + mqtt.publishing convention plugins
 
 Each library module applies `applyDefaultHierarchyTemplate()` (via `mqtt.kmp.library`), so
 `nativeMain`/`appleMain`/`linuxMain`/`mingwMain` are auto-created. macosArm64 only (macosX64
-deprecated in Kotlin 2.3.20). There is **no** custom `nonWebMain` source set any more: `:transport-tcp`
-simply omits the wasmJs target, so its `commonMain` is effectively the old "non-web" set.
+deprecated in Kotlin 2.3.20). The one custom intermediate source set is `:transport-ws`'s `cioMain`
+(jvm + android + apple + linux), which holds the single CIO `HttpClient` builder and the TLS trust
+plumbing (`applyWsTls` and the `configurePlatformTrust` expect/actuals). The old `nonWebMain` set is
+gone: `:transport-tcp` simply omits the wasmJs target, so its `commonMain` is effectively the old
+"non-web" set.
 
 ### Packet codec pipeline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `:transport-ws` now selects its Ktor engine explicitly per platform (CIO on JVM/Android/Apple/
-  Linux, WinHttp on Windows, Js on wasmJs) instead of relying on auto-detection. The engines are
-  the same ones auto-detection resolved, so behaviour is unchanged.
+  Linux, WinHttp on Windows, Js on wasmJs) instead of relying on auto-detection. These are the
+  engines the library itself ships for each target; auto-detection resolves via `ServiceLoader`
+  over the *consuming app's* classpath, not the library's, so an app that also pulls in another
+  Ktor engine (e.g. `ktor-client-okhttp`, common on Android) may previously have had its WebSocket
+  MQTT connection served by that engine instead of CIO, with different proxy, DNS, and socket
+  defaults. Such an app will now always get CIO for this transport.
 
 ## [0.6.1] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `WebSocketTransportFactory` now accepts an optional TLS customisation lambda, the WebSocket
+  counterpart to the `TcpTransportFactory` hook added in 0.6.0. Both take the same
+  `TLSConfigBuilder` receiver, so a single trust manager can serve `ssl://` and `wss://` brokers
+  behind a private or self-signed CA — scoped to the MQTT connection, with no app-wide
+  `network_security_config.xml` anchor. Honoured on JVM, Android, Apple, and Linux; ignored on
+  Windows (WinHttp exposes no TLS-configuration surface) and in the browser. The existing no-arg
+  constructor is unchanged (#107).
+
+### Changed
+
+- `:transport-ws` now selects its Ktor engine explicitly per platform (CIO on JVM/Android/Apple/
+  Linux, WinHttp on Windows, Js on wasmJs) instead of relying on auto-detection. The engines are
+  the same ones auto-detection resolved, so behaviour is unchanged.
+
 ## [0.6.1] - 2026-07-26
 
 **The published library artifacts are unchanged from 0.6.0.** `mqtt-client-core`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   counterpart to the `TcpTransportFactory` hook added in 0.6.0. Both take the same
   `TLSConfigBuilder` receiver, so a single trust manager can serve `ssl://` and `wss://` brokers
   behind a private or self-signed CA — scoped to the MQTT connection, with no app-wide
-  `network_security_config.xml` anchor. Honoured on JVM, Android, Apple, and Linux; ignored on
-  Windows (WinHttp exposes no TLS-configuration surface) and in the browser. The existing no-arg
-  constructor is unchanged (#107).
+  `network_security_config.xml` anchor. The lambda runs on JVM, Android, Apple, and Linux; ignored
+  on Windows (WinHttp exposes no TLS-configuration surface) and in the browser. The private-CA
+  trust manager itself is available only on JVM and Android, where `TLSConfigBuilder` exposes
+  `trustManager` — on Apple and Linux the lambda still runs but has no equivalent property to set.
+  The existing no-arg constructor is unchanged (#107).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -335,8 +335,10 @@ Log levels from most to least verbose: `TRACE` → `DEBUG` → `INFO` → `WARN`
 ### Custom TLS trust
 
 By default both transports validate the broker certificate against the platform CA store. To
-reach a broker behind a private or self-signed CA, pass a TLS customisation lambda to
-`TcpTransportFactory`. It runs against ktor's `TLSConfigBuilder`:
+reach a broker behind a private or self-signed CA, pass a TLS customisation lambda to the
+transport factory you use — `TcpTransportFactory`, `WebSocketTransportFactory`, or both, since a
+factory without the lambda keeps validating against the platform store alone. It runs against
+ktor's `TLSConfigBuilder`:
 
 ```kotlin
 import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Log levels from most to least verbose: `TRACE` → `DEBUG` → `INFO` → `WARN`
 
 ### Custom TLS trust
 
-By default the TCP transport validates the broker certificate against the platform CA store. To
+By default both transports validate the broker certificate against the platform CA store. To
 reach a broker behind a private or self-signed CA, pass a TLS customisation lambda to
 `TcpTransportFactory`. It runs against ktor's `TLSConfigBuilder`:
 
@@ -377,18 +377,21 @@ This scopes the extra trust to the MQTT connection alone. It replaces the app-wi
 adding `<certificates src="user"/>` to `network_security_config.xml`, which would affect every
 HTTPS connection the app makes.
 
-The hook composes with transport selection as usual:
+The hook composes with transport selection as usual, and both transports take the same lambda type,
+so one trust manager can serve both:
 
 ```kotlin
 transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager } +
-    WebSocketTransportFactory()
+    WebSocketTransportFactory { trustManager = myPrivateCaTrustManager }
 ```
 
-`TLSConfigBuilder` comes from `io.ktor:ktor-network-tls`, exposed transitively by
-`mqtt-client-transport-tcp` — no extra dependency needed. The WebSocket transport has no equivalent
-hook yet. `trustManager` specifically is available on the JVM and Android actuals of
-`TLSConfigBuilder`; on Apple, Linux, and Windows targets the hook still runs, but `TLSConfigBuilder`
-exposes a different set of properties there.
+`TLSConfigBuilder` comes from `io.ktor:ktor-network-tls`, exposed transitively by both
+`mqtt-client-transport-tcp` and `mqtt-client-transport-ws` — no extra dependency needed.
+`trustManager` specifically is available on the JVM and Android actuals of `TLSConfigBuilder`; on
+Apple and Linux the hook still runs, but `TLSConfigBuilder` exposes a different set of properties
+there. The WebSocket hook is additionally ignored on Windows (the WinHttp engine has no
+TLS-configuration surface) and in the browser (which cannot influence trust) — see
+`transport-ws/Module.md` for the per-target table.
 
 ## Android / KMP Integration
 

--- a/docs/superpowers/plans/2026-07-26-ws-tls-trust-hook.md
+++ b/docs/superpowers/plans/2026-07-26-ws-tls-trust-hook.md
@@ -1,0 +1,1185 @@
+# WebSocket TLS Trust Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `WebSocketTransportFactory` an optional `configureTls: (TLSConfigBuilder.() -> Unit)?` hook so a `wss://` broker behind a private or self-signed CA is reachable without app-wide trust changes.
+
+**Architecture:** `:transport-ws` stops relying on ktor engine auto-detection. Client construction moves behind an internal `expect fun buildWsHttpClient`, actualised three ways: a new intermediate `cioMain` source set (jvm + android + apple + linux) that applies the caller's hook to `CIO`'s `engine { https { … } }` and then wraps trust for Android, plus `mingwMain` (WinHttp) and `wasmJsMain` (Js) actuals that ignore the hook. The public signature uses ktor's `TLSConfigBuilder` — the same type `:transport-tcp` uses — so there is no `expect`/`actual` on the public API.
+
+**Tech Stack:** Kotlin 2.4.10, Gradle 9.6.1, ktor 3.5.1 (`ktor-client-cio`, `ktor-client-winhttp`, `ktor-client-js`, `ktor-network-tls`), kotlinx-coroutines 1.11.0, kotlin.test.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md`. **Issue:** #107.
+
+## Global Constraints
+
+- Every change is additive and binary-compatible. `WebSocketTransportFactory()` and `WebSocketTransport()` must keep linking for already-compiled callers — declare the zero-arg secondary constructors explicitly, because klib ABI dumps list constructors individually.
+- No new runtime dependencies outside the ktor / kotlinx-coroutines / kotlinx-io umbrella. `ktor-server-cio`, `ktor-server-websockets`, and `ktor-network-tls-certificates` are added in Task 5 as `testImplementation` only.
+- `:core` gains nothing. No ktor TLS types may reach it (ADR-0006, enforced by `core/build.gradle.kts`'s `verifyModuleBoundary`).
+- `:transport-ws` must not depend on `:transport-tcp`. `configurePlatformTrust` is deliberately duplicated; each copy's KDoc names its sibling.
+- Ordering rule, non-negotiable: the caller's hook runs **before** `configurePlatformTrust`, so Android wraps the caller's trust manager rather than replacing it.
+- Existing test-naming styles differ by file — `WebSocketTransportFactoryTest` uses backtick names, `:transport-tcp`'s tests use camelCase. Match the file you are editing; use camelCase in new files.
+- Gates that must pass before any task is called done: `./gradlew spotlessApply` then `./gradlew spotlessCheck detekt jvmTest wasmJsTest apiCheck`. Full `allTests` and `koverVerify` run in Task 6.
+- Zero lint tolerance: a task with a `detekt` or `spotlessCheck` failure is not finished.
+
+---
+
+### Task 1: Explicit per-engine client construction (no behaviour change)
+
+Replaces auto-detection with a named engine per platform, behind an internal seam. No public API change, no TLS yet — this task exists so the source-set restructuring is reviewable on its own.
+
+**Files:**
+- Modify: `transport-ws/build.gradle.kts:48-74` (source sets)
+- Create: `transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt`
+- Create: `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt`
+- Create: `transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt`
+- Create: `transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt`
+- Modify: `transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt:56-62`
+- Test: `transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTest.kt` (existing — must keep passing)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `internal expect fun buildWsHttpClient(maxFrameSize: Long): HttpClient` in package `org.meshtastic.mqtt.transport.ws`. Task 2 extends this signature; Task 3 adds a call inside the CIO actual.
+
+- [ ] **Step 1: Restructure the source sets**
+
+Replace the whole `sourceSets { … }` block in `transport-ws/build.gradle.kts` (currently lines 48-74) with this. The four separate CIO dependency blocks collapse into one `cioMain` declaration:
+
+```kotlin
+    sourceSets {
+        val commonMain by getting
+        // Intermediate source set for the four targets that use the CIO engine. It holds the
+        // single CIO client builder and, from Task 3, the TLS trust plumbing — written once
+        // instead of four times. Deliberately spans JVM-family and native targets, so it may
+        // only use API present in both (CIO and TLSConfigBuilder both are; TLSConfigBuilder's
+        // JVM-only `trustManager` is touched solely from the androidMain actual).
+        val cioMain by creating { dependsOn(commonMain) }
+
+        commonMain.dependencies {
+            api(project(":core"))
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.websockets)
+        }
+
+        cioMain.dependencies {
+            implementation(libs.ktor.client.cio)
+        }
+
+        // Ktor HttpClient engines — CIO where available, platform engines elsewhere.
+        jvmMain.get().dependsOn(cioMain)
+        findByName("androidMain")?.dependsOn(cioMain)
+        findByName("appleMain")?.dependsOn(cioMain)
+        findByName("linuxMain")?.dependsOn(cioMain)
+
+        findByName("mingwMain")?.dependencies {
+            implementation(libs.ktor.client.winhttp)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.js)
+        }
+    }
+```
+
+- [ ] **Step 2: Write the failing common seam**
+
+Create `transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt`. Copy the 16-line GPL header from `WebSocketTransport.kt` verbatim as the file's first lines (spotless enforces it), then:
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+
+/**
+ * Builds the [HttpClient] used for the WebSocket connection, with the WebSockets plugin
+ * installed and a platform-appropriate engine selected.
+ *
+ * Engine auto-detection cannot be used here: configuring engine-level TLS requires naming
+ * the engine, and a star-projected `HttpClientConfig<*>` cannot reach `engine { }` at all.
+ *
+ * @param maxFrameSize the WebSocket frame safety cap, in bytes.
+ */
+internal expect fun buildWsHttpClient(maxFrameSize: Long): HttpClient
+```
+
+- [ ] **Step 3: Run the build to verify it fails**
+
+Run: `./gradlew :transport-ws:compileKotlinJvm`
+Expected: FAIL — `Expected function 'buildWsHttpClient' has no actual declaration in module …`.
+
+- [ ] **Step 4: Write the three actuals**
+
+`transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt` (GPL header first, as in every file below):
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+
+/** CIO engine — JVM, Android, Apple, and Linux. */
+internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+    HttpClient(CIO) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }
+```
+
+`transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt`:
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.winhttp.WinHttp
+import io.ktor.client.plugins.websocket.WebSockets
+
+/** WinHttp engine — Windows. Trust is handled by the platform certificate store. */
+internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+    HttpClient(WinHttp) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }
+```
+
+`transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt`:
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.js.Js
+import io.ktor.client.plugins.websocket.WebSockets
+
+/** Js engine — browser (wasmJs). Trust is entirely the browser's; nothing is configurable. */
+internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+    HttpClient(Js) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }
+```
+
+- [ ] **Step 5: Call the seam from the transport**
+
+In `WebSocketTransport.connect`, replace this (lines 56-62):
+
+```kotlin
+        val httpClient =
+            HttpClient {
+                install(WebSockets) {
+                    maxFrameSize = MAX_FRAME_SIZE
+                }
+            }
+        client = httpClient
+```
+
+with:
+
+```kotlin
+        val httpClient = buildWsHttpClient(MAX_FRAME_SIZE)
+        client = httpClient
+```
+
+Then delete the now-unused imports `io.ktor.client.HttpClient`'s *usage* stays (the `client` field is typed `HttpClient?`), but `io.ktor.client.plugins.websocket.WebSockets` is no longer referenced in this file — remove that import. Leave everything else in the file untouched.
+
+- [ ] **Step 6: Verify compilation and existing tests across engines**
+
+Run: `./gradlew :transport-ws:jvmTest :transport-ws:wasmJsTest :transport-ws:compileKotlinMingwX64 :transport-ws:compileKotlinLinuxX64`
+Expected: PASS. All existing `WebSocketTransportFactoryTest` cases still green. If `compileKotlinMingwX64`/`LinuxX64` cannot run on this host, note it and rely on CI.
+
+- [ ] **Step 7: Lint**
+
+Run: `./gradlew spotlessApply && ./gradlew :transport-ws:spotlessCheck :transport-ws:detekt`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add transport-ws/build.gradle.kts transport-ws/src/commonMain transport-ws/src/cioMain transport-ws/src/mingwMain transport-ws/src/wasmJsMain
+git commit -m "refactor(transport): select the WebSocket ktor engine explicitly"
+```
+
+---
+
+### Task 2: The public `configureTls` hook
+
+**Files:**
+- Modify: `transport-ws/build.gradle.kts` (add `api(libs.ktor.network.tls)` to `commonMain`)
+- Modify: `transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt`
+- Modify: `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt`
+- Modify: `transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt`
+- Modify: `transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt`
+- Modify: `transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt`
+- Create: `transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTlsTest.kt`
+- Modify: `transport-ws/api/jvm/transport-ws.api`, `transport-ws/api/transport-ws.klib.api` (via `apiDump`)
+
+**Interfaces:**
+- Consumes: `internal expect fun buildWsHttpClient(maxFrameSize: Long): HttpClient` from Task 1.
+- Produces:
+  - `public class WebSocketTransport(internal val configureTls: (TLSConfigBuilder.() -> Unit)? = null)` with a `public constructor()`.
+  - `public class WebSocketTransportFactory(private val configureTls: (TLSConfigBuilder.() -> Unit)? = null)` with a `public constructor()`.
+  - `internal expect fun buildWsHttpClient(host: String, maxFrameSize: Long, configureTls: (TLSConfigBuilder.() -> Unit)?): HttpClient` — Task 3 adds a `configurePlatformTrust(host)` call after the hook inside the CIO actual.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTlsTest.kt` (GPL header first). Method names are camelCase — this is a new file, matching `:transport-tcp`'s test style:
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+import org.meshtastic.mqtt.MqttEndpoint
+import org.meshtastic.mqtt.plus
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Covers the caller-supplied TLS hook on [WebSocketTransportFactory] (issue #107).
+ *
+ * The hook only runs during a real TLS handshake, so these tests pin the surrounding
+ * contract: endpoint selection, transport type, hook forwarding, and `+` composition.
+ * The handshake itself is covered by the JVM end-to-end test in Task 5.
+ */
+class WebSocketTransportFactoryTlsTest {
+    private val endpoint = MqttEndpoint.WebSocket("wss://broker.example.com/mqtt")
+
+    @Test
+    fun factoryWithTlsHookStillSupportsOnlyWebSocketEndpoints() {
+        val factory = WebSocketTransportFactory { serverName = "override.example.com" }
+        assertTrue(factory.supports(endpoint))
+        assertFalse(factory.supports(MqttEndpoint.Tcp("broker.example.com")))
+    }
+
+    @Test
+    fun factoryForwardsTlsHookToCreatedTransport() {
+        // Guards against create() silently dropping configureTls: the transport must hold the
+        // very lambda instance the factory was constructed with.
+        val hook: TLSConfigBuilder.() -> Unit = { serverName = "override.example.com" }
+        val transport = WebSocketTransportFactory(hook).create(endpoint)
+        assertIs<WebSocketTransport>(transport)
+        assertSame(hook, transport.configureTls)
+    }
+
+    @Test
+    fun noArgFactoryProducesTransportWithoutHook() {
+        val transport = WebSocketTransportFactory().create(endpoint)
+        assertIs<WebSocketTransport>(transport)
+        assertNull(transport.configureTls)
+    }
+
+    @Test
+    fun factoryWithTlsHookStillComposesWithPlus() {
+        val combined = WebSocketTransportFactory { serverName = "override.example.com" } +
+            WebSocketTransportFactory()
+        assertIs<WebSocketTransport>(combined.create(endpoint))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :transport-ws:jvmTest --tests "org.meshtastic.mqtt.transport.ws.WebSocketTransportFactoryTlsTest"`
+Expected: FAIL at compilation — `Unresolved reference: TLSConfigBuilder` (the dependency is not on the classpath yet) and no matching constructor.
+
+- [ ] **Step 3: Expose `ktor-network-tls` as `api`**
+
+In `transport-ws/build.gradle.kts`, the `commonMain.dependencies` block becomes:
+
+```kotlin
+        commonMain.dependencies {
+            api(project(":core"))
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.websockets)
+            // api, not implementation: TLSConfigBuilder appears in WebSocketTransportFactory's
+            // public constructor signature, so consumers need it on their compile classpath.
+            // ktor-network-tls publishes a klib for every target this module builds, wasmJs
+            // included — `trustManager` is a JVM/Android-only property of that builder.
+            api(libs.ktor.network.tls)
+        }
+```
+
+- [ ] **Step 4: Thread the hook through the seam**
+
+`WsHttpClient.kt` (commonMain) — replace the `expect` declaration and its KDoc:
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * Builds the [HttpClient] used for the WebSocket connection, with the WebSockets plugin
+ * installed and a platform-appropriate engine selected.
+ *
+ * Engine auto-detection cannot be used here: configuring engine-level TLS requires naming
+ * the engine, and a star-projected `HttpClientConfig<*>` cannot reach `engine { }` at all.
+ *
+ * [configureTls] is honoured only where the engine exposes a TLS configuration — CIO, on JVM,
+ * Android, Apple, and Linux. On Windows (WinHttp) and in the browser (wasmJs / Js) it is
+ * silently ignored: WinHttp exposes no TLS-config surface and the browser cannot influence
+ * trust at all.
+ *
+ * @param host the broker host from the endpoint URL, used for trust evaluation.
+ * @param maxFrameSize the WebSocket frame safety cap, in bytes.
+ * @param configureTls optional caller customisation of the engine's TLS configuration.
+ */
+internal expect fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient
+```
+
+`WsHttpClient.cio.kt` — apply the hook:
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * CIO engine — JVM, Android, Apple, and Linux.
+ *
+ * The caller's hook is applied to CIO's `https` [TLSConfigBuilder], which is the same builder
+ * type `:transport-tcp` configures. `serverName` is deliberately not set here: the CIO *client*
+ * derives SNI from the request URL when it opens the connection, whereas this block runs once at
+ * client construction.
+ */
+internal actual fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient =
+    HttpClient(CIO) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+        engine {
+            https {
+                configureTls?.invoke(this)
+            }
+        }
+    }
+```
+
+`WsHttpClient.mingw.kt` and `WsHttpClient.wasmJs.kt` — same engine bodies as Task 1, with the widened signature and the hook explicitly discarded. For mingw:
+
+```kotlin
+/**
+ * WinHttp engine — Windows. Trust is handled by the platform certificate store.
+ *
+ * [configureTls] is ignored: `WinHttpClientEngineConfig` exposes no TLS-configuration surface.
+ * Documented in `Module.md`. Switching Windows to CIO would make the hook work, but CIO's
+ * native TLS has no Windows trust-store integration, so it would risk breaking ordinary `wss://`.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal actual fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient =
+    HttpClient(WinHttp) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }
+```
+
+For wasmJs, identical but with `HttpClient(Js)` and this KDoc:
+
+```kotlin
+/**
+ * Js engine — browser (wasmJs).
+ *
+ * [configureTls] is ignored: a browser page cannot influence TLS trust in any way. Documented
+ * in `Module.md`.
+ */
+```
+
+Add `import io.ktor.network.tls.TLSConfigBuilder` to both.
+
+- [ ] **Step 5: Add the constructor parameters**
+
+In `WebSocketTransport.kt`, add the import `io.ktor.http.Url` and `io.ktor.network.tls.TLSConfigBuilder`, then change the class declaration:
+
+```kotlin
+/**
+ * WebSocket-based [MqttTransport] for all platforms, including the browser (wasmJs).
+ *
+ * Uses Ktor's multiplatform HttpClient with a per-platform engine (CIO on JVM/Android/Apple/Linux,
+ * WinHttp on Windows, Js on wasmJs/browser). One binary WebSocket frame = one complete MQTT packet,
+ * so no stream parsing is needed — the WebSocket layer handles framing.
+ *
+ * @param configureTls optional hook applied to the engine's TLS configuration before platform
+ *   trust is configured. Use it to trust a private or self-signed CA for this connection only.
+ *   Honoured on JVM, Android, Apple, and Linux; ignored on Windows and in the browser.
+ */
+public class WebSocketTransport(
+    internal val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransport {
+    public constructor() : this(null)
+```
+
+In `connect`, derive the host from the URL and pass both through — replacing the Step 5 line from Task 1:
+
+```kotlin
+        val httpClient = buildWsHttpClient(Url(endpoint.url).host, MAX_FRAME_SIZE, configureTls)
+        client = httpClient
+```
+
+And the factory at the bottom of the same file:
+
+```kotlin
+/**
+ * [MqttTransportFactory] that builds a [WebSocketTransport] for [MqttEndpoint.WebSocket] endpoints.
+ *
+ * Add `org.meshtastic:mqtt-client-transport-ws` and pass an instance to
+ * [org.meshtastic.mqtt.MqttConfig.Builder.transportFactory]. This is the only transport available
+ * on the browser (wasmJs) target.
+ *
+ * To trust a broker whose certificate chain is not in the platform CA store — a private or
+ * self-signed CA — supply [configureTls]. The scope is this MQTT connection only, unlike Android's
+ * app-wide `network_security_config.xml` trust anchors:
+ *
+ * ```kotlin
+ * transportFactory = WebSocketTransportFactory { trustManager = myTrustManager }
+ * ```
+ *
+ * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport this
+ *   factory creates. It runs before platform trust is configured, so on Android a trust manager
+ *   installed here is reached through the hostname-aware `checkServerTrusted` overload rather than
+ *   bypassing it. Note that installing a trust manager replaces the platform's trust decision —
+ *   network-security-config anchors, pinning, and Certificate Transparency policy then hold only
+ *   insofar as that manager enforces them. Honoured on JVM, Android, Apple, and Linux; silently
+ *   ignored on Windows (WinHttp has no TLS-config surface) and in the browser (which cannot
+ *   influence trust). On Apple and Linux `TLSConfigBuilder` has no `trustManager`, so little is
+ *   configurable there in practice.
+ */
+public class WebSocketTransportFactory(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransportFactory {
+    public constructor() : this(null)
+
+    override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.WebSocket
+
+    override fun create(endpoint: MqttEndpoint): MqttTransport = WebSocketTransport(configureTls)
+}
+```
+
+If `io.ktor.http.Url` does not resolve, add `ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }` to `gradle/libs.versions.toml` and `implementation(libs.ktor.http)` to `commonMain`. Try without it first — `ktor-client-core` exposes `ktor-http` as an `api` dependency.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `./gradlew :transport-ws:jvmTest --tests "org.meshtastic.mqtt.transport.ws.WebSocketTransportFactoryTlsTest"`
+Expected: PASS, 4 tests.
+
+Then confirm nothing else broke: `./gradlew :transport-ws:jvmTest :transport-ws:wasmJsTest`
+Expected: PASS.
+
+- [ ] **Step 7: Regenerate the API baselines**
+
+Run: `./gradlew :transport-ws:apiDump && ./gradlew :transport-ws:apiCheck`
+Expected: PASS. `git diff transport-ws/api` should show only *added* lines: a one-arg constructor on each class alongside the existing zero-arg one, plus a `getConfigureTls`-style accessor if BCV records it. If any line was **removed**, stop — that is a binary-compatibility break and means the explicit `public constructor()` is missing.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+./gradlew spotlessApply && ./gradlew :transport-ws:spotlessCheck :transport-ws:detekt
+git add transport-ws
+git commit -m "feat(transport): add TLS trust hook to WebSocketTransportFactory"
+```
+
+---
+
+### Task 3: Android hostname-aware trust wrapping
+
+Duplicates `:transport-tcp`'s `configurePlatformTrust` into `:transport-ws` and calls it *after* the caller's hook.
+
+**Files:**
+- Create: `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt`
+- Create: `transport-ws/src/jvmMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.jvm.kt`
+- Create: `transport-ws/src/androidMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.android.kt`
+- Create: `transport-ws/src/appleMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.apple.kt`
+- Create: `transport-ws/src/linuxMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.linux.kt`
+- Modify: `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt`
+- Modify: `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt` (sibling cross-reference only)
+- Test: `transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt`
+
+**Interfaces:**
+- Consumes: `buildWsHttpClient(host, maxFrameSize, configureTls)` from Task 2.
+- Produces: `internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)` in `cioMain`, plus `internal fun TLSConfigBuilder.applyWsTls(host: String, configureTls: (TLSConfigBuilder.() -> Unit)?, platformTrust: TLSConfigBuilder.(String) -> Unit = { configurePlatformTrust(it) })` — the single ordering call site, with a test seam for `platformTrust`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt` (GPL header first):
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * JVM-only checks on the ordering inside [applyWsTls], using `trustManager` — a property that
+ * exists only on the JVM and Android actuals of [TLSConfigBuilder], so it cannot be asserted
+ * from `commonTest`.
+ *
+ * On the JVM `configurePlatformTrust` is a no-op, so a hook-installed trust manager survives
+ * untouched. On Android it is deliberately *not* preserved by identity — it gets wrapped in a
+ * hostname-aware delegate, which needs the `X509TrustManagerExtensions` framework class and is
+ * therefore out of unit-test scope. The ordering itself is asserted here via the
+ * `platformTrust` test seam.
+ */
+class WebSocketTrustManagerTest {
+    private object FakeTrustManager : X509TrustManager {
+        override fun checkClientTrusted(
+            chain: Array<out X509Certificate>,
+            authType: String,
+        ) = Unit
+
+        override fun checkServerTrusted(
+            chain: Array<out X509Certificate>,
+            authType: String,
+        ) = Unit
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    @Test
+    fun hookInstalledTrustManagerSurvivesApplyWsTls() {
+        val builder = TLSConfigBuilder()
+        builder.applyWsTls("broker.example.com") { trustManager = FakeTrustManager }
+        assertSame(FakeTrustManager, builder.trustManager)
+    }
+
+    @Test
+    fun callerHookRunsBeforePlatformTrust() {
+        // The Android wrapper reads whatever trustManager is on the builder, so the caller's
+        // assignment must already be present when platform trust runs. Reversing the two would
+        // silently drop Android's hostname-aware checkServerTrusted path.
+        val order = mutableListOf<String>()
+        val builder = TLSConfigBuilder()
+        builder.applyWsTls(
+            host = "broker.example.com",
+            configureTls = { order += "caller" },
+            platformTrust = { order += "platform" },
+        )
+        assertEquals(listOf("caller", "platform"), order)
+    }
+
+    @Test
+    fun platformTrustReceivesTheHostUnchanged() {
+        // Includes the IP-literal case: Android's 2-arg overload throws whenever the security
+        // config holds any domain-specific entry, regardless of target host, so an IP-only
+        // broker needs the wrapper too.
+        val seen = mutableListOf<String>()
+        TLSConfigBuilder().applyWsTls("192.168.1.50", null) { seen += it }
+        assertEquals(listOf("192.168.1.50"), seen)
+    }
+
+    @Test
+    fun nullHookIsANoOp() {
+        val builder = TLSConfigBuilder()
+        builder.applyWsTls("broker.example.com", null)
+        assertSame(null, builder.trustManager)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :transport-ws:jvmTest --tests "org.meshtastic.mqtt.transport.ws.WebSocketTrustManagerTest"`
+Expected: FAIL at compilation — `Unresolved reference: applyWsTls`.
+
+- [ ] **Step 3: Write the `cioMain` expect + ordering function**
+
+Create `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt` (GPL header first):
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * Applies platform-specific TLS trust configuration to the [TLSConfigBuilder].
+ *
+ * On Android, this installs a hostname-aware trust manager that satisfies
+ * `NetworkSecurityTrustManager`'s requirement for the 3-arg
+ * `checkServerTrusted(chain, authType, hostname)` overload when `network_security_config.xml`
+ * contains domain-specific configurations. The platform throws from the 2-arg overload whenever
+ * *any* domain-specific config is present — regardless of the target host — so this must run for
+ * IP-literal brokers too, not only DNS hostnames.
+ *
+ * On JVM, Apple, and Linux this is a no-op — the platform default suffices, and non-JVM
+ * `TLSConfigBuilder` has no `trustManager` property at all.
+ *
+ * **Sibling copy.** `:transport-ws` cannot depend on `:transport-tcp` — that module has no wasmJs
+ * target, and WS-only consumers should not pull a TCP artifact — so this logic is deliberately
+ * duplicated from
+ * `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt` and its
+ * per-platform actuals. **Any fix here must be applied there too, and vice versa.**
+ *
+ * @param host the broker host (DNS name or IP literal) used for trust evaluation.
+ */
+internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)
+
+/**
+ * Applies the MQTT TLS configuration to this [TLSConfigBuilder] in the one correct order:
+ *
+ * 1. [configureTls] — the caller's hook, so it can install its own trust manager (e.g. a private CA).
+ * 2. [configurePlatformTrust] — reads whatever trust manager is now on the builder and, on Android,
+ *    wraps it in a hostname-aware delegate.
+ *
+ * Step 1 must precede step 2. What step 2 provides is the call path: whatever trust manager is on
+ * the builder is reached through Android's hostname-aware
+ * `checkServerTrusted(chain, authType, hostname)` overload, which `NetworkSecurityTrustManager`
+ * requires whenever `network_security_config.xml` holds any domain-specific configuration.
+ * Reversing the two steps would discard that wrapper, leaving ktor's 2-arg call to hit the bare
+ * manager.
+ *
+ * Be precise about what this ordering does *not* provide. Installing a trust manager via
+ * [configureTls] *replaces the platform's trust decision*: that manager's anchors are used instead
+ * of the platform's, and `network_security_config.xml` anchors, certificate pinning, and
+ * Certificate Transparency policy are then enforced only insofar as that manager enforces them
+ * itself. Wrapping preserves the hostname-aware *call path*, not the platform's *policy*.
+ *
+ * Unlike `:transport-tcp`'s `applyMqttTls`, this does not set `serverName`: the CIO client derives
+ * SNI — and with it ktor's RFC 6125 subject-name check — from the request URL when it opens the
+ * connection, whereas this runs once at client construction.
+ *
+ * @param host the broker host (DNS name or IP literal), used for trust evaluation.
+ * @param configureTls optional caller customisation; `null` preserves the default behaviour.
+ * @param platformTrust test seam for [configurePlatformTrust]; production callers use the default.
+ */
+internal fun TLSConfigBuilder.applyWsTls(
+    host: String,
+    configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+    platformTrust: TLSConfigBuilder.(String) -> Unit = { configurePlatformTrust(it) },
+) {
+    configureTls?.invoke(this)
+    platformTrust(host)
+}
+```
+
+- [ ] **Step 4: Write the four actuals**
+
+`PlatformTls.jvm.kt` (jvmMain):
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/** See the sibling note on the `expect` declaration: mirrored in `:transport-tcp`. */
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
+    // No-op: JVM's default X509TrustManager handles the 2-arg checkServerTrusted correctly.
+}
+```
+
+`PlatformTls.apple.kt` (appleMain) and `PlatformTls.linux.kt` (linuxMain) are the same file with this comment body instead:
+
+```kotlin
+    // No-op: native TLSConfigBuilder does not expose a trustManager property.
+```
+
+`PlatformTls.android.kt` (androidMain) is a verbatim port of
+`transport-tcp/src/androidMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.android.kt`
+— read that file and copy it, changing only the `package` line to
+`org.meshtastic.mqtt.transport.ws` and adding this paragraph to the function's KDoc:
+
+```
+ * **Sibling copy** of `:transport-tcp`'s `PlatformTls.android.kt`. Any fix here must be applied
+ * there too, and vice versa.
+```
+
+Do not paraphrase or "improve" that file: the error-message wording, the `X509TrustManagerExtensions`
+wrapping, the `TrustManagerFactory` fallback, and the `host.isBlank()` guard are all load-bearing and
+were reviewed in #103.
+
+- [ ] **Step 5: Add the reciprocal cross-reference**
+
+In `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt`, append to the KDoc of `configurePlatformTrust` (just before the `@param host` line):
+
+```
+ * **Sibling copy.** The same logic is duplicated in
+ * `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt` and its
+ * actuals, because `:transport-ws` cannot depend on this module. **Any fix here must be applied
+ * there too, and vice versa.**
+```
+
+- [ ] **Step 6: Call it from the CIO client builder**
+
+In `WsHttpClient.cio.kt`, replace the `engine { https { … } }` block:
+
+```kotlin
+        engine {
+            https {
+                applyWsTls(host, configureTls)
+            }
+        }
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `./gradlew :transport-ws:jvmTest`
+Expected: PASS — 4 new `WebSocketTrustManagerTest` cases plus everything from Tasks 1-2.
+
+Run: `./gradlew :transport-ws:compileKotlinLinuxX64 :transport-ws:wasmJsTest`
+Expected: PASS. (Android compilation is covered by `./gradlew :transport-ws:assemble` or CI; run `./gradlew :transport-ws:compileDebugKotlinAndroid` if that task exists in this build.)
+
+- [ ] **Step 8: Confirm the API surface did not change**
+
+Run: `./gradlew :transport-ws:apiCheck`
+Expected: PASS with no dump changes — everything added in this task is `internal`.
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+./gradlew spotlessApply && ./gradlew :transport-ws:spotlessCheck :transport-ws:detekt :transport-tcp:spotlessCheck
+git add transport-ws transport-tcp
+git commit -m "feat(transport): wrap WS trust manager for Android hostname checks"
+```
+
+---
+
+### Task 4: Private-CA `wss://` end-to-end test
+
+The test that actually discharges the issue's acceptance criterion instead of asserting it.
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`
+- Modify: `transport-ws/build.gradle.kts` (`jvmTest` dependencies)
+- Test: `transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt`
+
+**Interfaces:**
+- Consumes: `WebSocketTransport(configureTls)` from Task 2, the trust ordering from Task 3.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the test-only dependencies**
+
+In `gradle/libs.versions.toml`, under `[libraries]` next to the other `ktor-` entries:
+
+```toml
+ktor-network-tls-certificates = { module = "io.ktor:ktor-network-tls-certificates", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+```
+
+In `transport-ws/build.gradle.kts`, inside `sourceSets { … }`, after the `wasmJsMain` block:
+
+```kotlin
+        jvmTest.get().dependencies {
+            // Test-only: a local wss:// server with a generated self-signed certificate, so the
+            // private-CA path is proven rather than asserted. Not part of the published artifact.
+            implementation(libs.ktor.server.cio)
+            implementation(libs.ktor.server.websockets)
+            implementation(libs.ktor.network.tls.certificates)
+        }
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt` (GPL header first):
+
+```kotlin
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.certificates.buildKeyStore
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.engine.sslConnector
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.meshtastic.mqtt.MqttEndpoint
+import java.io.File
+import java.net.ServerSocket
+import java.security.KeyStore
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end proof of issue #107's acceptance criterion: a `wss://` broker whose certificate is
+ * anchored in a private CA is reachable through the [WebSocketTransportFactory] hook alone, with
+ * no app-wide or JVM-wide trust changes.
+ *
+ * The server speaks WebSocket, not MQTT — what is under test is the TLS trust decision and the
+ * transport's binary framing, not the protocol layered on top.
+ */
+class WebSocketPrivateCaTest {
+    private val alias = "mqtt-ws-test"
+    private val password = "changeit"
+    private lateinit var keyStoreFile: File
+    private lateinit var keyStore: KeyStore
+    private var port = 0
+    private var server: io.ktor.server.engine.EmbeddedServer<*, *>? = null
+
+    @BeforeTest
+    fun startServer() {
+        keyStore =
+            buildKeyStore {
+                certificate(alias) {
+                    this.password = this@WebSocketPrivateCaTest.password
+                    domains = listOf("localhost")
+                }
+            }
+        keyStoreFile = File.createTempFile("mqtt-ws-test", ".jks")
+        keyStoreFile.outputStream().use { keyStore.store(it, password.toCharArray()) }
+
+        port = ServerSocket(0).use { it.localPort }
+
+        server =
+            embeddedServer(CIO, serverConfig {
+                module {
+                    install(WebSockets)
+                    routing {
+                        webSocket("/mqtt") {
+                            for (frame in incoming) {
+                                if (frame is Frame.Binary) send(Frame.Binary(true, frame.data))
+                            }
+                        }
+                    }
+                }
+            }) {
+                sslConnector(
+                    keyStore = keyStore,
+                    keyAlias = alias,
+                    keyStorePassword = { password.toCharArray() },
+                    privateKeyPassword = { password.toCharArray() },
+                ) {
+                    this.port = this@WebSocketPrivateCaTest.port
+                    this.keyStorePath = keyStoreFile
+                }
+            }.also { it.start(wait = false) }
+    }
+
+    @AfterTest
+    fun stopServer() {
+        server?.stop(gracePeriodMillis = 0, timeoutMillis = 1_000)
+        keyStoreFile.delete()
+    }
+
+    private val endpoint get() = MqttEndpoint.WebSocket("wss://localhost:$port/mqtt")
+
+    /** A trust store holding only the generated certificate — the "private CA". */
+    private fun privateCaTrustManager(): X509TrustManager {
+        val trustStore =
+            KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+                load(null, null)
+                setCertificateEntry("private-ca", keyStore.getCertificate(alias))
+            }
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(trustStore)
+        return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+    @Test
+    fun handshakeFailsWithoutTheHook() = runTest {
+        val transport = WebSocketTransportFactory().create(endpoint)
+        assertFailsWith<Exception> {
+            withTimeout(20_000) { transport.connect(endpoint) }
+        }
+        transport.close()
+    }
+
+    @Test
+    fun handshakeSucceedsAndFramesRoundTripWithTheHook() = runTest {
+        val tm = privateCaTrustManager()
+        val transport = WebSocketTransportFactory { trustManager = tm }.create(endpoint)
+        withTimeout(20_000) {
+            transport.connect(endpoint)
+            assertTrue(transport.isConnected)
+            val payload = byteArrayOf(0x10, 0x02, 0x00, 0x04)
+            transport.send(payload)
+            assertContentEquals(payload, transport.receive())
+        }
+        transport.close()
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails, then make it compile**
+
+Run: `./gradlew :transport-ws:jvmTest --tests "org.meshtastic.mqtt.transport.ws.WebSocketPrivateCaTest"`
+
+The ktor **server** API in Step 2 is written against ktor 3.5.1 from documentation, not from this
+repo (no ktor server dependency existed before this task). If it fails to compile, fix the test
+harness — not the production code:
+
+- `serverConfig { module { … } }` / `embeddedServer(factory, config) { connectors }` shapes moved
+  between ktor 3.x minors; check `io.ktor.server.engine.EmbeddedServerKt` in the resolved artifact
+  or ktor's docs for 3.5.x.
+- CIO's `sslConnector` may require `keyStorePath` to be set (it is, above) and may reject a
+  `port = 0`, hence the pre-picked free port.
+- `EmbeddedServer<*, *>`'s generic signature is awkward to name; if it fights you, store the server
+  in a `var server: Any?` and cast at `stop`, or hold it via a nullable `AutoCloseable` wrapper.
+
+Once it compiles, expect: `handshakeFailsWithoutTheHook` PASSES (the JVM does not trust the
+generated cert) and `handshakeSucceedsAndFramesRoundTripWithTheHook` PASSES. If the *second* test
+fails, that is a real defect in Tasks 2-3 — do not weaken the test; debug the hook.
+
+If `handshakeFailsWithoutTheHook` unexpectedly *passes the handshake*, something is trusting the
+cert globally (a `cacerts` entry or a stale `javax.net.ssl.trustStore` system property). Investigate
+before proceeding; a silently-always-trusting environment makes the second test meaningless.
+
+- [ ] **Step 4: Settle the open `serverName` question**
+
+The spec left one thing to determine empirically: whether a `serverName` a caller assigns inside the
+hook survives CIO's own per-request SNI assignment. Now that a live TLS server exists, answer it.
+Add this test temporarily:
+
+```kotlin
+    @Test
+    fun serverNameSetInsideTheHookLosesToCioRequestSni() = runTest {
+        val tm = privateCaTrustManager()
+        val transport =
+            WebSocketTransportFactory {
+                trustManager = tm
+                serverName = "not-the-server.example.com"
+            }.create(endpoint)
+        // If the connect succeeds, CIO overrode the hook's serverName with the request host.
+        // If it fails on subject-name mismatch, the hook's value won.
+        withTimeout(20_000) { transport.connect(endpoint) }
+        transport.close()
+    }
+```
+
+Run it, then keep it with whichever name matches reality (rename to
+`serverNameSetInsideTheHookWinsOverCioRequestSni` and wrap in `assertFailsWith` if the hook wins),
+and record the finding in one sentence in both `WsHttpClient.cio.kt`'s KDoc and the `Module.md`
+paragraph from Task 5. Do not leave the question open — a caller reading "this hook does not set
+the SNI server name" will reasonably wonder whether they can.
+
+- [ ] **Step 5: Confirm no public API change and lint**
+
+Run: `./gradlew :transport-ws:apiCheck && ./gradlew spotlessApply && ./gradlew :transport-ws:spotlessCheck :transport-ws:detekt`
+Expected: PASS. Test-only dependencies do not affect the dumps.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gradle/libs.versions.toml transport-ws/build.gradle.kts transport-ws/src/jvmTest
+git commit -m "test(transport): prove private-CA wss:// reachability via the hook"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `transport-ws/Module.md`
+- Modify: `README.md:335-392` (the "Custom TLS trust" section)
+- Modify: `AGENTS.md:46-47` and `AGENTS.md:53-56`
+- Modify: `CHANGELOG.md:8` (under `## [Unreleased]`)
+
+**Interfaces:**
+- Consumes: the public API from Task 2.
+- Produces: nothing.
+
+- [ ] **Step 1: Extend `transport-ws/Module.md`**
+
+Insert this before the closing "Available on every target…" paragraph, mirroring the structure of
+`transport-tcp/Module.md`'s "Trusting a private CA" section:
+
+```markdown
+## Trusting a private CA
+
+If the broker's certificate is issued by a private or self-signed CA that is not in the platform
+trust store, pass a TLS customisation lambda. It receives ktor's `TLSConfigBuilder` — the same type
+`mqtt-client-transport-tcp` uses, so one trust manager can serve both transports:
+
+```kotlin
+val client = MqttClient("sensor") {
+    transportFactory = TcpTransportFactory { trustManager = myTrustManager } +
+        WebSocketTransportFactory { trustManager = myTrustManager }
+}
+```
+
+The lambda is applied before platform trust configuration. On Android that ordering means the trust
+manager on the builder is reached through the hostname-aware
+`checkServerTrusted(chain, authType, hostname)` overload, which the platform requires whenever
+`network_security_config.xml` holds any domain-specific configuration.
+
+Be precise about what that does *not* buy you. Installing your own trust manager **replaces the
+platform's trust decision**: your anchors are used instead of the platform's, and
+`network_security_config.xml` anchors, certificate pinning, and Certificate Transparency policy are
+then enforced only insofar as your manager enforces them itself. Those platform policies apply as
+before only if you leave `trustManager` unset. Wrapping preserves the hostname-aware *call path*,
+not the platform's *policy*.
+
+On Android the manager must be one `X509TrustManagerExtensions` can wrap: either obtained from a
+`TrustManagerFactory`, or declaring the three-arg `checkServerTrusted(chain, authType, host)` that
+the platform looks up reflectively. Otherwise the handshake fails with an `IllegalArgumentException`
+explaining this.
+
+The added trust applies only to this MQTT connection — unlike Android's app-wide
+`network_security_config.xml` trust anchors.
+
+Where the hook takes effect depends on the platform's ktor engine:
+
+| Target | Engine | `configureTls` |
+| --- | --- | --- |
+| JVM, Android | CIO | Honoured; `trustManager` available |
+| iOS, macOS, Linux | CIO | Invoked, but `TLSConfigBuilder` has no `trustManager` there |
+| Windows | WinHttp | **Ignored** — the engine exposes no TLS-configuration surface |
+| Browser (wasmJs) | Js | **Ignored** — a page cannot influence TLS trust |
+
+The two ignored cases are deliberately silent so that shared common code can pass the hook
+unconditionally. On Windows in particular, a private CA must be installed in the system
+certificate store instead.
+
+Unlike the TCP transport, this hook does not set the SNI server name: the CIO client derives SNI
+from the request URL, which is also what gates ktor's RFC 6125 subject-name check.
+```
+
+Note for the implementer: the fenced `kotlin` block above is nested inside a fenced markdown block
+in *this plan*. Write it into `Module.md` as a normal triple-backtick block.
+
+- [ ] **Step 2: Update the README**
+
+Two edits in the "Custom TLS trust" section:
+
+1. Replace the opening sentence "By default the TCP transport validates the broker certificate
+   against the platform CA store." with: "By default both transports validate the broker
+   certificate against the platform CA store."
+2. Replace the composition snippet and the final paragraph (currently ending "The WebSocket
+   transport has no equivalent hook yet.") with:
+
+```markdown
+The hook composes with transport selection as usual, and both transports take the same lambda type,
+so one trust manager can serve both:
+
+```kotlin
+transportFactory = TcpTransportFactory { trustManager = myPrivateCaTrustManager } +
+    WebSocketTransportFactory { trustManager = myPrivateCaTrustManager }
+```
+
+`TLSConfigBuilder` comes from `io.ktor:ktor-network-tls`, exposed transitively by both
+`mqtt-client-transport-tcp` and `mqtt-client-transport-ws` — no extra dependency needed.
+`trustManager` specifically is available on the JVM and Android actuals of `TLSConfigBuilder`; on
+Apple and Linux the hook still runs, but `TLSConfigBuilder` exposes a different set of properties
+there. The WebSocket hook is additionally ignored on Windows (the WinHttp engine has no
+TLS-configuration surface) and in the browser (which cannot influence trust) — see
+`transport-ws/Module.md` for the per-target table.
+```
+
+- [ ] **Step 3: Update `AGENTS.md`**
+
+In the module layout block, change the `:transport-ws` entry to note the new source set:
+
+```
+:transport-ws              commonMain (WebSocketTransport) + cioMain (CIO engine + TLS trust hook)
+                           + per-platform Ktor engine deps. Targets: all, incl. wasmJs.
+```
+
+And replace the "There is **no** custom `nonWebMain` source set any more…" sentence with:
+
+```markdown
+The one custom intermediate source set is `:transport-ws`'s `cioMain` (jvm + android + apple +
+linux), which holds the single CIO `HttpClient` builder and the TLS trust plumbing. The old
+`nonWebMain` set is gone: `:transport-tcp` simply omits the wasmJs target, so its `commonMain` is
+effectively the old "non-web" set.
+```
+
+- [ ] **Step 4: Add the changelog entry**
+
+Under `## [Unreleased]` in `CHANGELOG.md`:
+
+```markdown
+### Added
+
+- `WebSocketTransportFactory` now accepts an optional TLS customisation lambda, the WebSocket
+  counterpart to the `TcpTransportFactory` hook added in 0.6.0. Both take the same
+  `TLSConfigBuilder` receiver, so a single trust manager can serve `ssl://` and `wss://` brokers
+  behind a private or self-signed CA — scoped to the MQTT connection, with no app-wide
+  `network_security_config.xml` anchor. Honoured on JVM, Android, Apple, and Linux; ignored on
+  Windows (WinHttp exposes no TLS-configuration surface) and in the browser. The existing no-arg
+  constructor is unchanged (#107).
+
+### Changed
+
+- `:transport-ws` now selects its Ktor engine explicitly per platform (CIO on JVM/Android/Apple/
+  Linux, WinHttp on Windows, Js on wasmJs) instead of relying on auto-detection. The engines are
+  the same ones auto-detection resolved, so behaviour is unchanged.
+```
+
+- [ ] **Step 5: Verify the docs build**
+
+Run: `./gradlew :transport-ws:dokkaGeneratePublicationHtml`
+Expected: PASS with no unresolved-link warnings for the new KDoc references.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add transport-ws/Module.md README.md AGENTS.md CHANGELOG.md
+git commit -m "docs: document the WebSocket TLS trust hook"
+```
+
+---
+
+### Task 6: Full baseline verification
+
+**Files:** none created; fixes land in whichever file fails.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: a branch ready for PR.
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `./gradlew spotlessCheck detekt allTests apiCheck koverVerify`
+Expected: PASS. Notes on likely failures:
+
+- `koverVerify` (≥80%): the new `configurePlatformTrust` no-op actuals and the ignored-hook engine
+  actuals are hard to cover. If coverage drops below the threshold, do **not** lower it — check
+  first whether `WebSocketPrivateCaTest` is actually running (it covers the CIO path end to end).
+- `allTests` includes `wasmJsTest`, which is what proves the wasmJs actual compiles and the Js
+  engine still works.
+
+- [ ] **Step 2: Confirm binary compatibility by inspection**
+
+Run: `git diff main -- transport-ws/api`
+Expected: additions only. Any removed line in `transport-ws.klib.api` or `api/jvm/transport-ws.api`
+means an existing consumer would fail to link — stop and fix.
+
+- [ ] **Step 3: Verify the module boundary still holds**
+
+Run: `./gradlew :core:check`
+Expected: PASS, including `verifyModuleBoundary` and the Konsist architecture suite. `:core` was not
+touched, so this is a regression guard rather than a change.
+
+- [ ] **Step 4: Commit any fixes and push**
+
+```bash
+git add -A
+git commit -m "chore: satisfy verification gates for the WS TLS hook"
+git push -u origin ws-tls-trust-hook
+```
+
+Then open the PR with title `feat(transport): add TLS trust hook to WebSocketTransportFactory`, a
+bullet list of the changes, `Fixes #107`, and an explicit note that the Meshtastic-Android
+`<certificates src="user"/>` anchor in `base-config` can come out once both transports are wired.

--- a/docs/superpowers/plans/2026-07-26-ws-tls-trust-hook.md
+++ b/docs/superpowers/plans/2026-07-26-ws-tls-trust-hook.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - Every change is additive and binary-compatible. `WebSocketTransportFactory()` and `WebSocketTransport()` must keep linking for already-compiled callers — declare the zero-arg secondary constructors explicitly, because klib ABI dumps list constructors individually.
-- No new runtime dependencies outside the ktor / kotlinx-coroutines / kotlinx-io umbrella. `ktor-server-cio`, `ktor-server-websockets`, and `ktor-network-tls-certificates` are added in Task 5 as `testImplementation` only.
+- No new runtime dependencies outside the ktor / kotlinx-coroutines / kotlinx-io umbrella. `ktor-server-cio`, `ktor-server-websockets`, and `ktor-network-tls-certificates` are added in Task 5 as `testImplementation` only. **As-built:** the server engine used is `ktor-server-netty`, not `ktor-server-cio` — ktor's server-side CIO engine does not support HTTPS/TLS, which this test requires. Still `testImplementation`-scoped only.
 - `:core` gains nothing. No ktor TLS types may reach it (ADR-0006, enforced by `core/build.gradle.kts`'s `verifyModuleBoundary`).
 - `:transport-ws` must not depend on `:transport-tcp`. `configurePlatformTrust` is deliberately duplicated; each copy's KDoc names its sibling.
 - Ordering rule, non-negotiable: the caller's hook runs **before** `configurePlatformTrust`, so Android wraps the caller's trust manager rather than replacing it.
@@ -701,7 +701,7 @@ internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
 — read that file and copy it, changing only the `package` line to
 `org.meshtastic.mqtt.transport.ws` and adding this paragraph to the function's KDoc:
 
-```
+```text
  * **Sibling copy** of `:transport-tcp`'s `PlatformTls.android.kt`. Any fix here must be applied
  * there too, and vice versa.
 ```
@@ -714,7 +714,7 @@ were reviewed in #103.
 
 In `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt`, append to the KDoc of `configurePlatformTrust` (just before the `@param host` line):
 
-```
+```text
  * **Sibling copy.** The same logic is duplicated in
  * `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt` and its
  * actuals, because `:transport-ws` cannot depend on this module. **Any fix here must be applied
@@ -771,6 +771,11 @@ The test that actually discharges the issue's acceptance criterion instead of as
 
 - [ ] **Step 1: Add the test-only dependencies**
 
+**As-built note:** this step drafted `ktor-server-cio` as the test server engine. It was replaced
+with `ktor-server-netty` during implementation — ktor's server-side CIO engine does not support
+HTTPS/TLS, which this test requires. `ktor-server-netty` is `testImplementation`-scoped only, same
+as the other two. The draft below is left as originally written.
+
 In `gradle/libs.versions.toml`, under `[libraries]` next to the other `ktor-` entries:
 
 ```toml
@@ -794,6 +799,10 @@ In `transport-ws/build.gradle.kts`, inside `sourceSets { … }`, after the `wasm
 - [ ] **Step 2: Write the failing test**
 
 Create `transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt` (GPL header first):
+
+**As-built note:** the draft below uses `embeddedServer(CIO, …)`. The shipped test uses
+`embeddedServer(Netty, …)` instead, for the same reason noted in Step 1 — ktor's server-side CIO
+engine rejects HTTPS. The draft is left as originally written.
 
 ```kotlin
 package org.meshtastic.mqtt.transport.ws
@@ -1005,7 +1014,7 @@ git commit -m "test(transport): prove private-CA wss:// reachability via the hoo
 Insert this before the closing "Available on every target…" paragraph, mirroring the structure of
 `transport-tcp/Module.md`'s "Trusting a private CA" section:
 
-```markdown
+````markdown
 ## Trusting a private CA
 
 If the broker's certificate is issued by a private or self-signed CA that is not in the platform
@@ -1054,10 +1063,10 @@ certificate store instead.
 
 Unlike the TCP transport, this hook does not set the SNI server name: the CIO client derives SNI
 from the request URL, which is also what gates ktor's RFC 6125 subject-name check.
-```
+````
 
-Note for the implementer: the fenced `kotlin` block above is nested inside a fenced markdown block
-in *this plan*. Write it into `Module.md` as a normal triple-backtick block.
+Note for the implementer: the outer fence above uses four backticks only so the nested ` ```kotlin `
+block renders correctly *in this plan*. Write it into `Module.md` as a normal triple-backtick block.
 
 - [ ] **Step 2: Update the README**
 
@@ -1069,7 +1078,7 @@ Two edits in the "Custom TLS trust" section:
 2. Replace the composition snippet and the final paragraph (currently ending "The WebSocket
    transport has no equivalent hook yet.") with:
 
-```markdown
+````markdown
 The hook composes with transport selection as usual, and both transports take the same lambda type,
 so one trust manager can serve both:
 
@@ -1085,13 +1094,13 @@ Apple and Linux the hook still runs, but `TLSConfigBuilder` exposes a different 
 there. The WebSocket hook is additionally ignored on Windows (the WinHttp engine has no
 TLS-configuration surface) and in the browser (which cannot influence trust) — see
 `transport-ws/Module.md` for the per-target table.
-```
+````
 
 - [ ] **Step 3: Update `AGENTS.md`**
 
 In the module layout block, change the `:transport-ws` entry to note the new source set:
 
-```
+```text
 :transport-ws              commonMain (WebSocketTransport) + cioMain (CIO engine + TLS trust hook)
                            + per-platform Ktor engine deps. Targets: all, incl. wasmJs.
 ```

--- a/docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md
+++ b/docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md
@@ -120,7 +120,7 @@ internal expect fun buildWsHttpClient(
 A new intermediate source set `cioMain` holds the single CIO implementation, so it is written once
 rather than four times:
 
-```
+```text
 commonMain            expect buildWsHttpClient
   └─ cioMain          actual (CIO) + expect TLSConfigBuilder.configurePlatformTrust
        ├─ jvmMain     actual configurePlatformTrust — no-op
@@ -171,6 +171,11 @@ is configured once at client construction. Setting `serverName` there would be a
 Whether a `serverName` a caller assigns inside the hook survives CIO's own assignment is a ktor
 precedence detail to confirm during implementation and document in whichever direction it turns
 out; the hook's advertised purpose is trust, not SNI.
+
+As-built note: confirmed. A `serverName` the hook assigns **wins** over CIO's per-request SNI —
+it becomes the name ktor verifies the certificate's subject names against, for every connection
+the factory creates. See `WebSocketPrivateCaTest.serverNameSetInsideTheHookWinsOverCioRequestSni`
+for the test that discharges this.
 
 What the ordering does **not** provide is unchanged from #103 and must be restated in the KDoc:
 installing a trust manager *replaces the platform's trust decision*. Network-security-config

--- a/docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md
+++ b/docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md
@@ -1,0 +1,277 @@
+# TLS trust configuration hook for the WebSocket transport
+
+Design for [issue #107](https://github.com/meshtastic/MQTTastic-Client-KMP/issues/107). Follow-on
+to [#102 / #103](2026-07-25-tls-trust-hook-design.md), which added the same capability to the TCP
+transport.
+
+## Problem
+
+`TcpTransportFactory` accepts a `configureTls: (TLSConfigBuilder.() -> Unit)?` hook, so a caller can
+reach an `ssl://` broker anchored in a private or self-signed CA without granting app-wide trust.
+`WebSocketTransportFactory` has no equivalent, so a `wss://` broker with the same CA remains
+unreachable.
+
+The consequence is that the #103 hook cannot actually be adopted. In Meshtastic-Android,
+`network_security_config.xml` carries `<certificates src="user"/>` inside `base-config` — an anchor
+that applies to *every* HTTPS connection the app makes — and the app registers
+`TcpTransportFactory() + WebSocketTransportFactory()` so users can enter `ws://`/`wss://` brokers.
+Removing the app-wide anchor today would keep private-CA `ssl://` working and break private-CA
+`wss://`. Both transports must be configurable before the anchor can come out.
+
+Concretely, as of 0.6.1:
+
+- `WebSocketTransportFactory` and `WebSocketTransport` are `final` with no-arg constructors.
+- `WebSocketTransport.connect` builds its client with a bare `HttpClient { install(WebSockets) { … } }`
+  (`transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt:56-61`),
+  relying on ktor engine auto-detection, and never exposes engine configuration.
+
+## Approach
+
+Add an optional `configureTls: (TLSConfigBuilder.() -> Unit)?` to `WebSocketTransportFactory`,
+threaded to `WebSocketTransport`, applied to the ktor engine's TLS configuration on the platforms
+whose engine has one.
+
+### Why `TLSConfigBuilder`, and not the shape the issue sketches
+
+The issue proposes an `HttpClientConfig<*>` receiver. That cannot work: `HttpClientConfig<T>`
+declares `fun engine(block: T.() -> Unit)`, and under the star projection `T` is in an `in`
+position, so `engine { }` is not callable at all. A caller handed an `HttpClientConfig<*>` can
+install plugins but can never reach TLS settings.
+
+The issue also assumes there is no shared lambda type to unify on — as did #103's spec, which
+recorded that `:transport-ws` "configures a ktor `HttpClient` and never touches `TLSConfigBuilder`".
+That was true of the code, but the type is in fact available everywhere we need it:
+
+- The engines already wired in `transport-ws/build.gradle.kts` are CIO on jvm/android/apple/linux,
+  WinHttp on mingw, and Js on wasmJs.
+- `CIOEngineConfig` exposes `https: TLSConfigBuilder` and `https { }` — the *same* builder type
+  `:transport-tcp` configures.
+- `ktor-network-tls` publishes a klib for every target this project builds, wasmJs included
+  (verified against Maven Central at ktor 3.5.1: `ktor-network-tls-wasm-js` contains
+  `io.ktor.network.tls.TLSConfigBuilder` via `TLSConfigBuilder.nonJvm.kt`). `trustManager` is a
+  JVM/Android-only property of that builder, exactly as on native.
+
+So the hook can use the identical type on both transports, with no `expect`/`actual` on the public
+API and no new public type name. `:core` gains no ktor TLS types, so ADR-0006 and
+`verifyModuleBoundary` are unaffected.
+
+Two alternatives were considered and rejected:
+
+- **A caller-supplied `HttpClient` (or `() -> HttpClient`).** Maximum power and the smallest diff,
+  but the ergonomics diverge from #103, the caller takes on engine-lifecycle knowledge, and Android
+  callers lose the hostname-aware trust-manager wrapping that `:transport-tcp` applies for free.
+- **Both that and the lambda.** Two code paths to document and test for one issue; YAGNI.
+
+## Public API
+
+```kotlin
+public class WebSocketTransportFactory(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransportFactory {
+    public constructor() : this(null)
+
+    override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.WebSocket
+
+    override fun create(endpoint: MqttEndpoint): MqttTransport = WebSocketTransport(configureTls)
+}
+
+public class WebSocketTransport(
+    internal val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransport {
+    public constructor() : this(null)
+}
+```
+
+This mirrors `:transport-tcp` member for member, including the explicit zero-arg secondary
+constructors — Kotlin synthesises one for an all-defaults constructor on JVM, but klib ABI dumps
+list constructors explicitly, so declaring it keeps the native/wasm ABI additive.
+
+Usage is then symmetric across both transports:
+
+```kotlin
+transportFactory =
+    TcpTransportFactory { trustManager = myTrustManager } +
+        WebSocketTransportFactory { trustManager = myTrustManager }
+```
+
+`WebSocketTransport.configureTls` is `internal val` rather than private so `commonTest` can assert
+the factory threads the hook through, matching `TcpTransport`.
+
+## The seam
+
+`WebSocketTransport.connect` currently calls `HttpClient { }` and lets ktor auto-detect the engine.
+Engine-specific TLS configuration requires naming the engine, so client construction moves behind
+one internal expect/actual in `transport-ws/src/commonMain`:
+
+```kotlin
+internal expect fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient
+```
+
+`host` comes from `Url(endpoint.url).host` (`ktor-http`, available on all targets). `connect` calls
+`buildWsHttpClient` in place of its current inline `HttpClient { }`; the rest of `connect`, `send`,
+`receive`, and `close` is unchanged, as is `MAX_FRAME_SIZE`.
+
+### Source-set layout
+
+A new intermediate source set `cioMain` holds the single CIO implementation, so it is written once
+rather than four times:
+
+```
+commonMain            expect buildWsHttpClient
+  └─ cioMain          actual (CIO) + expect TLSConfigBuilder.configurePlatformTrust
+       ├─ jvmMain     actual configurePlatformTrust — no-op
+       ├─ androidMain actual configurePlatformTrust — HostnameAwareTrustManager
+       ├─ appleMain   actual configurePlatformTrust — no-op
+       └─ linuxMain   actual configurePlatformTrust — no-op
+  ├─ mingwMain        actual (WinHttp) — hook ignored
+  └─ wasmJsMain       actual (Js)      — hook ignored
+```
+
+`cioMain` deliberately spans JVM-family and native targets; it may only use API present in both,
+which CIO and `TLSConfigBuilder` are. `trustManager` is JVM-only and is referenced solely from the
+`androidMain` actual. `AGENTS.md` currently states that no custom intermediate source sets remain
+(the old `nonWebMain` having been removed), so that sentence needs updating. Wiring goes through
+`findByName("androidMain")`, as the existing per-engine dependency blocks already do, because that
+source set comes from the AGP KMP plugin.
+
+The CIO actual:
+
+```kotlin
+internal actual fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient = HttpClient(CIO) {
+    install(WebSockets) { this.maxFrameSize = maxFrameSize }
+    engine {
+        https {
+            configureTls?.invoke(this)   // caller first…
+            configurePlatformTrust(host) // …so Android wraps their trustManager, not the reverse
+        }
+    }
+}
+```
+
+### Ordering, and the one difference from `applyMqttTls`
+
+The caller's lambda runs before `configurePlatformTrust`, for exactly the reason #103 established:
+on Android, `configurePlatformTrust` reads `trustManager` off the builder and wraps whatever it
+finds in a hostname-aware delegate, so the caller's assignment must already be present. Reversing
+the two would discard the wrapper and silently drop Android's 3-arg `checkServerTrusted` path,
+which `NetworkSecurityTrustManager` requires whenever `network_security_config.xml` holds any
+domain-specific configuration.
+
+`applyMqttTls`'s first step — `serverName = sniServerName(host)` — has no counterpart here. The CIO
+*client* derives SNI from the request URL when it opens the connection, whereas `engine { https { } }`
+is configured once at client construction. Setting `serverName` there would be at best redundant.
+Whether a `serverName` a caller assigns inside the hook survives CIO's own assignment is a ktor
+precedence detail to confirm during implementation and document in whichever direction it turns
+out; the hook's advertised purpose is trust, not SNI.
+
+What the ordering does **not** provide is unchanged from #103 and must be restated in the KDoc:
+installing a trust manager *replaces the platform's trust decision*. Network-security-config
+anchors, pinning, and Certificate Transparency policy then hold only insofar as that manager
+enforces them. Wrapping preserves the hostname-aware *call path*, not the platform's *policy*.
+
+### Duplicating `configurePlatformTrust`
+
+`:transport-ws` cannot depend on `:transport-tcp`: that module has no wasmJs target, and WS-only
+consumers should not pull a TCP artifact. `configurePlatformTrust` — the `expect` plus the Android
+`HostnameAwareTrustManager` and the three no-op actuals — is therefore copied into
+`org.meshtastic.mqtt.transport.ws`, roughly 90 lines including KDoc.
+
+This is a deliberate accepted cost, chosen over a fourth published artifact (whose API would become
+de-facto public to Maven consumers, for a ~90-line internal helper) and over cross-module `srcDir`
+wiring (surprising to Konsist/BCV/Kover and to future readers). The mitigation is explicit: each
+copy's KDoc names the other file as the sibling that must change in lockstep, and the JVM test
+asserting hook-then-platform ordering is mirrored in both modules.
+
+## Unsupported targets
+
+On mingw (WinHttp exposes no TLS-config surface) and wasmJs (the browser cannot influence trust at
+all), the lambda is simply never invoked. No throw, no warning: common code can pass the hook
+unconditionally and still compile and connect everywhere. The documented risk is that a caller may
+believe a private CA is trusted on Windows when it is not, and learn otherwise from a handshake
+failure. `Module.md` and the KDoc state the supported set plainly.
+
+Native CIO targets (apple, linux) do invoke the lambda, but `TLSConfigBuilder` there has no
+`trustManager`, so in practice there is little a caller can do — the same situation as
+`:transport-tcp`, and documented the same way.
+
+`ktor-client-cio-mingwx64` does exist, so switching Windows to CIO would make the hook work there.
+It is rejected: CIO's native TLS has no Windows trust-store integration, so the switch would risk
+breaking ordinary `wss://` on Windows to gain a niche capability.
+
+## Build and compatibility
+
+- `transport-ws/build.gradle.kts`: add `api(libs.ktor.network.tls)` to `commonMain` — a public
+  signature now names `TLSConfigBuilder`, so consumers need it on their compile classpath.
+  Engine dependencies are unchanged. Add the `cioMain` source set and its `dependsOn` wiring.
+- `./gradlew apiDump` regenerates `transport-ws/api/transport-ws.klib.api` and the JVM dump; both
+  are committed.
+- Binary compatible: every new parameter is defaulted and the zero-arg constructors are declared
+  explicitly, so already-compiled callers of `WebSocketTransportFactory()` keep linking.
+- No change to `:core`, `:transport-tcp`, or the BOM. No Konsist allowlist change — the ADR-0008
+  suite covers `:core` only.
+
+## Testing
+
+`commonTest` (extends `WebSocketTransportFactoryTest`):
+
+- `WebSocketTransportFactory { }.create(endpoint)` returns a `WebSocketTransport` whose
+  `configureTls` is the same lambda instance — the factory threads the hook through.
+- A no-arg `WebSocketTransportFactory()` yields a transport with a `null` hook.
+- `supports()` and the `+` combinator still behave as before with a hook present.
+
+`jvmTest`:
+
+- Mirror of `TcpTransportTrustManagerTest`: a `trustManager` assigned inside the hook is still the
+  builder's `trustManager` after `configurePlatformTrust` runs. JVM's actual is a no-op, so this
+  proves the hook reaches ktor's real builder state rather than a discarded copy.
+- End-to-end, and the test that actually discharges the acceptance criterion rather than asserting
+  it: stand up a local `wss://` server with a generated self-signed certificate, then assert that
+  `WebSocketTransport().connect(…)` **fails** the handshake and that a transport built with a hook
+  installing a `KeyStore`-backed `TrustManagerFactory` manager **connects and round-trips a binary
+  frame** through `send`/`receive` against an echoing server. The server speaks WebSocket, not MQTT
+  — this proves the trust hook and the transport's framing, which is all that is in question here.
+  Test-only dependencies: `ktor-server-cio`,
+  `ktor-server-websockets`, and `ktor-network-tls-certificates` (for `buildKeyStore`). These are
+  `testImplementation`-scoped and do not affect the published artifacts or the zero-dependency
+  policy for main source sets.
+
+Not covered: the Android wrapping order, for the same reason as #103 —
+`X509TrustManagerExtensions` is a framework class, so proving a caller's manager ends up inside
+`HostnameAwareTrustManager` needs an instrumentation test. Out of scope; the single call site is
+the mitigation.
+
+Existing `spotlessCheck`, `detekt`, `allTests`, `apiCheck`, and `koverVerify` (≥80%) gates all
+apply. `wasmJsTest` must still pass, which exercises the wasmJs actual's compilation.
+
+## Documentation
+
+- `transport-ws/Module.md` — a private-CA usage snippet plus a trust section matching
+  `transport-tcp/Module.md`: caller-before-platform ordering, what installing a trust manager
+  replaces, and the per-target support table (JVM/Android useful; apple/linux invoked but inert;
+  mingw/wasmJs ignored).
+- `transport-tcp/Module.md` and the duplicated `PlatformTls` KDoc — cross-references naming the
+  sibling copy.
+- `README.md` TLS section — extend the #103 pointer to cover both transports, framed as the
+  replacement for the app-wide `<certificates src="user"/>` workaround.
+- `AGENTS.md` — correct the "no custom intermediate source set any more" statement to describe
+  `cioMain`.
+- `CHANGELOG.md` — an entry under the next release.
+
+## Out of scope (YAGNI)
+
+- No `host` parameter on the lambda — a factory can close over whatever it needs.
+- No caller-supplied `HttpClient` escape hatch, and no plugin-installation hook.
+- No `MqttConfig`-level plumbing or transport-neutral trust abstraction in `:core`.
+- No engine change on Windows, and no attempt to make native trust configurable.
+- No wasmJs target for `:transport-tcp`. `ktor-network` does publish a wasmJs klib as of 3.1.3, but
+  its socket implementation is Node-only — it imports `node:net` and resolves to `null` off Node —
+  and this project declares `wasmJs { browser() }`. Adding a `nodejs()` target is a separate
+  question.

--- a/docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md
+++ b/docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md
@@ -243,6 +243,10 @@ breaking ordinary `wss://` on Windows to gain a niche capability.
   `testImplementation`-scoped and do not affect the published artifacts or the zero-dependency
   policy for main source sets.
 
+  As-built note: the server engine actually used is `ktor-server-netty`, not `ktor-server-cio` as
+  drafted above — ktor's server-side CIO engine does not support HTTPS/TLS, which this test
+  requires. `ktor-server-netty` is `testImplementation`-scoped only, same as the other two.
+
 Not covered: the Android wrapping order, for the same reason as #103 —
 `X509TrustManagerExtensions` is a framework class, so proving a caller's manager ends up inside
 `HostnameAwareTrustManager` needs an instrumentation test. Out of scope; the single call site is

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,9 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-winhttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
+ktor-network-tls-certificates = { module = "io.ktor:ktor-network-tls-certificates", version.ref = "ktor" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
 kotlinx-io-bytestring = { module = "org.jetbrains.kotlinx:kotlinx-io-bytestring", version.ref = "kotlinx-io" }
 meshtastic-protobufs = { module = "org.meshtastic:protobufs", version.ref = "meshtastic-protobufs" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }

--- a/transport-tcp/Module.md
+++ b/transport-tcp/Module.md
@@ -49,3 +49,9 @@ Android actuals of `TLSConfigBuilder`; on Apple, Linux, and Windows the lambda s
 
 Available on JVM, Android, iOS, macOS, Linux, and Windows. Not available on the browser (wasmJs) —
 use `mqtt-client-transport-ws` there.
+
+`mqtt-client-transport-ws`'s `WebSocketTransportFactory` accepts the identical hook against the same
+`TLSConfigBuilder` type. If your app dials both `ssl://` and `wss://` endpoints — or a broker whose
+scheme isn't known ahead of time — configure the hook on **both** factories; a trust manager
+installed on only one leaves the other transport validating against the platform trust store alone.
+See `mqtt-client-transport-ws`'s Module.md for its per-target support table.

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt
@@ -31,6 +31,11 @@ import io.ktor.network.tls.TLSConfigBuilder
  *
  * On JVM and native targets, this is a no-op — the platform default suffices.
  *
+ * **Sibling copy.** The same logic is duplicated in
+ * `transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt` and its
+ * actuals, because `:transport-ws` cannot depend on this module. **Any fix here must be applied
+ * there too, and vice versa.**
+ *
  * @param host the broker host (DNS name or IP literal) used for trust evaluation.
  *   Unlike the SNI server name, this is never `null`: an IP literal is a valid
  *   host for the hostname-aware trust check even though it must not be sent as SNI.

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -276,7 +276,8 @@ internal fun isIpLiteral(host: String): Boolean {
  * Android's app-wide `network_security_config.xml` trust anchors:
  *
  * ```kotlin
- * transportFactory = TcpTransportFactory { trustManager = myTrustManager } + WebSocketTransportFactory()
+ * transportFactory = TcpTransportFactory { trustManager = myTrustManager } +
+ *     WebSocketTransportFactory { trustManager = myTrustManager }
  * ```
  *
  * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport

--- a/transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt
+++ b/transport-tcp/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransportTrustManagerTest.kt
@@ -51,7 +51,7 @@ class TcpTransportTrustManagerTest {
     @Test
     fun hookInstalledTrustManagerSurvivesApplyMqttTls() {
         val builder = TLSConfigBuilder()
-        builder.applyMqttTls("broker.example.com") { trustManager = FakeTrustManager }
+        builder.applyMqttTls("broker.example.com", configureTls = { trustManager = FakeTrustManager })
         assertSame(FakeTrustManager, builder.trustManager)
     }
 
@@ -61,7 +61,7 @@ class TcpTransportTrustManagerTest {
         // earlier SNI/trust coupling bug (Meshtastic-Android #5894) was exactly this
         // class of mistake.
         val builder = TLSConfigBuilder()
-        builder.applyMqttTls("192.168.1.50") { trustManager = FakeTrustManager }
+        builder.applyMqttTls("192.168.1.50", configureTls = { trustManager = FakeTrustManager })
         assertSame(FakeTrustManager, builder.trustManager)
     }
 
@@ -72,10 +72,13 @@ class TcpTransportTrustManagerTest {
         // configurePlatformTrust is a no-op, so that ordering is not observable here.
         var ranWithBuilder = false
         val builder = TLSConfigBuilder()
-        builder.applyMqttTls("broker.example.com") {
-            ranWithBuilder = true
-            trustManager = FakeTrustManager
-        }
+        builder.applyMqttTls(
+            "broker.example.com",
+            configureTls = {
+                ranWithBuilder = true
+                trustManager = FakeTrustManager
+            },
+        )
         assertNotNull(builder.trustManager)
         assertSame(FakeTrustManager, builder.trustManager)
         kotlin.test.assertTrue(ranWithBuilder)

--- a/transport-ws/Module.md
+++ b/transport-ws/Module.md
@@ -59,9 +59,18 @@ unconditionally. On Windows in particular, a private CA must be installed in the
 certificate store instead.
 
 This hook does not set the SNI server name itself: the CIO client derives SNI from the request URL,
-which is also what gates ktor's RFC 6125 subject-name check. A `serverName` assigned inside the hook
-does take precedence, though — it becomes the name the certificate is verified against, so it must
-be present in the certificate's subject names.
+which is also what gates ktor's RFC 6125 subject-name check. If the hook assigns `serverName`
+itself, that value wins over CIO's per-request SNI for every connection this factory makes — it
+becomes the name the certificate is checked against instead of the host actually being contacted, so
+the certificate is no longer bound to the host you're connecting to. Only do this if the value is
+guaranteed to be present in the certificate's subject names.
+
+Unlike `mqtt-client-transport-tcp`, this transport never suppresses SNI for IP-literal hosts: CIO
+sets `serverName` from the request host unconditionally, IP literals included. One trust manager
+serves both transports, but `ssl://192.168.1.50` and `wss://192.168.1.50/mqtt` do not present
+identical SNI/name-verification behaviour — the TCP transport omits SNI for that address, the
+WebSocket transport sends it. IP-only private brokers are a common target for this feature, so this
+is worth knowing before you rely on parity between the two.
 
 Available on every target, including the browser (wasmJs) — where it is the only supported
 transport.

--- a/transport-ws/Module.md
+++ b/transport-ws/Module.md
@@ -12,5 +12,56 @@ val client = MqttClient("sensor") {
 client.connect(MqttEndpoint.WebSocket("wss://broker.example.com/mqtt"))
 ```
 
+## Trusting a private CA
+
+If the broker's certificate is issued by a private or self-signed CA that is not in the platform
+trust store, pass a TLS customisation lambda. It receives ktor's `TLSConfigBuilder` — the same type
+`mqtt-client-transport-tcp` uses, so one trust manager can serve both transports:
+
+```kotlin
+val client = MqttClient("sensor") {
+    transportFactory = TcpTransportFactory { trustManager = myTrustManager } +
+        WebSocketTransportFactory { trustManager = myTrustManager }
+}
+```
+
+The lambda is applied before platform trust configuration. On Android that ordering means the trust
+manager on the builder is reached through the hostname-aware
+`checkServerTrusted(chain, authType, hostname)` overload, which the platform requires whenever
+`network_security_config.xml` holds any domain-specific configuration.
+
+Be precise about what that does *not* buy you. Installing your own trust manager **replaces the
+platform's trust decision**: your anchors are used instead of the platform's, and
+`network_security_config.xml` anchors, certificate pinning, and Certificate Transparency policy are
+then enforced only insofar as your manager enforces them itself. Those platform policies apply as
+before only if you leave `trustManager` unset. Wrapping preserves the hostname-aware *call path*,
+not the platform's *policy*.
+
+On Android the manager must be one `X509TrustManagerExtensions` can wrap: either obtained from a
+`TrustManagerFactory`, or declaring the three-arg `checkServerTrusted(chain, authType, host)` that
+the platform looks up reflectively. Otherwise the handshake fails with an `IllegalArgumentException`
+explaining this.
+
+The added trust applies only to this MQTT connection — unlike Android's app-wide
+`network_security_config.xml` trust anchors.
+
+Where the hook takes effect depends on the platform's ktor engine:
+
+| Target | Engine | `configureTls` |
+| --- | --- | --- |
+| JVM, Android | CIO | Honoured; `trustManager` available |
+| iOS, macOS, Linux | CIO | Invoked, but `TLSConfigBuilder` has no `trustManager` there |
+| Windows | WinHttp | **Ignored** — the engine exposes no TLS-configuration surface |
+| Browser (wasmJs) | Js | **Ignored** — a page cannot influence TLS trust |
+
+The two ignored cases are deliberately silent so that shared common code can pass the hook
+unconditionally. On Windows in particular, a private CA must be installed in the system
+certificate store instead.
+
+This hook does not set the SNI server name itself: the CIO client derives SNI from the request URL,
+which is also what gates ktor's RFC 6125 subject-name check. A `serverName` assigned inside the hook
+does take precedence, though — it becomes the name the certificate is verified against, so it must
+be present in the certificate's subject names.
+
 Available on every target, including the browser (wasmJs) — where it is the only supported
 transport.

--- a/transport-ws/Module.md
+++ b/transport-ws/Module.md
@@ -25,6 +25,9 @@ val client = MqttClient("sensor") {
 }
 ```
 
+(`trustManager` itself is available only on the JVM and Android actuals of `TLSConfigBuilder` — see
+the per-target table below for the other platforms.)
+
 The lambda is applied before platform trust configuration. On Android that ordering means the trust
 manager on the builder is reached through the hostname-aware
 `checkServerTrusted(chain, authType, hostname)` overload, which the platform requires whenever

--- a/transport-ws/api/jvm/transport-ws.api
+++ b/transport-ws/api/jvm/transport-ws.api
@@ -1,6 +1,8 @@
 public final class org/meshtastic/mqtt/transport/ws/WebSocketTransport : org/meshtastic/mqtt/MqttTransport {
 	public static final field MAX_FRAME_SIZE J
 	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun connect (Lorg/meshtastic/mqtt/MqttEndpoint;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun isConnected ()Z
@@ -10,6 +12,8 @@ public final class org/meshtastic/mqtt/transport/ws/WebSocketTransport : org/mes
 
 public final class org/meshtastic/mqtt/transport/ws/WebSocketTransportFactory : org/meshtastic/mqtt/MqttTransportFactory {
 	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Lorg/meshtastic/mqtt/MqttEndpoint;)Lorg/meshtastic/mqtt/MqttTransport;
 	public fun supports (Lorg/meshtastic/mqtt/MqttEndpoint;)Z
 }

--- a/transport-ws/api/transport-ws.klib.api
+++ b/transport-ws/api/transport-ws.klib.api
@@ -8,6 +8,7 @@
 // Library unique name: <MQTTastic-Client-KMP:transport-ws>
 final class org.meshtastic.mqtt.transport.ws/WebSocketTransport : org.meshtastic.mqtt/MqttTransport { // org.meshtastic.mqtt.transport.ws/WebSocketTransport|null[0]
     constructor <init>() // org.meshtastic.mqtt.transport.ws/WebSocketTransport.<init>|<init>(){}[0]
+    constructor <init>(kotlin/Function1<io.ktor.network.tls/TLSConfigBuilder, kotlin/Unit>? = ...) // org.meshtastic.mqtt.transport.ws/WebSocketTransport.<init>|<init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder,kotlin.Unit>?){}[0]
 
     final val isConnected // org.meshtastic.mqtt.transport.ws/WebSocketTransport.isConnected|{}isConnected[0]
         final fun <get-isConnected>(): kotlin/Boolean // org.meshtastic.mqtt.transport.ws/WebSocketTransport.isConnected.<get-isConnected>|<get-isConnected>(){}[0]
@@ -20,6 +21,7 @@ final class org.meshtastic.mqtt.transport.ws/WebSocketTransport : org.meshtastic
 
 final class org.meshtastic.mqtt.transport.ws/WebSocketTransportFactory : org.meshtastic.mqtt/MqttTransportFactory { // org.meshtastic.mqtt.transport.ws/WebSocketTransportFactory|null[0]
     constructor <init>() // org.meshtastic.mqtt.transport.ws/WebSocketTransportFactory.<init>|<init>(){}[0]
+    constructor <init>(kotlin/Function1<io.ktor.network.tls/TLSConfigBuilder, kotlin/Unit>? = ...) // org.meshtastic.mqtt.transport.ws/WebSocketTransportFactory.<init>|<init>(kotlin.Function1<io.ktor.network.tls.TLSConfigBuilder,kotlin.Unit>?){}[0]
 
     final fun create(org.meshtastic.mqtt/MqttEndpoint): org.meshtastic.mqtt/MqttTransport // org.meshtastic.mqtt.transport.ws/WebSocketTransportFactory.create|create(org.meshtastic.mqtt.MqttEndpoint){}[0]
     final fun supports(org.meshtastic.mqtt/MqttEndpoint): kotlin/Boolean // org.meshtastic.mqtt.transport.ws/WebSocketTransportFactory.supports|supports(org.meshtastic.mqtt.MqttEndpoint){}[0]

--- a/transport-ws/build.gradle.kts
+++ b/transport-ws/build.gradle.kts
@@ -58,6 +58,11 @@ kotlin {
             api(project(":core"))
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.websockets)
+            // api, not implementation: TLSConfigBuilder appears in WebSocketTransportFactory's
+            // public constructor signature, so consumers need it on their compile classpath.
+            // ktor-network-tls publishes a klib for every target this module builds, wasmJs
+            // included — `trustManager` is a JVM/Android-only property of that builder.
+            api(libs.ktor.network.tls)
         }
 
         cioMain.dependencies {

--- a/transport-ws/build.gradle.kts
+++ b/transport-ws/build.gradle.kts
@@ -48,8 +48,9 @@ kotlin {
     sourceSets {
         val commonMain by getting
         // Intermediate source set for the four targets that use the CIO engine. It holds the
-        // single CIO client builder and, from Task 3, the TLS trust plumbing — written once
-        // instead of four times. Deliberately spans JVM-family and native targets, so it may
+        // single CIO client builder and the TLS trust plumbing (applyWsTls and the
+        // configurePlatformTrust expect/actuals) — written once instead of four times per
+        // target. Deliberately spans JVM-family and native targets, so it may
         // only use API present in both (CIO and TLSConfigBuilder both are; TLSConfigBuilder's
         // JVM-only `trustManager` is touched solely from the androidMain actual).
         val cioMain by creating { dependsOn(commonMain) }

--- a/transport-ws/build.gradle.kts
+++ b/transport-ws/build.gradle.kts
@@ -81,6 +81,16 @@ kotlin {
         wasmJsMain.dependencies {
             implementation(libs.ktor.client.js)
         }
+
+        jvmTest.get().dependencies {
+            // Test-only: a local wss:// server with a generated self-signed certificate, so the
+            // private-CA path is proven rather than asserted. Not part of the published artifact.
+            // Netty, not CIO: ktor's server-side CIO engine rejects HTTPS connectors outright
+            // ("CIO Engine does not currently support HTTPS").
+            implementation(libs.ktor.server.netty)
+            implementation(libs.ktor.server.websockets)
+            implementation(libs.ktor.network.tls.certificates)
+        }
     }
 }
 

--- a/transport-ws/build.gradle.kts
+++ b/transport-ws/build.gradle.kts
@@ -46,25 +46,30 @@ kotlin {
     }
 
     sourceSets {
+        val commonMain by getting
+        // Intermediate source set for the four targets that use the CIO engine. It holds the
+        // single CIO client builder and, from Task 3, the TLS trust plumbing — written once
+        // instead of four times. Deliberately spans JVM-family and native targets, so it may
+        // only use API present in both (CIO and TLSConfigBuilder both are; TLSConfigBuilder's
+        // JVM-only `trustManager` is touched solely from the androidMain actual).
+        val cioMain by creating { dependsOn(commonMain) }
+
         commonMain.dependencies {
             api(project(":core"))
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.websockets)
         }
 
-        // Ktor HttpClient engines — one per platform family for WebSocket auto-detection.
-        jvmMain.get().dependencies {
+        cioMain.dependencies {
             implementation(libs.ktor.client.cio)
         }
-        findByName("androidMain")?.dependencies {
-            implementation(libs.ktor.client.cio)
-        }
-        findByName("appleMain")?.dependencies {
-            implementation(libs.ktor.client.cio)
-        }
-        findByName("linuxMain")?.dependencies {
-            implementation(libs.ktor.client.cio)
-        }
+
+        // Ktor HttpClient engines — CIO where available, platform engines elsewhere.
+        jvmMain.get().dependsOn(cioMain)
+        findByName("androidMain")?.dependsOn(cioMain)
+        findByName("appleMain")?.dependsOn(cioMain)
+        findByName("linuxMain")?.dependsOn(cioMain)
+
         findByName("mingwMain")?.dependencies {
             implementation(libs.ktor.client.winhttp)
         }

--- a/transport-ws/src/androidMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.android.kt
+++ b/transport-ws/src/androidMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.android.kt
@@ -36,7 +36,9 @@ import javax.net.ssl.X509TrustManager
  * overload throws whenever the config has *any* domain-specific entry, independent of
  * the target host, so an IP-only broker (a common private-broker setup) hits the same
  * failure. The [host] — an IP literal or DNS name — is a valid argument for the 3-arg
- * overload even though an IP must never be sent as the TLS SNI server name.
+ * overload even though an IP must never be sent as the TLS SNI server name in
+ * `:transport-tcp`; unlike that module, this one's CIO client does send the IP literal
+ * as SNI (see `WsHttpClient.cio.kt`), which does not affect this function's own behaviour.
  *
  * **Constraint on caller-supplied trust managers.** Whatever [X509TrustManager] is on the
  * builder must be one Android can wrap for hostname-aware checking. In practice that means it

--- a/transport-ws/src/androidMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.android.kt
+++ b/transport-ws/src/androidMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.android.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import android.net.http.X509TrustManagerExtensions
+import io.ktor.network.tls.TLSConfigBuilder
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * On Android, installs a hostname-aware [X509TrustManager] that delegates to the
+ * platform default via [X509TrustManagerExtensions].
+ *
+ * Android's `NetworkSecurityTrustManager` (injected when `network_security_config.xml`
+ * has domain-specific rules) throws from the standard 2-arg `checkServerTrusted` and
+ * requires the 3-arg hostname-aware overload. Ktor's TLS handshake only calls the
+ * 2-arg version, so we intercept and route through the extensions API.
+ *
+ * This runs for IP-literal brokers as well as DNS hostnames: the platform's 2-arg
+ * overload throws whenever the config has *any* domain-specific entry, independent of
+ * the target host, so an IP-only broker (a common private-broker setup) hits the same
+ * failure. The [host] — an IP literal or DNS name — is a valid argument for the 3-arg
+ * overload even though an IP must never be sent as the TLS SNI server name.
+ *
+ * **Constraint on caller-supplied trust managers.** Whatever [X509TrustManager] is on the
+ * builder must be one Android can wrap for hostname-aware checking. In practice that means it
+ * must come from a [TrustManagerFactory] (which yields the platform's `TrustManagerImpl`), or
+ * it must itself declare a `checkServerTrusted(X509Certificate[], String, String)` method.
+ * A hand-written `X509TrustManager` that implements only the two-arg overloads cannot be
+ * wrapped, and this function throws [IllegalArgumentException] rather than silently dropping
+ * Android's policy checks. To trust a private CA, load it into a [KeyStore] and initialise a
+ * [TrustManagerFactory] with that store.
+ *
+ * Note that the hostname passed to the 3-arg overload drives network-security-config lookup,
+ * certificate pinning, and Certificate Transparency policy — it does **not** perform RFC 6125
+ * subject-name matching. That comes from ktor and only when the SNI server name is set.
+ *
+ * **Sibling copy** of `:transport-tcp`'s `PlatformTls.android.kt`. Any fix here must be applied
+ * there too, and vice versa.
+ */
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
+    if (host.isBlank()) return
+
+    val baseTm =
+        (trustManager as? X509TrustManager) ?: run {
+            val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+            tmf.init(null as KeyStore?)
+            tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+        }
+
+    trustManager =
+        try {
+            HostnameAwareTrustManager(baseTm, host)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException(
+                "Android cannot wrap the configured X509TrustManager (${baseTm::class.java.name}) " +
+                    "for hostname-aware certificate checking. The trust manager must either be " +
+                    "obtained from TrustManagerFactory (which yields the platform TrustManagerImpl) " +
+                    "or declare checkServerTrusted(X509Certificate[], String, String). To trust a " +
+                    "private CA, load it into a KeyStore and initialise a TrustManagerFactory with " +
+                    "that KeyStore instead of hand-implementing X509TrustManager.",
+                e,
+            )
+        }
+}
+
+/**
+ * Wraps a platform [X509TrustManager] so that the 2-arg `checkServerTrusted` call
+ * (which is all Ktor invokes) is routed through Android's hostname-aware
+ * [X509TrustManagerExtensions.checkServerTrusted] overload.
+ */
+private class HostnameAwareTrustManager(
+    private val delegate: X509TrustManager,
+    private val hostname: String,
+) : X509TrustManager {
+    private val extensions = X509TrustManagerExtensions(delegate)
+
+    override fun checkClientTrusted(
+        chain: Array<out X509Certificate>,
+        authType: String,
+    ) {
+        delegate.checkClientTrusted(chain, authType)
+    }
+
+    override fun checkServerTrusted(
+        chain: Array<out X509Certificate>,
+        authType: String,
+    ) {
+        // Route through the hostname-aware overload to satisfy NetworkSecurityTrustManager.
+        extensions.checkServerTrusted(chain, authType, hostname)
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = delegate.acceptedIssuers
+}

--- a/transport-ws/src/appleMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.apple.kt
+++ b/transport-ws/src/appleMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.apple.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/** See the sibling note on the `expect` declaration: mirrored in `:transport-tcp`. */
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
+    // No-op: native TLSConfigBuilder does not expose a trustManager property.
+}

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * Applies platform-specific TLS trust configuration to the [TLSConfigBuilder].
+ *
+ * On Android, this installs a hostname-aware trust manager that satisfies
+ * `NetworkSecurityTrustManager`'s requirement for the 3-arg
+ * `checkServerTrusted(chain, authType, hostname)` overload when `network_security_config.xml`
+ * contains domain-specific configurations. The platform throws from the 2-arg overload whenever
+ * *any* domain-specific config is present — regardless of the target host — so this must run for
+ * IP-literal brokers too, not only DNS hostnames.
+ *
+ * On JVM, Apple, and Linux this is a no-op — the platform default suffices, and non-JVM
+ * `TLSConfigBuilder` has no `trustManager` property at all.
+ *
+ * **Sibling copy.** `:transport-ws` cannot depend on `:transport-tcp` — that module has no wasmJs
+ * target, and WS-only consumers should not pull a TCP artifact — so this logic is deliberately
+ * duplicated from
+ * `transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/PlatformTls.kt` and its
+ * per-platform actuals. **Any fix here must be applied there too, and vice versa.**
+ *
+ * @param host the broker host (DNS name or IP literal) used for trust evaluation.
+ */
+internal expect fun TLSConfigBuilder.configurePlatformTrust(host: String)
+
+/**
+ * Applies the MQTT TLS configuration to this [TLSConfigBuilder] in the one correct order:
+ *
+ * 1. [configureTls] — the caller's hook, so it can install its own trust manager (e.g. a private CA).
+ * 2. [configurePlatformTrust] — reads whatever trust manager is now on the builder and, on Android,
+ *    wraps it in a hostname-aware delegate.
+ *
+ * Step 1 must precede step 2. What step 2 provides is the call path: whatever trust manager is on
+ * the builder is reached through Android's hostname-aware
+ * `checkServerTrusted(chain, authType, hostname)` overload, which `NetworkSecurityTrustManager`
+ * requires whenever `network_security_config.xml` holds any domain-specific configuration.
+ * Reversing the two steps would discard that wrapper, leaving ktor's 2-arg call to hit the bare
+ * manager.
+ *
+ * Be precise about what this ordering does *not* provide. Installing a trust manager via
+ * [configureTls] *replaces the platform's trust decision*: that manager's anchors are used instead
+ * of the platform's, and `network_security_config.xml` anchors, certificate pinning, and
+ * Certificate Transparency policy are then enforced only insofar as that manager enforces them
+ * itself. Wrapping preserves the hostname-aware *call path*, not the platform's *policy*.
+ *
+ * Unlike `:transport-tcp`'s `applyMqttTls`, this does not set `serverName`: the CIO client derives
+ * SNI — and with it ktor's RFC 6125 subject-name check — from the request URL when it opens the
+ * connection, whereas this runs once at client construction.
+ *
+ * @param host the broker host (DNS name or IP literal), used for trust evaluation.
+ * @param configureTls optional caller customisation; `null` preserves the default behaviour.
+ * @param platformTrust test seam for [configurePlatformTrust]; production callers use the default.
+ */
+internal fun TLSConfigBuilder.applyWsTls(
+    host: String,
+    configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+    platformTrust: TLSConfigBuilder.(String) -> Unit = { configurePlatformTrust(it) },
+) {
+    configureTls?.invoke(this)
+    platformTrust(host)
+}

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
@@ -29,7 +29,7 @@ import io.ktor.network.tls.TLSConfigBuilder
  * derives SNI from the request URL when it opens the connection, whereas this block runs once at
  * client construction. A `serverName` a caller does assign inside the hook is *not* overwritten by
  * CIO's per-request SNI — it wins, and ktor verifies the certificate's subject names against it, so
- * setting it to anything other than the broker's own hostname breaks the handshake (verified by
+ * the value must be present among the broker certificate's subject names (verified by
  * `WebSocketPrivateCaTest.serverNameSetInsideTheHookWinsOverCioRequestSni`).
  */
 internal actual fun buildWsHttpClient(

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
@@ -27,7 +27,10 @@ import io.ktor.network.tls.TLSConfigBuilder
  * The caller's hook is applied to CIO's `https` [TLSConfigBuilder], which is the same builder
  * type `:transport-tcp` configures. `serverName` is deliberately not set here: the CIO *client*
  * derives SNI from the request URL when it opens the connection, whereas this block runs once at
- * client construction.
+ * client construction. A `serverName` a caller does assign inside the hook is *not* overwritten by
+ * CIO's per-request SNI — it wins, and ktor verifies the certificate's subject names against it, so
+ * setting it to anything other than the broker's own hostname breaks the handshake (verified by
+ * `WebSocketPrivateCaTest.serverNameSetInsideTheHookWinsOverCioRequestSni`).
  */
 internal actual fun buildWsHttpClient(
     host: String,

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
@@ -27,9 +27,11 @@ import io.ktor.network.tls.TLSConfigBuilder
  * The caller's hook is applied to CIO's `https` [TLSConfigBuilder], which is the same builder
  * type `:transport-tcp` configures. `serverName` is deliberately not set here: the CIO *client*
  * derives SNI from the request URL when it opens the connection, whereas this block runs once at
- * client construction. A `serverName` a caller does assign inside the hook is *not* overwritten by
- * CIO's per-request SNI — it wins, and ktor verifies the certificate's subject names against it, so
- * the value must be present among the broker certificate's subject names (verified by
+ * client construction. If the hook assigns `serverName` itself, that value is *not* overwritten by
+ * CIO's per-request SNI — it wins, for every connection this factory makes, and ktor verifies the
+ * certificate's subject names against it instead of the host actually being contacted. Assigning
+ * the wrong name there silently rebinds trust to that name, so do not set it unless the value is
+ * guaranteed to be present among the broker certificate's subject names (verified by
  * `WebSocketPrivateCaTest.serverNameSetInsideTheHookWinsOverCioRequestSni`).
  */
 internal actual fun buildWsHttpClient(

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
@@ -19,11 +19,28 @@ package org.meshtastic.mqtt.transport.ws
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.network.tls.TLSConfigBuilder
 
-/** CIO engine — JVM, Android, Apple, and Linux. */
-internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+/**
+ * CIO engine — JVM, Android, Apple, and Linux.
+ *
+ * The caller's hook is applied to CIO's `https` [TLSConfigBuilder], which is the same builder
+ * type `:transport-tcp` configures. `serverName` is deliberately not set here: the CIO *client*
+ * derives SNI from the request URL when it opens the connection, whereas this block runs once at
+ * client construction.
+ */
+internal actual fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient =
     HttpClient(CIO) {
         install(WebSockets) {
             this.maxFrameSize = maxFrameSize
+        }
+        engine {
+            https {
+                configureTls?.invoke(this)
+            }
         }
     }

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+
+/** CIO engine — JVM, Android, Apple, and Linux. */
+internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+    HttpClient(CIO) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }

--- a/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
+++ b/transport-ws/src/cioMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.cio.kt
@@ -40,7 +40,7 @@ internal actual fun buildWsHttpClient(
         }
         engine {
             https {
-                configureTls?.invoke(this)
+                applyWsTls(host, configureTls)
             }
         }
     }

--- a/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
+++ b/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
@@ -19,6 +19,8 @@ package org.meshtastic.mqtt.transport.ws
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.http.Url
+import io.ktor.network.tls.TLSConfigBuilder
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readBytes
@@ -32,11 +34,19 @@ import org.meshtastic.mqtt.MqttTransportFactory
 /**
  * WebSocket-based [MqttTransport] for all platforms, including the browser (wasmJs).
  *
- * Uses Ktor's multiplatform HttpClient with engine auto-detection (CIO on JVM/Android/Apple/Linux,
+ * Uses Ktor's multiplatform HttpClient with a per-platform engine (CIO on JVM/Android/Apple/Linux,
  * WinHttp on Windows, Js on wasmJs/browser). One binary WebSocket frame = one complete MQTT packet,
  * so no stream parsing is needed — the WebSocket layer handles framing.
+ *
+ * @param configureTls optional hook applied to the engine's TLS configuration before platform
+ *   trust is configured. Use it to trust a private or self-signed CA for this connection only.
+ *   Honoured on JVM, Android, Apple, and Linux; ignored on Windows and in the browser.
  */
-public class WebSocketTransport : MqttTransport {
+public class WebSocketTransport(
+    internal val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransport {
+    public constructor() : this(null)
+
     private var client: HttpClient? = null
     private var session: DefaultClientWebSocketSession? = null
     private val sendMutex = Mutex()
@@ -52,7 +62,7 @@ public class WebSocketTransport : MqttTransport {
         // Close any existing connection to prevent resource leaks on reconnect
         close()
 
-        val httpClient = buildWsHttpClient(MAX_FRAME_SIZE)
+        val httpClient = buildWsHttpClient(Url(endpoint.url).host, MAX_FRAME_SIZE, configureTls)
         client = httpClient
 
         val wsSession =
@@ -117,9 +127,31 @@ public class WebSocketTransport : MqttTransport {
  * Add `org.meshtastic:mqtt-client-transport-ws` and pass an instance to
  * [org.meshtastic.mqtt.MqttConfig.Builder.transportFactory]. This is the only transport available
  * on the browser (wasmJs) target.
+ *
+ * To trust a broker whose certificate chain is not in the platform CA store — a private or
+ * self-signed CA — supply [configureTls]. The scope is this MQTT connection only, unlike Android's
+ * app-wide `network_security_config.xml` trust anchors:
+ *
+ * ```kotlin
+ * transportFactory = WebSocketTransportFactory { trustManager = myTrustManager }
+ * ```
+ *
+ * @param configureTls optional hook applied to ktor's [TLSConfigBuilder] for every transport this
+ *   factory creates. It runs before platform trust is configured, so on Android a trust manager
+ *   installed here is reached through the hostname-aware `checkServerTrusted` overload rather than
+ *   bypassing it. Note that installing a trust manager replaces the platform's trust decision —
+ *   network-security-config anchors, pinning, and Certificate Transparency policy then hold only
+ *   insofar as that manager enforces them. Honoured on JVM, Android, Apple, and Linux; silently
+ *   ignored on Windows (WinHttp has no TLS-config surface) and in the browser (which cannot
+ *   influence trust). On Apple and Linux `TLSConfigBuilder` has no `trustManager`, so little is
+ *   configurable there in practice.
  */
-public class WebSocketTransportFactory : MqttTransportFactory {
+public class WebSocketTransportFactory(
+    private val configureTls: (TLSConfigBuilder.() -> Unit)? = null,
+) : MqttTransportFactory {
+    public constructor() : this(null)
+
     override fun supports(endpoint: MqttEndpoint): Boolean = endpoint is MqttEndpoint.WebSocket
 
-    override fun create(endpoint: MqttEndpoint): MqttTransport = WebSocketTransport()
+    override fun create(endpoint: MqttEndpoint): MqttTransport = WebSocketTransport(configureTls)
 }

--- a/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
+++ b/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
@@ -18,7 +18,6 @@ package org.meshtastic.mqtt.transport.ws
 
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
-import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
@@ -53,12 +52,7 @@ public class WebSocketTransport : MqttTransport {
         // Close any existing connection to prevent resource leaks on reconnect
         close()
 
-        val httpClient =
-            HttpClient {
-                install(WebSockets) {
-                    maxFrameSize = MAX_FRAME_SIZE
-                }
-            }
+        val httpClient = buildWsHttpClient(MAX_FRAME_SIZE)
         client = httpClient
 
         val wsSession =

--- a/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt
+++ b/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.mqtt.transport.ws
 
 import io.ktor.client.HttpClient
+import io.ktor.network.tls.TLSConfigBuilder
 
 /**
  * Builds the [HttpClient] used for the WebSocket connection, with the WebSockets plugin
@@ -25,6 +26,17 @@ import io.ktor.client.HttpClient
  * Engine auto-detection cannot be used here: configuring engine-level TLS requires naming
  * the engine, and a star-projected `HttpClientConfig<*>` cannot reach `engine { }` at all.
  *
+ * [configureTls] is honoured only where the engine exposes a TLS configuration — CIO, on JVM,
+ * Android, Apple, and Linux. On Windows (WinHttp) and in the browser (wasmJs / Js) it is
+ * silently ignored: WinHttp exposes no TLS-config surface and the browser cannot influence
+ * trust at all.
+ *
+ * @param host the broker host from the endpoint URL, used for trust evaluation.
  * @param maxFrameSize the WebSocket frame safety cap, in bytes.
+ * @param configureTls optional caller customisation of the engine's TLS configuration.
  */
-internal expect fun buildWsHttpClient(maxFrameSize: Long): HttpClient
+internal expect fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient

--- a/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt
+++ b/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+
+/**
+ * Builds the [HttpClient] used for the WebSocket connection, with the WebSockets plugin
+ * installed and a platform-appropriate engine selected.
+ *
+ * Engine auto-detection cannot be used here: configuring engine-level TLS requires naming
+ * the engine, and a star-projected `HttpClientConfig<*>` cannot reach `engine { }` at all.
+ *
+ * @param maxFrameSize the WebSocket frame safety cap, in bytes.
+ */
+internal expect fun buildWsHttpClient(maxFrameSize: Long): HttpClient

--- a/transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTlsTest.kt
+++ b/transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTlsTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+import org.meshtastic.mqtt.MqttEndpoint
+import org.meshtastic.mqtt.plus
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Covers the caller-supplied TLS hook on [WebSocketTransportFactory] (issue #107).
+ *
+ * The hook only runs during a real TLS handshake, so these tests pin the surrounding
+ * contract: endpoint selection, transport type, hook forwarding, and `+` composition.
+ * The handshake itself is covered by the JVM end-to-end test in Task 5.
+ */
+class WebSocketTransportFactoryTlsTest {
+    private val endpoint = MqttEndpoint.WebSocket("wss://broker.example.com/mqtt")
+
+    @Test
+    fun factoryWithTlsHookStillSupportsOnlyWebSocketEndpoints() {
+        val factory = WebSocketTransportFactory { serverName = "override.example.com" }
+        assertTrue(factory.supports(endpoint))
+        assertFalse(factory.supports(MqttEndpoint.Tcp("broker.example.com")))
+    }
+
+    @Test
+    fun factoryForwardsTlsHookToCreatedTransport() {
+        // Guards against create() silently dropping configureTls: the transport must hold the
+        // very lambda instance the factory was constructed with.
+        val hook: TLSConfigBuilder.() -> Unit = { serverName = "override.example.com" }
+        val transport = WebSocketTransportFactory(hook).create(endpoint)
+        assertIs<WebSocketTransport>(transport)
+        assertSame(hook, transport.configureTls)
+    }
+
+    @Test
+    fun noArgFactoryProducesTransportWithoutHook() {
+        val transport = WebSocketTransportFactory().create(endpoint)
+        assertIs<WebSocketTransport>(transport)
+        assertNull(transport.configureTls)
+    }
+
+    @Test
+    fun factoryWithTlsHookStillComposesWithPlus() {
+        val combined =
+            WebSocketTransportFactory { serverName = "override.example.com" } +
+                WebSocketTransportFactory()
+        assertIs<WebSocketTransport>(combined.create(endpoint))
+    }
+}

--- a/transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTlsTest.kt
+++ b/transport-ws/src/commonTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransportFactoryTlsTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertTrue
  *
  * The hook only runs during a real TLS handshake, so these tests pin the surrounding
  * contract: endpoint selection, transport type, hook forwarding, and `+` composition.
- * The handshake itself is covered by the JVM end-to-end test in Task 5.
+ * The handshake itself is covered by the JVM end-to-end test, [WebSocketPrivateCaTest].
  */
 class WebSocketTransportFactoryTlsTest {
     private val endpoint = MqttEndpoint.WebSocket("wss://broker.example.com/mqtt")

--- a/transport-ws/src/jvmMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.jvm.kt
+++ b/transport-ws/src/jvmMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.jvm.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/** See the sibling note on the `expect` declaration: mirrored in `:transport-tcp`. */
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
+    // No-op: JVM's default X509TrustManager handles the 2-arg checkServerTrusted correctly.
+}

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
@@ -44,6 +44,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -123,9 +124,17 @@ class WebSocketPrivateCaTest {
 
     @AfterTest
     fun stopServer() {
-        server?.stop(gracePeriodMillis = 0, timeoutMillis = 1_000)
-        keyStoreFile?.delete()
-        nettyLogger.level = previousNettyLevel
+        // Each cleanup step must run even if an earlier one throws — mirrors the nested
+        // try/finally pattern in TcpTransport.close().
+        try {
+            server?.stop(gracePeriodMillis = 0, timeoutMillis = 1_000)
+        } finally {
+            try {
+                keyStoreFile?.delete()
+            } finally {
+                nettyLogger.level = previousNettyLevel
+            }
+        }
     }
 
     private val endpoint get() = MqttEndpoint.WebSocket("wss://localhost:$port/mqtt")
@@ -200,6 +209,26 @@ class WebSocketPrivateCaTest {
                     assertFailsWith<TLSException> {
                         withTimeout(20_000) { transport.connect(endpoint) }
                     }
+                // The type check alone cannot distinguish "serverName reached certificate
+                // verification" from "serverName was silently discarded and some other TLS
+                // failure occurred" — both throw TLSException. The substring check on the message
+                // is what proves the hook's serverName specifically drove subject-name
+                // verification, so it stays even though message text is comparatively brittle: a
+                // ktor wording change degrades this assertion rather than the type check, which
+                // still passes.
+                // The type check alone cannot distinguish "serverName reached certificate
+                // verification" from "serverName was silently discarded and some unrelated TLS
+                // failure occurred" — both would surface as TLSException here. The substring
+                // check on the message is what proves the hook's serverName specifically drove
+                // subject-name verification, so it stays even though message text is
+                // comparatively brittle: a ktor wording change degrades this assertion (and
+                // this one alone) rather than breaking the test outright, since the type checks
+                // below still hold.
+                assertIs<TLSException>(
+                    failure.cause,
+                    "expected the TLSException to be caused by a nested certificate-verification " +
+                        "TLSException, got: ${failure.cause}",
+                )
                 assertTrue(
                     failure.message.orEmpty().contains("not-the-server.example.com"),
                     "expected subject-name verification against the hook's serverName, got: ${failure.message}",

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
@@ -210,20 +210,12 @@ class WebSocketPrivateCaTest {
                         withTimeout(20_000) { transport.connect(endpoint) }
                     }
                 // The type check alone cannot distinguish "serverName reached certificate
-                // verification" from "serverName was silently discarded and some other TLS
-                // failure occurred" — both throw TLSException. The substring check on the message
-                // is what proves the hook's serverName specifically drove subject-name
-                // verification, so it stays even though message text is comparatively brittle: a
-                // ktor wording change degrades this assertion rather than the type check, which
-                // still passes.
-                // The type check alone cannot distinguish "serverName reached certificate
                 // verification" from "serverName was silently discarded and some unrelated TLS
                 // failure occurred" — both would surface as TLSException here. The substring
                 // check on the message is what proves the hook's serverName specifically drove
                 // subject-name verification, so it stays even though message text is
-                // comparatively brittle: a ktor wording change degrades this assertion (and
-                // this one alone) rather than breaking the test outright, since the type checks
-                // below still hold.
+                // comparatively brittle: a ktor wording change degrades that one assertion
+                // rather than breaking the test outright, since the type check below still holds.
                 assertIs<TLSException>(
                     failure.cause,
                     "expected the TLSException to be caused by a nested certificate-verification " +

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSException
+import io.ktor.network.tls.certificates.buildKeyStore
+import io.ktor.server.application.install
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.applicationEnvironment
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.engine.sslConnector
+import io.ktor.server.netty.Netty
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.meshtastic.mqtt.MqttEndpoint
+import java.io.File
+import java.security.KeyStore
+import java.security.cert.CertPathBuilderException
+import java.security.cert.CertPathValidatorException
+import java.util.logging.Level
+import java.util.logging.Logger
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end proof of issue #107's acceptance criterion: a `wss://` broker whose certificate is
+ * anchored in a private CA is reachable through the [WebSocketTransportFactory] hook alone, with
+ * no app-wide or JVM-wide trust changes.
+ *
+ * The server speaks WebSocket, not MQTT — what is under test is the TLS trust decision and the
+ * transport's binary framing, not the protocol layered on top.
+ */
+class WebSocketPrivateCaTest {
+    private val alias = "mqtt-ws-test"
+    private val password = "changeit"
+    private lateinit var keyStoreFile: File
+    private lateinit var keyStore: KeyStore
+    private var port = 0
+    private var server: EmbeddedServer<*, *>? = null
+    private val nettyLogger: Logger = Logger.getLogger("io.netty")
+
+    @BeforeTest
+    fun startServer() {
+        // Two of the three tests deliberately fail the handshake; Netty logs each one at WARNING.
+        // Silence it so a passing run has clean output. The Logger must be held in a field —
+        // java.util.logging discards the configuration of unreferenced Logger instances.
+        nettyLogger.level = Level.OFF
+
+        keyStore =
+            buildKeyStore {
+                certificate(alias) {
+                    this.password = this@WebSocketPrivateCaTest.password
+                    domains = listOf("localhost")
+                }
+            }
+        keyStoreFile = File.createTempFile("mqtt-ws-test", ".jks")
+        keyStoreFile.outputStream().use { keyStore.store(it, password.toCharArray()) }
+
+        val embedded =
+            embeddedServer(Netty, environment = applicationEnvironment { }, configure = {
+                sslConnector(
+                    keyStore = keyStore,
+                    keyAlias = alias,
+                    keyStorePassword = { password.toCharArray() },
+                    privateKeyPassword = { password.toCharArray() },
+                ) {
+                    // Port 0: let the OS pick, then read it back from the bound connector, so two
+                    // concurrent runs of this test can never collide on a port.
+                    this.port = 0
+                    this.keyStorePath = keyStoreFile
+                }
+            }) {
+                install(WebSockets)
+                routing {
+                    webSocket("/mqtt") {
+                        for (frame in incoming) {
+                            if (frame is Frame.Binary) send(Frame.Binary(true, frame.data))
+                        }
+                    }
+                }
+            }
+        embedded.start(wait = false)
+        server = embedded
+        // resolvedConnectors() only returns once the connector is actually bound, so the tests
+        // cannot race the server's startup.
+        port =
+            runBlocking {
+                embedded.engine
+                    .resolvedConnectors()
+                    .first()
+                    .port
+            }
+    }
+
+    @AfterTest
+    fun stopServer() {
+        server?.stop(gracePeriodMillis = 0, timeoutMillis = 1_000)
+        keyStoreFile.delete()
+    }
+
+    private val endpoint get() = MqttEndpoint.WebSocket("wss://localhost:$port/mqtt")
+
+    /** A trust store holding only the generated certificate — the "private CA". */
+    private fun privateCaTrustManager(): X509TrustManager {
+        val trustStore =
+            KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+                load(null, null)
+                setCertificateEntry("private-ca", keyStore.getCertificate(alias))
+            }
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(trustStore)
+        return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+    @Test
+    fun handshakeFailsWithoutTheHook() =
+        runBlocking {
+            val transport = WebSocketTransportFactory().create(endpoint)
+            val failure =
+                assertFailsWith<Exception> {
+                    withTimeout(20_000) { transport.connect(endpoint) }
+                }
+            // Assert the *reason*: certificate trust, not a bad URL or an unstarted server.
+            // The JVM default trust manager reports SunCertPathBuilderException / CertPathValidatorException.
+            val chain = generateSequence<Throwable>(failure) { it.cause }.toList()
+            assertTrue(
+                chain.any { it is CertPathBuilderException || it is CertPathValidatorException },
+                "expected a certificate-path failure, got: ${chain.map { it::class.qualifiedName }}",
+            )
+            transport.close()
+        }
+
+    @Test
+    fun handshakeSucceedsAndFramesRoundTripWithTheHook() =
+        runBlocking {
+            val tm = privateCaTrustManager()
+            val transport = WebSocketTransportFactory { trustManager = tm }.create(endpoint)
+            withTimeout(20_000) {
+                transport.connect(endpoint)
+                assertTrue(transport.isConnected)
+                val payload = byteArrayOf(0x10, 0x02, 0x00, 0x04)
+                transport.send(payload)
+                assertContentEquals(payload, transport.receive())
+            }
+            transport.close()
+        }
+
+    /**
+     * Settles the question the design left open: a `serverName` assigned inside the hook is *not*
+     * overwritten by CIO's per-request SNI — it wins, and ktor then verifies the certificate's
+     * subject names against it, so a value that does not match the broker breaks the handshake.
+     */
+    @Test
+    fun serverNameSetInsideTheHookWinsOverCioRequestSni() =
+        runBlocking {
+            val tm = privateCaTrustManager()
+            val transport =
+                WebSocketTransportFactory {
+                    trustManager = tm
+                    serverName = "not-the-server.example.com"
+                }.create(endpoint)
+            val failure =
+                assertFailsWith<TLSException> {
+                    withTimeout(20_000) { transport.connect(endpoint) }
+                }
+            assertTrue(
+                failure.message.orEmpty().contains("not-the-server.example.com"),
+                "expected subject-name verification against the hook's serverName, got: ${failure.message}",
+            )
+            transport.close()
+        }
+}

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
@@ -35,6 +35,7 @@ import java.io.File
 import java.security.KeyStore
 import java.security.cert.CertPathBuilderException
 import java.security.cert.CertPathValidatorException
+import java.security.cert.CertificateException
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.net.ssl.TrustManagerFactory
@@ -44,7 +45,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -161,11 +161,17 @@ class WebSocketPrivateCaTest {
                         withTimeout(20_000) { transport.connect(endpoint) }
                     }
                 // Assert the *reason*: certificate trust, not a bad URL or an unstarted server.
-                // The JVM default trust manager reports SunCertPathBuilderException / CertPathValidatorException.
+                // The JVM default trust manager reports SunCertPathBuilderException wrapped in a
+                // ValidatorException; other JDKs and JSSE providers may surface only the
+                // CertificateException layer, so accept any of the three. All of them are still
+                // trust-specific — a connectivity or URL failure arrives as an IOException
+                // subtype and would fail this assertion.
                 val chain = generateSequence<Throwable>(failure) { it.cause }.toList()
                 assertTrue(
-                    chain.any { it is CertPathBuilderException || it is CertPathValidatorException },
-                    "expected a certificate-path failure, got: ${chain.map { it::class.qualifiedName }}",
+                    chain.any {
+                        it is CertPathBuilderException || it is CertPathValidatorException || it is CertificateException
+                    },
+                    "expected a certificate-trust failure, got: ${chain.map { it::class.qualifiedName }}",
                 )
             } finally {
                 transport.close()
@@ -209,21 +215,20 @@ class WebSocketPrivateCaTest {
                     assertFailsWith<TLSException> {
                         withTimeout(20_000) { transport.connect(endpoint) }
                     }
-                // The type check alone cannot distinguish "serverName reached certificate
+                // The TLSException type alone cannot distinguish "serverName reached certificate
                 // verification" from "serverName was silently discarded and some unrelated TLS
-                // failure occurred" — both would surface as TLSException here. The substring
-                // check on the message is what proves the hook's serverName specifically drove
-                // subject-name verification, so it stays even though message text is
-                // comparatively brittle: a ktor wording change degrades that one assertion
-                // rather than breaking the test outright, since the type check below still holds.
-                assertIs<TLSException>(
-                    failure.cause,
-                    "expected the TLSException to be caused by a nested certificate-verification " +
-                        "TLSException, got: ${failure.cause}",
-                )
+                // failure occurred". Finding the hook's serverName in the failure is what proves
+                // it specifically drove subject-name verification, so that check stays even
+                // though message text is comparatively brittle — it is the only available
+                // evidence for the behaviour under test.
+                //
+                // Search the whole cause chain rather than the top-level message, and do not
+                // assert on how the exceptions nest: the nesting is incidental to the contract
+                // and has no reason to be stable across ktor versions.
+                val messages = generateSequence<Throwable>(failure) { it.cause }.mapNotNull { it.message }.toList()
                 assertTrue(
-                    failure.message.orEmpty().contains("not-the-server.example.com"),
-                    "expected subject-name verification against the hook's serverName, got: ${failure.message}",
+                    messages.any { it.contains("not-the-server.example.com") },
+                    "expected subject-name verification against the hook's serverName, got: $messages",
                 )
             } finally {
                 transport.close()

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketPrivateCaTest.kt
@@ -57,17 +57,20 @@ import kotlin.test.assertTrue
 class WebSocketPrivateCaTest {
     private val alias = "mqtt-ws-test"
     private val password = "changeit"
-    private lateinit var keyStoreFile: File
+    private var keyStoreFile: File? = null
     private lateinit var keyStore: KeyStore
     private var port = 0
     private var server: EmbeddedServer<*, *>? = null
     private val nettyLogger: Logger = Logger.getLogger("io.netty")
+    private var previousNettyLevel: Level? = null
 
     @BeforeTest
     fun startServer() {
         // Two of the three tests deliberately fail the handshake; Netty logs each one at WARNING.
         // Silence it so a passing run has clean output. The Logger must be held in a field —
-        // java.util.logging discards the configuration of unreferenced Logger instances.
+        // java.util.logging discards the configuration of unreferenced Logger instances. Restored
+        // in stopServer() since this is a JVM-wide mutation shared with every other test in the module.
+        previousNettyLevel = nettyLogger.level
         nettyLogger.level = Level.OFF
 
         keyStore =
@@ -77,8 +80,10 @@ class WebSocketPrivateCaTest {
                     domains = listOf("localhost")
                 }
             }
-        keyStoreFile = File.createTempFile("mqtt-ws-test", ".jks")
-        keyStoreFile.outputStream().use { keyStore.store(it, password.toCharArray()) }
+        val file = File.createTempFile("mqtt-ws-test", ".jks")
+        file.deleteOnExit()
+        keyStoreFile = file
+        file.outputStream().use { keyStore.store(it, password.toCharArray()) }
 
         val embedded =
             embeddedServer(Netty, environment = applicationEnvironment { }, configure = {
@@ -119,7 +124,8 @@ class WebSocketPrivateCaTest {
     @AfterTest
     fun stopServer() {
         server?.stop(gracePeriodMillis = 0, timeoutMillis = 1_000)
-        keyStoreFile.delete()
+        keyStoreFile?.delete()
+        nettyLogger.level = previousNettyLevel
     }
 
     private val endpoint get() = MqttEndpoint.WebSocket("wss://localhost:$port/mqtt")
@@ -140,18 +146,21 @@ class WebSocketPrivateCaTest {
     fun handshakeFailsWithoutTheHook() =
         runBlocking {
             val transport = WebSocketTransportFactory().create(endpoint)
-            val failure =
-                assertFailsWith<Exception> {
-                    withTimeout(20_000) { transport.connect(endpoint) }
-                }
-            // Assert the *reason*: certificate trust, not a bad URL or an unstarted server.
-            // The JVM default trust manager reports SunCertPathBuilderException / CertPathValidatorException.
-            val chain = generateSequence<Throwable>(failure) { it.cause }.toList()
-            assertTrue(
-                chain.any { it is CertPathBuilderException || it is CertPathValidatorException },
-                "expected a certificate-path failure, got: ${chain.map { it::class.qualifiedName }}",
-            )
-            transport.close()
+            try {
+                val failure =
+                    assertFailsWith<Exception> {
+                        withTimeout(20_000) { transport.connect(endpoint) }
+                    }
+                // Assert the *reason*: certificate trust, not a bad URL or an unstarted server.
+                // The JVM default trust manager reports SunCertPathBuilderException / CertPathValidatorException.
+                val chain = generateSequence<Throwable>(failure) { it.cause }.toList()
+                assertTrue(
+                    chain.any { it is CertPathBuilderException || it is CertPathValidatorException },
+                    "expected a certificate-path failure, got: ${chain.map { it::class.qualifiedName }}",
+                )
+            } finally {
+                transport.close()
+            }
         }
 
     @Test
@@ -159,14 +168,17 @@ class WebSocketPrivateCaTest {
         runBlocking {
             val tm = privateCaTrustManager()
             val transport = WebSocketTransportFactory { trustManager = tm }.create(endpoint)
-            withTimeout(20_000) {
-                transport.connect(endpoint)
-                assertTrue(transport.isConnected)
-                val payload = byteArrayOf(0x10, 0x02, 0x00, 0x04)
-                transport.send(payload)
-                assertContentEquals(payload, transport.receive())
+            try {
+                withTimeout(20_000) {
+                    transport.connect(endpoint)
+                    assertTrue(transport.isConnected)
+                    val payload = byteArrayOf(0x10, 0x02, 0x00, 0x04)
+                    transport.send(payload)
+                    assertContentEquals(payload, transport.receive())
+                }
+            } finally {
+                transport.close()
             }
-            transport.close()
         }
 
     /**
@@ -183,14 +195,17 @@ class WebSocketPrivateCaTest {
                     trustManager = tm
                     serverName = "not-the-server.example.com"
                 }.create(endpoint)
-            val failure =
-                assertFailsWith<TLSException> {
-                    withTimeout(20_000) { transport.connect(endpoint) }
-                }
-            assertTrue(
-                failure.message.orEmpty().contains("not-the-server.example.com"),
-                "expected subject-name verification against the hook's serverName, got: ${failure.message}",
-            )
-            transport.close()
+            try {
+                val failure =
+                    assertFailsWith<TLSException> {
+                        withTimeout(20_000) { transport.connect(endpoint) }
+                    }
+                assertTrue(
+                    failure.message.orEmpty().contains("not-the-server.example.com"),
+                    "expected subject-name verification against the hook's serverName, got: ${failure.message}",
+                )
+            } finally {
+                transport.close()
+            }
         }
 }

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt
@@ -52,7 +52,7 @@ class WebSocketTrustManagerTest {
     @Test
     fun hookInstalledTrustManagerSurvivesApplyWsTls() {
         val builder = TLSConfigBuilder()
-        builder.applyWsTls("broker.example.com") { trustManager = FakeTrustManager }
+        builder.applyWsTls("broker.example.com", configureTls = { trustManager = FakeTrustManager })
         assertSame(FakeTrustManager, builder.trustManager)
     }
 

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * JVM-only checks on the ordering inside [applyWsTls], using `trustManager` — a property that
+ * exists only on the JVM and Android actuals of [TLSConfigBuilder], so it cannot be asserted
+ * from `commonTest`.
+ *
+ * On the JVM `configurePlatformTrust` is a no-op, so a hook-installed trust manager survives
+ * untouched. On Android it is deliberately *not* preserved by identity — it gets wrapped in a
+ * hostname-aware delegate, which needs the `X509TrustManagerExtensions` framework class and is
+ * therefore out of unit-test scope. The ordering itself is asserted here via the
+ * `platformTrust` test seam.
+ */
+class WebSocketTrustManagerTest {
+    private object FakeTrustManager : X509TrustManager {
+        override fun checkClientTrusted(
+            chain: Array<out X509Certificate>,
+            authType: String,
+        ) = Unit
+
+        override fun checkServerTrusted(
+            chain: Array<out X509Certificate>,
+            authType: String,
+        ) = Unit
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    @Test
+    fun hookInstalledTrustManagerSurvivesApplyWsTls() {
+        val builder = TLSConfigBuilder()
+        builder.applyWsTls("broker.example.com") { trustManager = FakeTrustManager }
+        assertSame(FakeTrustManager, builder.trustManager)
+    }
+
+    @Test
+    fun callerHookRunsBeforePlatformTrust() {
+        // The Android wrapper reads whatever trustManager is on the builder, so the caller's
+        // assignment must already be present when platform trust runs. Reversing the two would
+        // silently drop Android's hostname-aware checkServerTrusted path.
+        val order = mutableListOf<String>()
+        val builder = TLSConfigBuilder()
+        builder.applyWsTls(
+            host = "broker.example.com",
+            configureTls = { order += "caller" },
+            platformTrust = { order += "platform" },
+        )
+        assertEquals(listOf("caller", "platform"), order)
+    }
+
+    @Test
+    fun platformTrustReceivesTheHostUnchanged() {
+        // Includes the IP-literal case: Android's 2-arg overload throws whenever the security
+        // config holds any domain-specific entry, regardless of target host, so an IP-only
+        // broker needs the wrapper too.
+        val seen = mutableListOf<String>()
+        TLSConfigBuilder().applyWsTls("192.168.1.50", null) { seen += it }
+        assertEquals(listOf("192.168.1.50"), seen)
+    }
+
+    @Test
+    fun nullHookIsANoOp() {
+        val builder = TLSConfigBuilder()
+        builder.applyWsTls("broker.example.com", null)
+        assertSame(null, builder.trustManager)
+    }
+}

--- a/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt
+++ b/transport-ws/src/jvmTest/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTrustManagerTest.kt
@@ -82,9 +82,16 @@ class WebSocketTrustManagerTest {
     }
 
     @Test
-    fun nullHookIsANoOp() {
+    fun nullHookLeavesExistingTrustStateUntouched() {
+        // Asserts this module's contract — a null hook mutates no trust state — rather than
+        // TLSConfigBuilder's default `trustManager` value, which is ktor's implementation
+        // detail and could change without our behaviour changing. Starting from a known
+        // non-default state also catches a hook path that clears the manager rather than
+        // leaving it alone. On the JVM `configurePlatformTrust` is a no-op, so nothing else
+        // in `applyWsTls` should touch it either.
         val builder = TLSConfigBuilder()
+        builder.trustManager = FakeTrustManager
         builder.applyWsTls("broker.example.com", null)
-        assertSame(null, builder.trustManager)
+        assertSame(FakeTrustManager, builder.trustManager)
     }
 }

--- a/transport-ws/src/linuxMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.linux.kt
+++ b/transport-ws/src/linuxMain/kotlin/org/meshtastic/mqtt/transport/ws/PlatformTls.linux.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/** See the sibling note on the `expect` declaration: mirrored in `:transport-tcp`. */
+internal actual fun TLSConfigBuilder.configurePlatformTrust(host: String) {
+    // No-op: native TLSConfigBuilder does not expose a trustManager property.
+}

--- a/transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt
+++ b/transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt
@@ -19,9 +19,21 @@ package org.meshtastic.mqtt.transport.ws
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.winhttp.WinHttp
 import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.network.tls.TLSConfigBuilder
 
-/** WinHttp engine — Windows. Trust is handled by the platform certificate store. */
-internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+/**
+ * WinHttp engine — Windows. Trust is handled by the platform certificate store.
+ *
+ * [configureTls] is ignored: `WinHttpClientEngineConfig` exposes no TLS-configuration surface.
+ * Documented in `Module.md`. Switching Windows to CIO would make the hook work, but CIO's
+ * native TLS has no Windows trust-store integration, so it would risk breaking ordinary `wss://`.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal actual fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient =
     HttpClient(WinHttp) {
         install(WebSockets) {
             this.maxFrameSize = maxFrameSize

--- a/transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt
+++ b/transport-ws/src/mingwMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.mingw.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.winhttp.WinHttp
+import io.ktor.client.plugins.websocket.WebSockets
+
+/** WinHttp engine — Windows. Trust is handled by the platform certificate store. */
+internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+    HttpClient(WinHttp) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }

--- a/transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt
+++ b/transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt.transport.ws
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.js.Js
+import io.ktor.client.plugins.websocket.WebSockets
+
+/** Js engine — browser (wasmJs). Trust is entirely the browser's; nothing is configurable. */
+internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+    HttpClient(Js) {
+        install(WebSockets) {
+            this.maxFrameSize = maxFrameSize
+        }
+    }

--- a/transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt
+++ b/transport-ws/src/wasmJsMain/kotlin/org/meshtastic/mqtt/transport/ws/WsHttpClient.wasmJs.kt
@@ -19,9 +19,20 @@ package org.meshtastic.mqtt.transport.ws
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.js.Js
 import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.network.tls.TLSConfigBuilder
 
-/** Js engine — browser (wasmJs). Trust is entirely the browser's; nothing is configurable. */
-internal actual fun buildWsHttpClient(maxFrameSize: Long): HttpClient =
+/**
+ * Js engine — browser (wasmJs).
+ *
+ * [configureTls] is ignored: a browser page cannot influence TLS trust in any way. Documented
+ * in `Module.md`.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal actual fun buildWsHttpClient(
+    host: String,
+    maxFrameSize: Long,
+    configureTls: (TLSConfigBuilder.() -> Unit)?,
+): HttpClient =
     HttpClient(Js) {
         install(WebSockets) {
             this.maxFrameSize = maxFrameSize


### PR DESCRIPTION
## Description

`TcpTransportFactory` got an optional TLS-customisation lambda in #103, but `WebSocketTransportFactory` had no equivalent — so a `wss://` broker behind a private or self-signed CA stayed unreachable without app-wide trust changes. That gap blocks the whole point of #102: Meshtastic-Android cannot drop the `<certificates src="user"/>` anchor from `network_security_config.xml`'s `base-config` (which applies to *every* HTTPS connection the app makes) while private-CA `wss://` still depends on it.

This adds the WebSocket half. Both transports now take the **same** `TLSConfigBuilder` lambda, so one trust manager serves `ssl://` and `wss://` alike:

```kotlin
transportFactory = TcpTransportFactory { trustManager = tm } + WebSocketTransportFactory { trustManager = tm }
```

The issue sketched an `HttpClientConfig<*>` receiver. That cannot work — `HttpClientConfig<T>.engine(block: T.() -> Unit)` puts `T` in an `in` position, so under the star projection `engine { }` is not callable and TLS is unreachable. `ktor-network-tls` turns out to publish a klib for all nine targets (wasmJs included), so no new public type or `expect`/`actual` was needed on the API surface.

## Changes

- `WebSocketTransportFactory(configureTls: (TLSConfigBuilder.() -> Unit)? = null)` and the same on `WebSocketTransport`, mirroring `:transport-tcp` member for member, with explicit zero-arg secondary constructors so the klib ABI stays additive.
- `:transport-ws` now names its ktor engine explicitly per platform instead of relying on auto-detection (required to reach engine TLS config), behind an internal `expect fun buildWsHttpClient`. Same engines auto-detection resolved from the library's own dependencies: CIO on JVM/Android/Apple/Linux, WinHttp on Windows, Js on wasmJs.
- New `cioMain` intermediate source set (jvm + android + apple + linux) holding the single CIO client builder and the TLS trust plumbing.
- Caller hook runs **before** platform trust configuration, expressed in exactly one place (`applyWsTls`) so it cannot drift — on Android that ordering is what lets `X509TrustManagerExtensions` wrap the caller's trust manager for hostname-aware `checkServerTrusted`, rather than replacing it.
- `configurePlatformTrust` is deliberately duplicated from `:transport-tcp` (that module has no wasmJs target, and WS-only consumers shouldn't pull a TCP artifact), with bidirectional sibling KDoc cross-references so the pair stays in lockstep.
- Hook is silently ignored on Windows (WinHttp exposes no TLS-config surface) and in the browser (a page cannot influence trust) — deliberate, so shared common code can pass it unconditionally. Windows stays on WinHttp: CIO would make the hook work but has no Windows trust-store integration.
- Documented in `transport-ws/Module.md` with a per-target support table, matching the trust-ordering notes #103 added to `transport-tcp/Module.md`, plus the TCP-side cross-reference and README/CHANGELOG updates.
- Settled empirically: a `serverName` assigned inside the hook **wins** over CIO's per-request SNI and becomes the name the certificate is verified against. Test-asserted and documented with the appropriate warning.

## Testing

- [x] `./gradlew spotlessCheck detekt allTests build` passes
- [x] New/updated tests cover the changes

Beyond unit coverage of hook forwarding and the caller→platform ordering, `WebSocketPrivateCaTest` (jvmTest) stands up a local `wss://` server with a generated self-signed certificate and asserts that a bare `WebSocketTransportFactory()` **fails** on certificate-path validation while a hook supplying a `KeyStore`-backed trust manager **connects and round-trips a binary frame**. That discharges the acceptance criterion rather than asserting it. Test-only deps: `ktor-server-netty`, `ktor-server-websockets`, `ktor-network-tls-certificates` (netty rather than CIO because ktor's server-side CIO engine rejects HTTPS).

Verified: `koverVerify` 85.7% aggregate; `apiCheck` additions only in both `transport-ws.api` and `transport-ws.klib.api` (no removed line, so existing `WebSocketTransportFactory()` callers keep linking); `:core:check` green including `verifyModuleBoundary` and the Konsist suite; `compileAndroidMain` green. macOS/iOS/Windows tests could not run on the Linux dev host — compile-only checks pass, CI covers the rest.

Design and plan: `docs/superpowers/specs/2026-07-26-ws-tls-trust-hook-design.md`, `docs/superpowers/plans/2026-07-26-ws-tls-trust-hook.md`.

## Related Issues

Fixes #107. Relates to #102, #103.

Once this lands, Meshtastic-Android can remove the app-wide `<certificates src="user"/>` anchor and configure trust per-connection on both transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-connection TLS trust customization hook for WebSocket MQTT transports (`wss://`), enabling private/self-signed CA trust and sharing the same trust configuration across TCP and WebSocket factories.
  * Preserved no-arg constructors for compatibility.
* **Improvements**
  * WebSocket transport now selects the Ktor engine explicitly per platform, avoiding classpath-based auto-detection.
  * Clarified platform behavior: the hook is honored where supported and ignored silently on Windows and in the browser.
* **Documentation**
  * Updated README, module guides, agent guidance, and changelog with TLS examples and platform/SNI notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->