### PR TITLE
ci: make the detekt gate real and clear its findings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 <!-- How was this tested? Which targets? -->
 
-- [ ] `./gradlew spotlessCheck detekt allTests build` passes
+- [ ] `./gradlew spotlessCheck detektAll allTests build` passes
 - [ ] New/updated tests cover the changes
 
 ## Related Issues

--- a/.github/skills/mqtt-kmp/SKILL.md
+++ b/.github/skills/mqtt-kmp/SKILL.md
@@ -43,7 +43,7 @@ description: 'MQTTastic Client KMP — Kotlin Multiplatform MQTT 5.0 client libr
 ./gradlew allTests                 # all KMP tests
 ./gradlew jvmTest                  # JVM tests only
 ./gradlew spotlessApply            # auto-fix formatting
-./gradlew detektAll                   # static analysis
+./gradlew detektAll                # static analysis
 ./gradlew apiCheck                 # public API compatibility
 ./gradlew koverVerify              # coverage check (≥80%)
 ```

--- a/.github/skills/mqtt-kmp/SKILL.md
+++ b/.github/skills/mqtt-kmp/SKILL.md
@@ -25,7 +25,7 @@ description: 'MQTTastic Client KMP — Kotlin Multiplatform MQTT 5.0 client libr
 - Packet codecs must match OASIS MQTT 5.0 byte-level spec exactly
 - All new features need encode/decode round-trip tests
 - Code coverage ≥80% enforced via koverVerify
-- `spotlessCheck` + `detekt` + `apiCheck` must pass
+- `spotlessCheck` + `detektAll` + `apiCheck` must pass
 
 ## File Locations
 | What | Where |
@@ -43,7 +43,7 @@ description: 'MQTTastic Client KMP — Kotlin Multiplatform MQTT 5.0 client libr
 ./gradlew allTests                 # all KMP tests
 ./gradlew jvmTest                  # JVM tests only
 ./gradlew spotlessApply            # auto-fix formatting
-./gradlew detekt                   # static analysis
+./gradlew detektAll                   # static analysis
 ./gradlew apiCheck                 # public API compatibility
 ./gradlew koverVerify              # coverage check (≥80%)
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           cache_read_only: ${{ github.event_name == 'pull_request' }}
 
-      - name: Run spotlessCheck and detekt
-        run: ./gradlew spotlessCheck detekt --stacktrace
+      - name: Run spotlessCheck and detektAll
+        run: ./gradlew spotlessCheck detektAll --stacktrace
 
   test-jvm:
     name: Test JVM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           cache_read_only: 'false'
 
       - name: Validate before publish
-        run: ./gradlew spotlessCheck detekt jvmTest apiCheck --stacktrace
+        run: ./gradlew spotlessCheck detektAll jvmTest apiCheck --stacktrace
 
       - name: Stage signed artifacts locally
         run: ./gradlew publishToMavenLocal --stacktrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ All protocol features are fully implemented: 15 MQTT 5.0 packet types, QoS 0/1/2
 # Formatting & linting:
 ./gradlew spotlessCheck            # check formatting
 ./gradlew spotlessApply            # auto-fix formatting
-./gradlew detekt                   # static analysis
+./gradlew detektAll                # static analysis (all Kotlin source sets)
 
 # Binary compatibility & coverage:
 ./gradlew apiCheck                 # verify public API hasn't changed
@@ -96,11 +96,13 @@ All protocol features are fully implemented: 15 MQTT 5.0 packet types, QoS 0/1/2
 ./gradlew dokkaGeneratePublicationHtml  # generate API docs to library/build/dokka/html/
 
 # Full baseline verification:
-./gradlew spotlessCheck detekt allTests apiCheck koverVerify
+./gradlew spotlessCheck detektAll allTests apiCheck koverVerify
 
 # Publish locally:
 ./gradlew publishToMavenLocal
 ```
+
+> **`detektAll` vs `detekt`:** Always use `detektAll`. The detekt plugin's bare `detekt` task only knows the JVM-style `src/main/kotlin` layout, so in every module here it is `NO-SOURCE` and analyses nothing. `detektAll` (registered by the `mqtt.kmp.library` convention plugin) aggregates the per-source-set tasks — `detektMetadataCommonMain`, `detektJvmMain`, `detektJvmTest`, `detektAndroidMain`, `detektWasmJsMain`, `detektLinuxX64Main`, … — and is wired into `check`, so `build` covers it too.
 
 > **`allTests` vs `test`:** Always use `allTests` — it is the KMP lifecycle task that correctly covers all source sets. The bare `test` task is ambiguous in KMP projects and Gradle may silently skip targets.
 
@@ -110,7 +112,7 @@ Build system: Kotlin DSL (`build.gradle.kts`) with version catalog (`gradle/libs
 - **No Framework Bleed:** NEVER import `java.*`, `android.*`, or any platform API in `commonMain`. Use KMP equivalents: `kotlinx.coroutines.sync.Mutex` for locks, `kotlinx.io` or Ktor's `ByteReadChannel`/`ByteWriteChannel` for I/O.
 - **No Lazy Coding:** DO NOT use placeholders like `// ... existing code ...`. Always provide complete, valid code blocks for the sections you modify.
 - **Dependency Discipline:** Zero dependencies beyond Ktor + kotlinx-coroutines + kotlinx-io-bytestring (already a transitive Ktor dependency). Check `gradle/libs.versions.toml` before adding anything. Prefer removing dependencies over adding them.
-- **Zero Lint Tolerance:** A task is incomplete if `detekt` fails or `spotlessCheck` does not pass.
+- **Zero Lint Tolerance:** A task is incomplete if `detektAll` fails or `spotlessCheck` does not pass.
 - **Spec Compliance:** Every packet encoder/decoder must match the byte-level layout in the OASIS MQTT 5.0 specification exactly. When in doubt, cite the relevant spec section number.
 - **Test Coverage:** Every new packet type, property, or protocol feature must have encode/decode round-trip tests with known byte sequences from the spec. QoS 2 flow tests must cover the full state machine including retransmission and session resumption.
 - **Internal by Default:** In `:core`, the public surface is `MqttClient`, `MqttConfig`, `MqttMessage`, `PublishProperties`, `MqttEndpoint`, `QoS`, `ConnectionState`, `ReasonCode`, `WillConfig`, `MqttLogger`, `MqttLogLevel`, `RetainHandling`, `AuthChallenge`, `MqttProtocolVersion`, the transport SPI (`MqttTransport`, `MqttTransportFactory` + its `plus` operator), the VBI framing helper (`VariableByteInt`, `VbiResult`), the convenience extensions (`messagesForTopic`, `messagesMatching`, `use`), and the `MqttClient(clientId) {}` factory. Everything else — including `MqttProperties` and the entire `MqttPacket` hierarchy — is `internal`. Transport modules add `TcpTransport`/`TcpTransportFactory` and `WebSocketTransport`/`WebSocketTransportFactory`. Enforced by the Konsist allowlist (ADR-0008) and `apiCheck`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ See the **Build & Test Commands** section in [AGENTS.md](AGENTS.md) for the full
 **Before submitting a PR, ensure all checks pass:**
 
 ```bash
-./gradlew spotlessApply detekt allTests apiCheck koverVerify
+./gradlew spotlessApply detektAll allTests apiCheck koverVerify
 ```
 
 ## Code Style

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     compileOnly(libs.kotlin.gradle.plugin)
     implementation(libs.dokka.gradle.plugin)
     implementation(libs.vanniktech.publish.gradle.plugin)
+    implementation(libs.detekt.gradle.plugin)
 }
 
 gradlePlugin {

--- a/build-logic/convention/src/main/kotlin/MqttKmpLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MqttKmpLibraryConventionPlugin.kt
@@ -14,11 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 /**
@@ -71,5 +74,29 @@ class MqttKmpLibraryConventionPlugin : Plugin<Project> {
                     implementation(libs.findLibrary("kotlinx-coroutines-test").get())
                 }
             }
+
+            wireDetektIntoCheck()
         }
+
+    /**
+     * The detekt plugin's bare `detekt` task only knows the JVM-style `src/main/kotlin` layout, so
+     * in a KMP module it is always NO-SOURCE. The real analysis lives in the per-source-set tasks
+     * the plugin registers instead (`detektMetadataCommonMain`, `detektJvmMain`, `detektJvmTest`,
+     * `detektLinuxX64Main`, …), and none of them is wired into `check` by default.
+     *
+     * Aggregate them into a single `detektAll` task and make `check` depend on it, so both CI and
+     * the documented local gate actually perform static analysis.
+     */
+    private fun Project.wireDetektIntoCheck() {
+        pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
+            val detektAll =
+                tasks.register("detektAll") {
+                    group = "verification"
+                    description = "Runs detekt over every Kotlin source set in this module."
+                    // The bare `detekt` task is excluded: it is NO-SOURCE for KMP layouts.
+                    dependsOn(tasks.withType<Detekt>().matching { it.name != "detekt" })
+                }
+            tasks.named("check") { dependsOn(detektAll) }
+        }
+    }
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -5,14 +5,40 @@ complexity:
   active: true
   LongMethod:
     threshold: 60
+    # The codec is a set of spec-driven `when` tables: one branch per packet type,
+    # reason code, or property ID (ADR-0003). Splitting them hurts byte-level
+    # reviewability against the OASIS spec rather than helping it. Long test
+    # functions are end-to-end broker/protocol flows that read best in one piece.
+    excludes: ['**/packet/**', '**/*Test.kt']
+  CyclomaticComplexMethod:
+    excludes: ['**/packet/**', '**/*Test.kt']
+  TooManyFunctions:
+    # One encode/decode function per packet type; grouping them per file is the point.
+    excludes: ['**/packet/**', '**/*Test.kt']
   LongParameterList:
     functionThreshold: 10
     constructorThreshold: 10
 
 style:
   active: true
+  # Protocol validation is a sequence of guard clauses — one `throw` per malformed-packet
+  # or illegal-state case — so the default limit of 2 fights the spec, not the code.
+  ThrowsCount:
+    max: 6
+    excludeGuardClauses: true
+  # Guard-clause-heavy decoding: one early return per short-circuit case.
+  ReturnCount:
+    max: 5
+    excludeGuardClauses: true
   MaxLineLength:
-    maxLineLength: 120
+    # Matches the ktlint_official limit applied via Spotless.
+    maxLineLength: 140
     excludeCommentStatements: true
   WildcardImport:
+    active: false
+  # This library is a wire-protocol codec: nearly every literal is a byte value, bit
+  # mask, property ID, or reason code fixed by the MQTT specification, and the
+  # surrounding code cites the spec section. The rule fires 400+ times on such
+  # literals, where naming each one adds indirection without adding meaning.
+  MagicNumber:
     active: false

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
@@ -710,6 +710,10 @@ public class MqttClient
 
         // --- Private helpers ---
 
+        // One linear sequence: negotiate the protocol version, build the connection, connect,
+        // then fall back to 3.1.1 on an unsupported-version CONNACK. Splitting the fallback out
+        // would separate it from the state it has to unwind.
+        @Suppress("LongMethod", "NestedBlockDepth")
         private suspend fun connectInternal(endpoint: MqttEndpoint) {
             val effectiveVersion = negotiatedProtocolVersion
             val effectiveConfig =
@@ -756,7 +760,9 @@ public class MqttClient
                     val fallbackConn = MqttConnection(fallbackTransport, fallbackConfig, scope, log)
                     try {
                         fallbackConn.connect(endpoint)
-                    } catch (fallbackError: Exception) {
+                    } catch (
+                        @Suppress("TooGenericExceptionCaught") fallbackError: Exception,
+                    ) {
                         try {
                             fallbackTransport.close()
                         } catch (
@@ -871,6 +877,9 @@ public class MqttClient
             redirectForwardJob = null
         }
 
+        // The backoff loop, its attempt bookkeeping, and the resubscribe-on-success step form a
+        // single retry policy; the length is the loop body, not branching complexity.
+        @Suppress("LongMethod")
         private suspend fun startReconnect() {
             connectionMutex.withLock {
                 if (reconnectJob?.isActive == true) return
@@ -985,10 +994,17 @@ public class MqttClient
 
         private fun requireConnection(): MqttConnection {
             check(!closed) { "Client has been closed and cannot be reused" }
-            return connection ?: throw IllegalStateException("Not connected")
+            return connection ?: error("Not connected")
         }
 
-        /** Wrap internal [MqttConnectionException] into the public [MqttException] hierarchy. */
+        /**
+         * Wrap internal [MqttConnectionException] into the public [MqttException] hierarchy.
+         *
+         * The internal exception is deliberately not chained as the cause (`SwallowedException`):
+         * its own cause and reason code are carried over, and the internal type is not part of
+         * the public API.
+         */
+        @Suppress("SwallowedException")
         private suspend inline fun wrapConnectionErrors(block: () -> Unit) {
             try {
                 block()

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -90,11 +90,15 @@ public data class AuthChallenge(
  *
  * Not part of the public API — consumers use [MqttClient] instead.
  *
+ * `LargeClass` is suppressed deliberately: lifecycle, keepalive, read loop and the QoS 0/1/2
+ * flows share the same in-flight maps, mutexes and packet-ID counter, so splitting the class
+ * would spread that state across types without reducing it.
+ *
  * @param transport The byte-level transport to use for sending/receiving packets.
  * @param config Client configuration mapping to CONNECT packet fields (§3.1).
  * @param scope Coroutine scope for background jobs (read loop, keepalive).
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LargeClass")
 internal class MqttConnection(
     private val transport: MqttTransport,
     private val config: MqttConfig,
@@ -186,10 +190,18 @@ internal class MqttConnection(
      * Performs the CONNECT/CONNACK handshake per §3.1/§3.2, then starts the background
      * read loop and keepalive timer.
      *
+     * The complexity suppressions are deliberate: §3.2 CONNACK carries a dozen independent server
+     * capabilities (session present, receive maximum, topic-alias maximum, maximum QoS, keepalive
+     * override, assigned client ID, …), each applied to connection state before the read loop
+     * starts, so the branching is one `if` per property in spec order. Likewise each `throw` is a
+     * distinct rejection path (unsupported version, bad reason code, malformed CONNACK property,
+     * transport failure) carrying its own reason code.
+     *
      * @param endpoint Broker endpoint (TCP or WebSocket).
      * @return The CONNACK packet from the broker.
      * @throws MqttConnectionException if the broker rejects the connection.
      */
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "NestedBlockDepth", "ThrowsCount")
     suspend fun connect(endpoint: MqttEndpoint): ConnAck {
         _connectionState.value = ConnectionState.Connecting
 
@@ -509,10 +521,15 @@ internal class MqttConnection(
     /**
      * Subscribe to one or more topic filters per §3.8.
      *
+     * `LongMethod` is suppressed deliberately: building SUBSCRIBE, awaiting the correlated SUBACK,
+     * and mapping its per-filter reason codes (§3.9) back onto the requested subscriptions is one
+     * round trip that has to stay together.
+     *
      * @param subscriptions List of topic subscriptions with QoS and options.
      * @param properties Optional MQTT 5.0 properties for the SUBSCRIBE packet.
      * @return The SUBACK packet from the broker.
      */
+    @Suppress("LongMethod")
     suspend fun subscribe(
         subscriptions: List<Subscription>,
         properties: MqttProperties = MqttProperties.EMPTY,
@@ -931,8 +948,13 @@ internal class MqttConnection(
         }
     }
 
-    /** Dispatch an incoming packet to the appropriate handler. */
-    @Suppress("CyclomaticComplexMethod")
+    /**
+     * Dispatch an incoming packet to the appropriate handler.
+     *
+     * One `when` branch per inbound packet type (§3): the dispatch table itself is the length and
+     * the complexity, hence the suppressions.
+     */
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     private suspend fun handlePacket(packet: MqttPacket) {
         when (packet) {
             is PubAck -> {

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
@@ -105,7 +105,12 @@ private fun buildProbeConfig(configure: MqttConfig.Builder.() -> Unit): MqttConf
 /**
  * Test-injectable variant that takes a pre-built transport. Public-internal so
  * `commonTest` can drive each [ProbeResult] arm via [FakeTransport].
+ *
+ * `SwallowedException` is suppressed deliberately: a timeout is a normal probe outcome, not an
+ * error, and is translated into [ProbeResult.Timeout], which carries the timeout budget instead
+ * of the exception.
  */
+@Suppress("SwallowedException")
 internal suspend fun runProbe(
     config: MqttConfig,
     transport: MqttTransport,

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
@@ -103,7 +103,7 @@ private fun buildProbeConfig(configure: MqttConfig.Builder.() -> Unit): MqttConf
         }.build()
 
 /**
- * Test-injectable variant that takes a pre-built transport. Public-internal so
+ * Test-injectable variant that takes a pre-built transport. `internal` rather than private so
  * `commonTest` can drive each [ProbeResult] arm via [FakeTransport].
  *
  * `SwallowedException` is suppressed deliberately: a timeout is a normal probe outcome, not an

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/packet/MqttDecoder.kt
@@ -43,8 +43,8 @@ internal fun decodePacket(
     val type = PacketType.fromValue(typeValue)
 
     // MQTT 3.1.1 does not have AUTH packets
-    if (!version.supportsProperties && type == PacketType.AUTH) {
-        throw IllegalArgumentException("AUTH packets are not valid in MQTT 3.1.1")
+    require(version.supportsProperties || type != PacketType.AUTH) {
+        "AUTH packets are not valid in MQTT 3.1.1"
     }
 
     // Validate flags (PUBLISH has variable flags)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ javaToolchain = "11"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 vanniktech-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktechMavenPublish" }
+detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -112,7 +112,9 @@ public class TcpTransport(
                         } else {
                             rawSocket
                         }
-                    } catch (e: Exception) {
+                    } catch (
+                        @Suppress("TooGenericExceptionCaught") e: Exception,
+                    ) {
                         // TLS handshake failed — close the raw socket before re-throwing
                         try {
                             rawSocket.close()
@@ -127,7 +129,9 @@ public class TcpTransport(
                 selectorManager = selector
                 readChannel = socket!!.openReadChannel()
                 writeChannel = socket!!.openWriteChannel(autoFlush = false)
-            } catch (e: Exception) {
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Exception,
+            ) {
                 // Any failure (TCP connect, TLS handshake, channel setup) — close selector to prevent leaks
                 try {
                     socket?.close()
@@ -180,9 +184,7 @@ public class TcpTransport(
             vbiBytes[vbiLen++] = b
         } while (b.toInt() and 0x80 != 0 && vbiLen < 4)
 
-        if (vbiLen == 4 && vbiBytes[3].toInt() and 0x80 != 0) {
-            throw IllegalArgumentException("Malformed VBI: exceeds 4 bytes")
-        }
+        require(vbiLen < 4 || vbiBytes[3].toInt() and 0x80 == 0) { "Malformed VBI: exceeds 4 bytes" }
 
         val vbiResult = VariableByteInt.decode(vbiBytes, 0)
         val remainingLength = vbiResult.value
@@ -190,10 +192,8 @@ public class TcpTransport(
         // Safety cap: reject packets larger than the VBI maximum to prevent OOM
         // from a malicious/broken broker. Application-level enforcement of
         // config.maximumPacketSize happens in MqttConnection's read loop.
-        if (remainingLength > MAX_PACKET_REMAINING_LENGTH) {
-            throw IllegalArgumentException(
-                "Packet remaining length $remainingLength exceeds safety cap $MAX_PACKET_REMAINING_LENGTH",
-            )
+        require(remainingLength <= MAX_PACKET_REMAINING_LENGTH) {
+            "Packet remaining length $remainingLength exceeds safety cap $MAX_PACKET_REMAINING_LENGTH"
         }
 
         // Step 3: Read exactly remainingLength bytes

--- a/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
+++ b/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
@@ -69,31 +69,29 @@ public class WebSocketTransport : MqttTransport {
     }
 
     override suspend fun send(bytes: ByteArray) {
-        val ws = session ?: throw IllegalStateException("Not connected")
+        val ws = session ?: error("Not connected")
         sendMutex.withLock {
             ws.send(Frame.Binary(true, bytes))
         }
     }
 
     override suspend fun receive(): ByteArray {
-        val ws = session ?: throw IllegalStateException("Not connected")
+        val ws = session ?: error("Not connected")
         val frame = ws.incoming.receive()
         return when (frame) {
             is Frame.Binary -> {
-                if (frame.data.size > MAX_FRAME_SIZE) {
-                    throw IllegalArgumentException(
-                        "WebSocket frame size ${frame.data.size} exceeds safety cap $MAX_FRAME_SIZE",
-                    )
+                require(frame.data.size <= MAX_FRAME_SIZE) {
+                    "WebSocket frame size ${frame.data.size} exceeds safety cap $MAX_FRAME_SIZE"
                 }
                 frame.readBytes()
             }
 
             is Frame.Close -> {
-                throw IllegalStateException("WebSocket closed by server")
+                error("WebSocket closed by server")
             }
 
             else -> {
-                throw IllegalStateException("Unexpected frame type: ${frame.frameType}")
+                error("Unexpected frame type: ${frame.frameType}")
             }
         }
     }


### PR DESCRIPTION
The bare `detekt` task the CI lint job and documented local gate invoked is `NO-SOURCE` in every module — the detekt plugin only knows the JVM-style `src/main/kotlin` layout, and the per-source-set tasks it registers instead were never wired into `check`. So no static analysis was running anywhere.

## Changes

**Make the gate real**
- Register a `detektAll` task per library module in the `mqtt.kmp.library` convention plugin, aggregating every `Detekt` task except the bare no-op one, and wire it into `check`. Coverage confirmed via `--dry-run`: 24 tasks in `:core`, 20 in `:transport-tcp`, 24 in `:transport-ws` — metadata/common, jvm, android, all natives, wasmJs, plus every test source set.
- Point `ci.yml`, `release.yml`, the PR template, `CONTRIBUTING.md` and `.github/skills/` at `detektAll`; document `detektAll` vs `detekt` in `AGENTS.md` alongside the existing `allTests` vs `test` note.

**Clear the findings** (~490 raw, ~60 distinct; none of these change behaviour)
- Use `require()`/`check()`/`error()` in `WebSocketTransport`, `TcpTransport`, `MqttDecoder` and `MqttClient` — same exception types and messages.
- Tune `config/detekt/detekt.yml`, each entry with rationale: `MagicNumber` off (426 hits, all spec-defined byte values, property IDs and reason codes); `MaxLineLength` 120 → 140 to match the ktlint limit Spotless actually enforces (no line in the repo exceeds 140); `ReturnCount`/`ThrowsCount` raised with `excludeGuardClauses`; complexity rules excluded for `**/packet/**` and `**/*Test.kt` (ADR-0003 spec-driven `when` tables, end-to-end test flows).
- Localized `@Suppress` with rationale in KDoc for the deliberate ones: `MqttConnection` (`LargeClass`, `connect`, `subscribe`, `handlePacket`), `MqttClient` (`connectInternal`, `startReconnect`, `wrapConnectionErrors`, cleanup-and-rethrow catches), `Probe.runProbe`.

## Verification

- Gate fails on a deliberately reintroduced violation (one `error("Not connected")` back to `throw IllegalStateException(...)`): `:transport-ws:detektAll` → `Analysis failed with 1 weighted issues`, and `:transport-ws:check` → `Task :transport-ws:detektMetadataCommonMain FAILED`.
- `./gradlew spotlessCheck detektAll apiCheck` → BUILD SUCCESSFUL
- `./gradlew allTests koverVerify` → BUILD SUCCESSFUL

Note: the Android detekt tasks resolve dependencies through the SDK, so `ANDROID_HOME` must be set locally. GitHub's ubuntu runners have it preinstalled, which the existing `build` job already relies on.

Out of scope: `:sample` doesn't apply detekt at all, so it remains unanalysed. It's unpublished and was never part of the gate — happy to extend it in a follow-up.

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)