### PR TITLE
docs: changelog for 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-26
+
 ### Added
 
 - `WebSocketTransportFactory` now accepts an optional TLS customisation lambda, the WebSocket
@@ -28,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Ktor engine (e.g. `ktor-client-okhttp`, common on Android) may previously have had its WebSocket
   MQTT connection served by that engine instead of CIO, with different proxy, DNS, and socket
   defaults. Such an app will now always get CIO for this transport.
+- The detekt gate is now real (#110). The bare `detekt` task that CI and the documented local gate
+  invoked is `NO-SOURCE` in every module — the plugin only recognises the JVM-style
+  `src/main/kotlin` layout, and the per-source-set tasks it registers were never wired into
+  `check` — so no static analysis had been running. A `detektAll` aggregator is now registered per
+  module and wired into `check`, and the findings it surfaced are cleared. Those fixes are
+  suppressions with written justifications plus one equivalent rewrite
+  (`throw IllegalStateException(…)` → `error(…)`); no behaviour changed and no public API moved.
 
 ## [0.6.1] - 2026-07-26
 


### PR DESCRIPTION
Cuts 0.7.0.

**Minor, not patch** — #108 adds public API. Verified against the committed ABI dumps: `WebSocketTransport` and `WebSocketTransportFactory` each gain an optional `TLSConfigBuilder` lambda constructor, with **no removals**, and `core`/`transport-tcp` dumps untouched. Existing no-arg call sites compile and link unchanged.

The `[Unreleased]` entries #108 shipped are kept as written (they already cover the hook and the Ktor-engine pinning, which is a genuine behavioural change for apps that also ship `ktor-client-okhttp`). I added the missing note for #110 — worth recording because the detekt gate had been **analysing nothing** in every module, and the fixes it forced were suppressions-with-justification plus one equivalent rewrite, so no behaviour changed.

Notably this release closes the loop on #107 → Meshtastic-Android can now scope its user-CA trust to the MQTT connection for **both** `ssl://` and `wss://` (meshtastic/Meshtastic-Android#6454).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.7.0.
  * Documented improvements to the Detekt CI quality gate, ensuring static analysis runs across modules.
  * Noted related cleanup of analysis findings and behavior-preserving code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->