### PR TITLE
fix(client): classify connect failures by origin, plus 3.1.1 silent-close fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unexpected packet type, an AUTH packet during an MQTT 3.1.1 handshake — took a rethrow path that
   skipped transport cleanup, as did an invalid Maximum QoS value in the CONNACK. Handshake cleanup
   is now centralised and covers every rejection path.
+- Cancelling `connect()` mid-handshake no longer leaks the socket either. The cancellation branch
+  rethrows to preserve structured concurrency and so bypassed the failure paths' cleanup; it now
+  closes the transport on a `NonCancellable` context, because the coroutine is already cancelled
+  and a plain suspending close would abort immediately.
+- `probe()` now reports a transport-factory failure as a `ProbeResult` instead of throwing. A
+  composite factory with no delegate for the endpoint throws synchronously from `create()`, which
+  was evaluated outside the classified path and escaped as a raw `IllegalArgumentException`.
 
 ## [0.7.0] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- MQTT 5.0 → 3.1.1 version negotiation now also triggers when a broker **silently closes** the
+  connection on an MQTT 5.0 CONNECT instead of answering with an `UNSUPPORTED_PROTOCOL_VERSION`
+  CONNACK. Many older brokers and gateways (observed live on `mqtt.defcon.run:4433`) drop the
+  connection without any reply, which previously surfaced as a bare transport error
+  (`EOFException: Not enough data available`) — the Meshtastic Android app misreported it as a
+  credentials problem, while iOS clients, which speak 3.1.1 natively, connected fine. The client
+  and `MqttClient.probe` now retry once with MQTT 3.1.1 when `negotiateVersion` is enabled (the
+  default). The fallback is phase-gated: it fires only when the connection failed *after* the
+  CONNECT packet was written and *before* a CONNACK arrived. DNS, TCP, and TLS failures — and
+  CONNACK timeouts, where the broker kept the connection open — keep their current behaviour, so
+  real network errors are never masked and dead hosts don't pay a doubled connect latency. The
+  probe's retry runs within the remaining `timeoutMs` budget, preserving its total wall-clock
+  contract. `probe` additionally gains the explicit `UNSUPPORTED_PROTOCOL_VERSION` fallback the
+  client already had, so probing a 3.1.1-only broker now reports `Success` instead of `Rejected`.
+
 ## [0.7.0] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `MqttException.ConnectionFailed` — a new subtype for a connect attempt that failed before the
+  broker accepted or refused it: DNS, TCP connect, TLS handshake, a socket that closed
+  mid-handshake, or a CONNACK that never arrived.
+
+### Changed
+
+- **`connect()` no longer reports every failure as `MqttException.ConnectionRejected`.** It now
+  classifies by which side of the handshake failed, because a consumer cannot write a correct retry
+  policy without that distinction: a rejection means the broker read the CONNECT and said no, so
+  retrying the same configuration is pointless, whereas a network failure is exactly what a retry
+  is for. Previously both arrived as `ConnectionRejected`, so a TCP timeout or a TLS chain failure
+  was indistinguishable from a bad password — a caller that stopped on `ConnectionRejected` gave up
+  permanently on a transient network blip, and one that retried hammered a broker that would never
+  accept it. Downstream consumers had to reach past the type and re-derive the answer from reason
+  codes.
+
+  `connect()` now throws:
+
+  - `ConnectionRejected` only for a genuine CONNACK carrying an error reason code — including an
+    unsupported protocol version that could not be renegotiated, and including a CONNACK whose
+    reason code is `PROTOCOL_ERROR`, since the broker still answered. `serverReference` is
+    preserved.
+  - `ConnectionFailed` for transport and I/O failures, with the original platform exception kept as
+    `cause`.
+  - `ProtocolError` when the broker answered but violated the spec (a malformed CONNACK, an
+    unexpected packet type mid-handshake).
+
+  Reason codes alone could not express this — a broker may legitimately refuse a CONNECT with
+  `PROTOCOL_ERROR`, and a transport failure has no broker reason code at all and synthesises
+  `UNSPECIFIED_ERROR` — so the connection layer now records the failure's origin explicitly.
+
+  **Migration:** callers matching `MqttException.ConnectionRejected` to stop retrying keep working
+  and get more accurate: only real refusals land there now. Code that relied on `ConnectionRejected`
+  as the catch-all for *any* connect failure should add a `ConnectionFailed` branch, or catch
+  `MqttException`. Auto-reconnect behaviour is unchanged — it already classified by reason code and
+  never stopped on a transport failure.
+
 ### Fixed
 
 - MQTT 5.0 → 3.1.1 version negotiation now also triggers when a broker **silently closes** the
@@ -18,11 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `MqttClient.probe` now retry once with MQTT 3.1.1 when `negotiateVersion` is enabled (the
   default). The fallback is phase-gated: it fires only when the connection failed *after* the
   CONNECT packet was written and *before* a CONNACK arrived. DNS, TCP, and TLS failures — and
-  CONNACK timeouts, where the broker kept the connection open — keep their current behaviour, so
-  real network errors are never masked and dead hosts don't pay a doubled connect latency. The
-  probe's retry runs within the remaining `timeoutMs` budget, preserving its total wall-clock
-  contract. `probe` additionally gains the explicit `UNSUPPORTED_PROTOCOL_VERSION` fallback the
-  client already had, so probing a 3.1.1-only broker now reports `Success` instead of `Rejected`.
+  CONNACK timeouts, where the broker kept the connection open — do not trigger it, so real network
+  errors are never masked and dead hosts don't pay a doubled connect latency. Those failures are
+  still reported accurately, as `ConnectionFailed` per the classification change above. The probe's
+  retry runs within the remaining `timeoutMs` budget, preserving its total wall-clock contract.
+  `probe` additionally gains the explicit `UNSUPPORTED_PROTOCOL_VERSION` fallback the client
+  already had, so probing a 3.1.1-only broker now reports `Success` instead of `Rejected`.
+- A failed handshake no longer leaks the socket. Rejections raised while awaiting CONNACK — an
+  unexpected packet type, an AUTH packet during an MQTT 3.1.1 handshake — took a rethrow path that
+  skipped transport cleanup, as did an invalid Maximum QoS value in the CONNACK. Handshake cleanup
+  is now centralised and covers every rejection path.
 
 ## [0.7.0] - 2026-07-26
 

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -723,6 +723,10 @@ sealed class org.meshtastic.mqtt/MqttException : kotlin/Exception { // org.mesht
     final val reasonCode // org.meshtastic.mqtt/MqttException.reasonCode|{}reasonCode[0]
         final fun <get-reasonCode>(): org.meshtastic.mqtt/ReasonCode // org.meshtastic.mqtt/MqttException.reasonCode.<get-reasonCode>|<get-reasonCode>(){}[0]
 
+    final class ConnectionFailed : org.meshtastic.mqtt/MqttException { // org.meshtastic.mqtt/MqttException.ConnectionFailed|null[0]
+        constructor <init>(org.meshtastic.mqtt/ReasonCode, kotlin/String, kotlin/Throwable? = ...) // org.meshtastic.mqtt/MqttException.ConnectionFailed.<init>|<init>(org.meshtastic.mqtt.ReasonCode;kotlin.String;kotlin.Throwable?){}[0]
+    }
+
     final class ConnectionLost : org.meshtastic.mqtt/MqttException { // org.meshtastic.mqtt/MqttException.ConnectionLost|null[0]
         constructor <init>(org.meshtastic.mqtt/ReasonCode, kotlin/String, kotlin/Throwable? = ...) // org.meshtastic.mqtt/MqttException.ConnectionLost.<init>|<init>(org.meshtastic.mqtt.ReasonCode;kotlin.String;kotlin.Throwable?){}[0]
     }

--- a/core/api/jvm/core.api
+++ b/core/api/jvm/core.api
@@ -269,6 +269,11 @@ public abstract class org/meshtastic/mqtt/MqttException : java/lang/Exception {
 	public final fun getReasonCode ()Lorg/meshtastic/mqtt/ReasonCode;
 }
 
+public final class org/meshtastic/mqtt/MqttException$ConnectionFailed : org/meshtastic/mqtt/MqttException {
+	public fun <init> (Lorg/meshtastic/mqtt/ReasonCode;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lorg/meshtastic/mqtt/ReasonCode;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class org/meshtastic/mqtt/MqttException$ConnectionLost : org/meshtastic/mqtt/MqttException {
 	public fun <init> (Lorg/meshtastic/mqtt/ReasonCode;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Lorg/meshtastic/mqtt/ReasonCode;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
@@ -363,9 +363,23 @@ public class MqttClient
          * `SERVER_MOVED` with a Server Reference property), the client automatically follows
          * the redirect up to [MAX_REDIRECTS] times (§4.13).
          *
+         * Failures are classified by which side of the handshake produced them, so a caller can
+         * tell an unusable configuration from a bad network and pick a retry policy accordingly.
+         *
          * @param endpoint Broker endpoint (TCP or WebSocket).
-         * @throws MqttException.ConnectionRejected if the broker rejects the connection.
+         * @throws MqttException.ConnectionRejected if the broker answered with a CONNACK carrying
+         *   an error reason code — including an unsupported protocol version that could not be
+         *   renegotiated. Retrying the same configuration will fail the same way.
+         * @throws MqttException.ConnectionFailed if the transport failed before any CONNACK
+         *   arrived (DNS, TCP, TLS, a socket closed mid-handshake, or a CONNACK timeout). The
+         *   broker never expressed an opinion, so a retry may succeed.
+         * @throws MqttException.ProtocolError if the broker answered but violated the spec.
+         *
+         * `SwallowedException` is suppressed deliberately: the internal exception is not chained as
+         * the cause, because [toConnectException] carries over its reason code, message, server
+         * reference and its own cause, and the internal type is not part of the public API.
          */
+        @Suppress("SwallowedException")
         @Throws(MqttException::class, kotlin.coroutines.cancellation.CancellationException::class)
         public suspend fun connect(endpoint: MqttEndpoint) {
             try {
@@ -395,16 +409,10 @@ public class MqttClient
                     connectWithRedirect(endpoint, redirectsRemaining = MAX_REDIRECTS)
                 }
             } catch (e: MqttConnectionException) {
-                val rejected =
-                    MqttException.ConnectionRejected(
-                        reasonCode = e.reasonCode,
-                        message = e.message ?: "Connection failed",
-                        cause = e.cause,
-                        serverReference = e.serverReference,
-                    )
+                val failure = e.toConnectException()
                 // Forwarding hasn't started yet (connection==null on failure), so we own the state.
-                _connectionState.value = ConnectionState.Disconnected(reason = rejected)
-                throw rejected
+                _connectionState.value = ConnectionState.Disconnected(reason = failure)
+                throw failure
             }
         }
 

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttClient.kt
@@ -729,14 +729,20 @@ public class MqttClient
             try {
                 conn.connect(endpoint)
             } catch (e: MqttConnectionException) {
-                // Version fallback: if broker rejected V5_0, try V3_1_1 on a fresh transport
-                if (
-                    e.reasonCode == ReasonCode.UNSUPPORTED_PROTOCOL_VERSION &&
-                    effectiveVersion == MqttProtocolVersion.V5_0 &&
-                    config.negotiateVersion
-                ) {
+                // Version fallback: if broker rejected V5_0 — either explicitly with an
+                // UNSUPPORTED_PROTOCOL_VERSION CONNACK, or silently by closing the connection
+                // after the CONNECT was written without ever answering (many older brokers and
+                // gateways do this) — try V3_1_1 on a fresh transport.
+                val silentClose = e.closedBeforeConnAck
+                val v5Refused = e.reasonCode == ReasonCode.UNSUPPORTED_PROTOCOL_VERSION || silentClose
+                if (v5Refused && effectiveVersion == MqttProtocolVersion.V5_0 && config.negotiateVersion) {
                     log.info(TAG) {
-                        "Broker rejected MQTT 5.0 — falling back to MQTT 3.1.1"
+                        if (silentClose) {
+                            "Broker closed the connection without answering the MQTT 5.0 CONNECT — " +
+                                "falling back to MQTT 3.1.1"
+                        } else {
+                            "Broker rejected MQTT 5.0 — falling back to MQTT 3.1.1"
+                        }
                     }
                     // Validate the config is compatible with 3.1.1 before retrying
                     try {

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -214,14 +214,22 @@ internal class MqttConnection(
 
         log.debug(TAG) { "Establishing transport connection to $endpoint" }
 
+        // Tracks the handshake phase so the generic catch below can tell a broker that
+        // closed the connection *after* the CONNECT packet was written (some brokers
+        // silently drop unsupported protocol versions instead of answering with an
+        // UNSUPPORTED_PROTOCOL_VERSION CONNACK) apart from TCP/TLS/DNS failures that
+        // happen before CONNECT was ever sent.
+        var awaitingConnAck = false
         try {
             transport.connect(endpoint)
             val connectPacket = buildConnectPacket()
             log.debug(TAG) { "Sending CONNECT (clientId='${config.clientId}', cleanStart=${config.cleanStart})" }
             sendPacket(connectPacket)
+            awaitingConnAck = true
 
             // Read responses until CONNACK; AUTH packets may interleave for enhanced auth (§4.12)
             val connAck = awaitConnAck()
+            awaitingConnAck = false
 
             if (connAck.reasonCode != ReasonCode.SUCCESS) {
                 log.error(TAG) { "Connection refused: ${connAck.reasonCode}" }
@@ -338,6 +346,12 @@ internal class MqttConnection(
                 // Best-effort transport close on handshake failure
             }
             _connectionState.value = ConnectionState.Disconnected.Idle
+            if (awaitingConnAck) {
+                throw ConnectionClosedBeforeConnAckException(
+                    "Connection closed before CONNACK: ${e.message}",
+                    e,
+                )
+            }
             throw MqttConnectionException(ReasonCode.UNSPECIFIED_ERROR, "Connection failed: ${e.message}", e)
         }
     }
@@ -1415,12 +1429,36 @@ internal class MqttConnection(
  * @property reasonCode The MQTT 5.0 reason code from the broker.
  * @property serverReference Server reference from CONNACK/DISCONNECT for redirect handling (§4.13).
  */
-internal class MqttConnectionException(
+internal open class MqttConnectionException(
     val reasonCode: ReasonCode,
     message: String,
     cause: Throwable? = null,
     val serverReference: String? = null,
-) : Exception(message, cause)
+) : Exception(message, cause) {
+    /**
+     * `true` when the failure was a broker closing the connection between CONNECT being
+     * written and CONNACK arriving — see [ConnectionClosedBeforeConnAckException].
+     */
+    open val closedBeforeConnAck: Boolean get() = false
+}
+
+/**
+ * The transport failed *after* the CONNECT packet was written but *before* a CONNACK
+ * arrived — typically a broker that silently closes the connection instead of answering
+ * an unsupported CONNECT (e.g. older brokers/gateways dropping MQTT 5.0 CONNECTs).
+ *
+ * [MqttClient] and the probe path use this phase distinction to fall back to MQTT 3.1.1
+ * when version negotiation is enabled. Failures before CONNECT was written (TCP connect,
+ * TLS handshake, DNS) deliberately stay plain [MqttConnectionException]s so real network
+ * errors are never masked by a pointless retry. A CONNACK timeout is also excluded: the
+ * broker kept the connection open, so retrying with 3.1.1 would just double the wait.
+ */
+internal class ConnectionClosedBeforeConnAckException(
+    message: String,
+    cause: Throwable? = null,
+) : MqttConnectionException(ReasonCode.UNSPECIFIED_ERROR, message, cause) {
+    override val closedBeforeConnAck: Boolean get() = true
+}
 
 /**
  * Represents a server redirect instruction received via CONNACK or DISCONNECT (§4.13).

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -233,13 +233,12 @@ internal class MqttConnection(
 
             if (connAck.reasonCode != ReasonCode.SUCCESS) {
                 log.error(TAG) { "Connection refused: ${connAck.reasonCode}" }
-                transport.close()
-                _connectionState.value = ConnectionState.Disconnected.Idle
                 val serverRef = connAck.properties.serverReference
                 throw MqttConnectionException(
                     connAck.reasonCode,
                     "Connection refused: ${connAck.reasonCode}",
                     serverReference = serverRef,
+                    failure = ConnectFailure.BROKER_REFUSAL,
                 )
             }
 
@@ -252,11 +251,10 @@ internal class MqttConnection(
                 log.error(TAG) {
                     "Protocol error: sessionPresent=true with cleanStart=true (§3.2.2.1.1)"
                 }
-                transport.close()
-                _connectionState.value = ConnectionState.Disconnected.Idle
                 throw MqttConnectionException(
                     ReasonCode.PROTOCOL_ERROR,
                     "Server set sessionPresent=true with cleanStart=true (§3.2.2.1.1)",
+                    failure = ConnectFailure.PROTOCOL_VIOLATION,
                 )
             }
 
@@ -282,6 +280,7 @@ internal class MqttConnection(
                                 throw MqttConnectionException(
                                     ReasonCode.PROTOCOL_ERROR,
                                     "Invalid Maximum QoS value $value in CONNACK (§3.2.2.3.4)",
+                                    failure = ConnectFailure.PROTOCOL_VIOLATION,
                                 )
                             }
                         }
@@ -315,22 +314,19 @@ internal class MqttConnection(
 
             return connAck
         } catch (e: MqttConnectionException) {
+            // Every handshake rejection lands here, including the ones awaitConnAck raises, so
+            // the socket is released on all of them rather than only where the throw is inline.
+            abandonHandshake()
             throw e
         } catch (e: TimeoutCancellationException) {
             // awaitConnAck timed out — map to a meaningful connection error
             log.error(TAG) { "Connection timed out waiting for CONNACK" }
-            try {
-                transport.close()
-            } catch (
-                @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
-            ) {
-                // Best-effort transport close
-            }
-            _connectionState.value = ConnectionState.Disconnected.Idle
+            abandonHandshake()
             throw MqttConnectionException(
                 ReasonCode.UNSPECIFIED_ERROR,
                 "Connection timed out: no CONNACK received within ${ACK_TIMEOUT_MS}ms",
                 e,
+                failure = ConnectFailure.TRANSPORT,
             )
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e // Preserve structured concurrency — do not wrap cancellation
@@ -338,22 +334,32 @@ internal class MqttConnection(
             @Suppress("TooGenericExceptionCaught") e: Exception,
         ) {
             log.error(TAG, throwable = e) { "Connection failed: ${e.message}" }
-            try {
-                transport.close()
-            } catch (
-                @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
-            ) {
-                // Best-effort transport close on handshake failure
-            }
-            _connectionState.value = ConnectionState.Disconnected.Idle
+            abandonHandshake()
             if (awaitingConnAck) {
                 throw ConnectionClosedBeforeConnAckException(
                     "Connection closed before CONNACK: ${e.message}",
                     e,
                 )
             }
-            throw MqttConnectionException(ReasonCode.UNSPECIFIED_ERROR, "Connection failed: ${e.message}", e)
+            throw MqttConnectionException(
+                ReasonCode.UNSPECIFIED_ERROR,
+                "Connection failed: ${e.message}",
+                e,
+                failure = ConnectFailure.TRANSPORT,
+            )
         }
+    }
+
+    /** Release the socket and reset state after a failed CONNECT/CONNACK handshake. */
+    private suspend fun abandonHandshake() {
+        try {
+            transport.close()
+        } catch (
+            @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+        ) {
+            // Best-effort transport close on handshake failure
+        }
+        _connectionState.value = ConnectionState.Disconnected.Idle
     }
 
     /**
@@ -378,6 +384,7 @@ internal class MqttConnection(
                             throw MqttConnectionException(
                                 ReasonCode.PROTOCOL_ERROR,
                                 "Received AUTH packet during MQTT 3.1.1 handshake",
+                                failure = ConnectFailure.PROTOCOL_VIOLATION,
                             )
                         }
                         _authChallenges.emit(
@@ -394,6 +401,7 @@ internal class MqttConnection(
                         throw MqttConnectionException(
                             ReasonCode.PROTOCOL_ERROR,
                             "Expected CONNACK or AUTH during handshake, got ${response.packetType}",
+                            failure = ConnectFailure.PROTOCOL_VIOLATION,
                         )
                     }
                 }
@@ -1428,12 +1436,17 @@ internal class MqttConnection(
  *
  * @property reasonCode The MQTT 5.0 reason code from the broker.
  * @property serverReference Server reference from CONNACK/DISCONNECT for redirect handling (§4.13).
+ * @property failure Which side of the handshake produced the failure, or `null` outside the
+ *   CONNECT/CONNACK handshake. Reason codes alone cannot carry this: a broker may legitimately
+ *   refuse a CONNECT with `PROTOCOL_ERROR`, and a transport failure has no broker reason code at
+ *   all, so both arrive as reason codes the connect path would otherwise classify identically.
  */
 internal open class MqttConnectionException(
     val reasonCode: ReasonCode,
     message: String,
     cause: Throwable? = null,
     val serverReference: String? = null,
+    val failure: ConnectFailure? = null,
 ) : Exception(message, cause) {
     /**
      * `true` when the failure was a broker closing the connection between CONNECT being
@@ -1452,12 +1465,37 @@ internal open class MqttConnectionException(
  * TLS handshake, DNS) deliberately stay plain [MqttConnectionException]s so real network
  * errors are never masked by a pointless retry. A CONNACK timeout is also excluded: the
  * broker kept the connection open, so retrying with 3.1.1 would just double the wait.
+ *
+ * Still a [ConnectFailure.TRANSPORT] failure: the broker never answered, so once the 3.1.1
+ * fallback has been exhausted this surfaces to the caller as [MqttException.ConnectionFailed].
  */
 internal class ConnectionClosedBeforeConnAckException(
     message: String,
     cause: Throwable? = null,
-) : MqttConnectionException(ReasonCode.UNSPECIFIED_ERROR, message, cause) {
+) : MqttConnectionException(
+        ReasonCode.UNSPECIFIED_ERROR,
+        message,
+        cause,
+        failure = ConnectFailure.TRANSPORT,
+    ) {
     override val closedBeforeConnAck: Boolean get() = true
+}
+
+/**
+ * Which side of the CONNECT/CONNACK handshake produced a [MqttConnectionException].
+ *
+ * The distinction drives retry policy: only [BROKER_REFUSAL] means the broker saw the CONNECT
+ * and said no, so a retry with the same configuration will fail the same way.
+ */
+internal enum class ConnectFailure {
+    /** The broker answered with a CONNACK carrying a non-SUCCESS reason code (§3.2.2.2). */
+    BROKER_REFUSAL,
+
+    /** The broker answered, but violated the spec (malformed CONNACK, wrong packet type). */
+    PROTOCOL_VIOLATION,
+
+    /** Transport or I/O failed before any CONNACK arrived — DNS, TCP, TLS, EOF, or timeout. */
+    TRANSPORT,
 }
 
 /**

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -329,6 +329,10 @@ internal class MqttConnection(
                 failure = ConnectFailure.TRANSPORT,
             )
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            // Cancelled mid-handshake, so the socket may already be open. Cleanup runs on a
+            // non-cancellable context because this coroutine is already cancelled and a plain
+            // suspending close would abort immediately, leaking the transport.
+            withContext(NonCancellable) { abandonHandshake() }
             throw e // Preserve structured concurrency — do not wrap cancellation
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Exception,

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttException.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttException.kt
@@ -57,10 +57,26 @@ public sealed class MqttException(
     ) : MqttException(reasonCode, message, cause)
 
     /**
-     * The connection was lost unexpectedly.
+     * The connection attempt failed before the broker accepted or refused it.
+     *
+     * Covers transport-level failures during [MqttClient.connect] — DNS resolution, TCP connect,
+     * TLS handshake, a socket that closed mid-handshake, and a CONNACK that never arrived. The
+     * broker never expressed an opinion, so the attempt is worth retrying; contrast
+     * [ConnectionRejected], which carries the broker's own refusal and will fail the same way
+     * against the same configuration.
+     */
+    public class ConnectionFailed(
+        reasonCode: ReasonCode,
+        message: String,
+        cause: Throwable? = null,
+    ) : MqttException(reasonCode, message, cause)
+
+    /**
+     * The connection was lost unexpectedly, after it had been established.
      *
      * Emitted when the transport fails, keepalive times out, or the broker
-     * sends a DISCONNECT packet.
+     * sends a DISCONNECT packet. A failure during the initial handshake is
+     * [ConnectionFailed] instead.
      */
     public class ConnectionLost(
         reasonCode: ReasonCode,
@@ -106,6 +122,12 @@ internal fun Throwable.toMqttException(defaultReasonCode: ReasonCode = ReasonCod
                     cause = this.cause,
                     serverReference = this.serverReference,
                 )
+            } else if (this.failure == ConnectFailure.TRANSPORT) {
+                MqttException.ConnectionFailed(
+                    reasonCode = this.reasonCode,
+                    message = this.message ?: "Connection failed",
+                    cause = this.cause,
+                )
             } else {
                 MqttException.ConnectionLost(
                     reasonCode = this.reasonCode,
@@ -121,5 +143,49 @@ internal fun Throwable.toMqttException(defaultReasonCode: ReasonCode = ReasonCod
                 message = this.message ?: this::class.simpleName ?: "Unknown error",
                 cause = this,
             )
+        }
+    }
+
+/**
+ * Map a handshake failure to the public [MqttException] the [MqttClient.connect] caller sees.
+ *
+ * Classification follows which side failed, not the reason code: a broker may refuse a CONNECT
+ * with `PROTOCOL_ERROR`, and a transport failure synthesises `UNSPECIFIED_ERROR`, so the reason
+ * code alone cannot separate "the broker said no" from "the network flaked". Only
+ * [ConnectFailure.BROKER_REFUSAL] becomes [MqttException.ConnectionRejected]; retrying the others
+ * against the same configuration may well succeed.
+ *
+ * Falls back to [toMqttException] when the origin is unset, which happens only for failures
+ * raised outside the CONNECT/CONNACK handshake.
+ */
+internal fun MqttConnectionException.toConnectException(): MqttException =
+    when (failure) {
+        ConnectFailure.BROKER_REFUSAL -> {
+            MqttException.ConnectionRejected(
+                reasonCode = reasonCode,
+                message = message ?: "Connection refused by broker",
+                cause = cause,
+                serverReference = serverReference,
+            )
+        }
+
+        ConnectFailure.PROTOCOL_VIOLATION -> {
+            MqttException.ProtocolError(
+                reasonCode = reasonCode,
+                message = message ?: "Protocol error during connect",
+                cause = cause,
+            )
+        }
+
+        ConnectFailure.TRANSPORT -> {
+            MqttException.ConnectionFailed(
+                reasonCode = reasonCode,
+                message = message ?: "Connection failed",
+                cause = cause,
+            )
+        }
+
+        null -> {
+            toMqttException()
         }
     }

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
@@ -123,7 +123,7 @@ internal suspend fun runProbeNegotiating(
     timeoutMs: Long,
 ): ProbeResult {
     val start = TimeSource.Monotonic.markNow()
-    val attempt = runProbeAttempt(config, createTransport(), endpoint, timeoutMs)
+    val attempt = runProbeAttempt(config, createTransport, endpoint, timeoutMs)
     val remainingMs = timeoutMs - start.elapsedNow().inWholeMilliseconds
 
     // Fall back only when the first (MQTT 5.0) attempt indicates the broker doesn't speak
@@ -139,7 +139,7 @@ internal suspend fun runProbeNegotiating(
             runCatching { config.validateV311Compatibility() }.isSuccess
     return if (v5Refused && canFallBack && remainingMs > 0) {
         val fallbackConfig = config.copy(protocolVersion = MqttProtocolVersion.V3_1_1)
-        runProbeAttempt(fallbackConfig, createTransport(), endpoint, remainingMs).result
+        runProbeAttempt(fallbackConfig, createTransport, endpoint, remainingMs).result
     } else {
         attempt.result
     }
@@ -155,7 +155,7 @@ internal suspend fun runProbe(
     transport: MqttTransport,
     endpoint: MqttEndpoint,
     timeoutMs: Long,
-): ProbeResult = runProbeAttempt(config, transport, endpoint, timeoutMs).result
+): ProbeResult = runProbeAttempt(config, { transport }, endpoint, timeoutMs).result
 
 /** Outcome of one probe attempt, plus the phase signal driving 5.0 → 3.1.1 fallback. */
 private class ProbeAttempt(
@@ -164,7 +164,11 @@ private class ProbeAttempt(
 )
 
 /**
- * One CONNECT/CONNACK probe attempt against a pre-built transport.
+ * One CONNECT/CONNACK probe attempt, against a transport it builds via [createTransport].
+ *
+ * The transport is built inside the classified path on purpose: a factory can reject the endpoint
+ * synchronously (a composite factory with no delegate that supports it), and [probe] promises to
+ * report failures as a [ProbeResult] rather than throw.
  *
  * `SwallowedException` is suppressed deliberately: a timeout is a normal probe outcome, not an
  * error, and is translated into [ProbeResult.Timeout], which carries the timeout budget instead
@@ -173,10 +177,23 @@ private class ProbeAttempt(
 @Suppress("SwallowedException")
 private suspend fun runProbeAttempt(
     config: MqttConfig,
-    transport: MqttTransport,
+    createTransport: () -> MqttTransport,
     endpoint: MqttEndpoint,
     timeoutMs: Long,
 ): ProbeAttempt {
+    val transport =
+        try {
+            createTransport()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Throwable,
+        ) {
+            return ProbeAttempt(
+                classifyProbeFailure(e, fallbackTimeoutMs = timeoutMs),
+                closedBeforeConnAck = false,
+            )
+        }
     val probeScope =
         CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("MqttProbe"))
     val connection = MqttConnection(transport, config, probeScope)

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
@@ -231,10 +231,8 @@ internal fun classifyProbeFailure(
             serverReference = error.serverReference,
         )
     }
-    if (error is MqttConnectionException && error.cause == null) {
-        // CONNACK refusal path: MqttConnection throws MqttConnectionException directly (no cause)
-        // when the broker returns a non-SUCCESS reason code. Treat as a Rejected outcome so
-        // probe consumers can surface the broker's reason code to the user.
+    if (error is MqttConnectionException && error.failure == ConnectFailure.BROKER_REFUSAL) {
+        // CONNACK refusal: report the broker's own reason code so probe consumers can surface it.
         return ProbeResult.Rejected(
             reasonCode = error.reasonCode,
             message = error.message ?: "Broker rejected the connection",

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/Probe.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.meshtastic.mqtt.packet.MqttProperties
+import kotlin.time.TimeSource
 
 /**
  * Default timeout for [MqttClient.probe], in milliseconds.
@@ -49,6 +50,11 @@ public const val DEFAULT_PROBE_TIMEOUT_MS: Long = 5_000
  * default; override via [configure] if your broker enforces specific credentials
  * or client identifiers. `autoReconnect` is forced to `false` regardless of the
  * configure block — probes are always single-shot.
+ *
+ * Version negotiation matches [MqttClient.connect]: when `negotiateVersion` is enabled
+ * (the default) and the broker either rejects the MQTT 5.0 CONNECT with
+ * `UNSUPPORTED_PROTOCOL_VERSION` or closes the connection without answering it, the
+ * probe retries once with MQTT 3.1.1 within the remaining [timeoutMs] budget.
  *
  * ## Example
  * ```kotlin
@@ -75,48 +81,102 @@ public suspend fun MqttClient.Companion.probe(
     configure: MqttConfig.Builder.() -> Unit = {},
 ): ProbeResult {
     require(timeoutMs > 0) { "timeoutMs must be > 0, got: $timeoutMs" }
-    val config = buildProbeConfig(configure)
-    val transport =
-        (
-            config.transportFactory ?: error(
-                "probe() requires a transportFactory. Set it in the configure block, " +
-                    "e.g. transportFactory = TcpTransportFactory().",
-            )
-        ).create(endpoint)
-    return runProbe(config, transport, endpoint, timeoutMs)
+    // Transient probe config: force autoReconnect=false and default keepAliveSeconds=0 so
+    // the probe never starts a keepalive loop, but let the caller override clientId,
+    // credentials, will, etc.
+    val config =
+        MqttConfig
+            .Builder()
+            .apply {
+                clientId = ""
+                keepAliveSeconds = 0
+                cleanStart = true
+                configure()
+                autoReconnect = false
+            }.build()
+    val factory =
+        config.transportFactory ?: error(
+            "probe() requires a transportFactory. Set it in the configure block, " +
+                "e.g. transportFactory = TcpTransportFactory().",
+        )
+    return runProbeNegotiating(config, { factory.create(endpoint) }, endpoint, timeoutMs)
 }
 
 /**
- * Build the transient config used by [probe]. Forces `autoReconnect = false` and
- * defaults `keepAliveSeconds = 0` so the probe never starts a keepalive loop, but
- * lets the caller override clientId, credentials, will, etc.
+ * Run a probe with the same MQTT version negotiation [MqttClient.connect] performs: when
+ * [MqttConfig.negotiateVersion] is enabled and an MQTT 5.0 CONNECT is either rejected with
+ * `UNSUPPORTED_PROTOCOL_VERSION` or the broker closes the connection without answering it
+ * (a silent close after CONNECT was written — common on older brokers and gateways), retry
+ * once with MQTT 3.1.1 on a fresh transport.
+ *
+ * The retry runs within whatever remains of the caller's [timeoutMs] budget, so the probe's
+ * "total wall-clock budget" contract holds across both attempts. Failures before CONNECT was
+ * written (DNS, TCP, TLS) never trigger the retry — see [ConnectionClosedBeforeConnAckException].
+ *
+ * `internal` rather than private so `commonTest` can drive the negotiation arms via
+ * [FakeTransport]-producing factories.
  */
-private fun buildProbeConfig(configure: MqttConfig.Builder.() -> Unit): MqttConfig =
-    MqttConfig
-        .Builder()
-        .apply {
-            clientId = ""
-            keepAliveSeconds = 0
-            cleanStart = true
-            configure()
-            autoReconnect = false
-        }.build()
+internal suspend fun runProbeNegotiating(
+    config: MqttConfig,
+    createTransport: () -> MqttTransport,
+    endpoint: MqttEndpoint,
+    timeoutMs: Long,
+): ProbeResult {
+    val start = TimeSource.Monotonic.markNow()
+    val attempt = runProbeAttempt(config, createTransport(), endpoint, timeoutMs)
+    val remainingMs = timeoutMs - start.elapsedNow().inWholeMilliseconds
+
+    // Fall back only when the first (MQTT 5.0) attempt indicates the broker doesn't speak
+    // 5.0 — an explicit UNSUPPORTED_PROTOCOL_VERSION CONNACK or a silent close after the
+    // CONNECT was written — and the config both permits negotiation and can be expressed
+    // in 3.1.1.
+    val v5Refused =
+        attempt.closedBeforeConnAck ||
+            (attempt.result as? ProbeResult.Rejected)?.reasonCode == ReasonCode.UNSUPPORTED_PROTOCOL_VERSION
+    val canFallBack =
+        config.negotiateVersion &&
+            config.protocolVersion == MqttProtocolVersion.V5_0 &&
+            runCatching { config.validateV311Compatibility() }.isSuccess
+    return if (v5Refused && canFallBack && remainingMs > 0) {
+        val fallbackConfig = config.copy(protocolVersion = MqttProtocolVersion.V3_1_1)
+        runProbeAttempt(fallbackConfig, createTransport(), endpoint, remainingMs).result
+    } else {
+        attempt.result
+    }
+}
 
 /**
- * Test-injectable variant that takes a pre-built transport. `internal` rather than private so
- * `commonTest` can drive each [ProbeResult] arm via [FakeTransport].
+ * Test-injectable variant that takes a pre-built transport and performs a single attempt with
+ * no version negotiation. `internal` rather than private so `commonTest` can drive each
+ * [ProbeResult] arm via [FakeTransport].
+ */
+internal suspend fun runProbe(
+    config: MqttConfig,
+    transport: MqttTransport,
+    endpoint: MqttEndpoint,
+    timeoutMs: Long,
+): ProbeResult = runProbeAttempt(config, transport, endpoint, timeoutMs).result
+
+/** Outcome of one probe attempt, plus the phase signal driving 5.0 → 3.1.1 fallback. */
+private class ProbeAttempt(
+    val result: ProbeResult,
+    val closedBeforeConnAck: Boolean,
+)
+
+/**
+ * One CONNECT/CONNACK probe attempt against a pre-built transport.
  *
  * `SwallowedException` is suppressed deliberately: a timeout is a normal probe outcome, not an
  * error, and is translated into [ProbeResult.Timeout], which carries the timeout budget instead
  * of the exception.
  */
 @Suppress("SwallowedException")
-internal suspend fun runProbe(
+private suspend fun runProbeAttempt(
     config: MqttConfig,
     transport: MqttTransport,
     endpoint: MqttEndpoint,
     timeoutMs: Long,
-): ProbeResult {
+): ProbeAttempt {
     val probeScope =
         CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("MqttProbe"))
     val connection = MqttConnection(transport, config, probeScope)
@@ -128,16 +188,21 @@ internal suspend fun runProbe(
             } else {
                 ProbeServerInfo() // Empty info for MQTT 3.1.1
             }
-        ProbeResult.Success(serverInfo = serverInfo)
+        ProbeAttempt(ProbeResult.Success(serverInfo = serverInfo), closedBeforeConnAck = false)
     } catch (e: TimeoutCancellationException) {
-        ProbeResult.Timeout(durationMs = timeoutMs)
+        ProbeAttempt(ProbeResult.Timeout(durationMs = timeoutMs), closedBeforeConnAck = false)
     } catch (e: CancellationException) {
         // External cancellation — propagate to preserve structured concurrency.
         throw e
+    } catch (e: MqttConnectionException) {
+        ProbeAttempt(
+            classifyProbeFailure(e, fallbackTimeoutMs = timeoutMs),
+            closedBeforeConnAck = e.closedBeforeConnAck,
+        )
     } catch (
         @Suppress("TooGenericExceptionCaught") e: Throwable,
     ) {
-        classifyProbeFailure(e, fallbackTimeoutMs = timeoutMs)
+        ProbeAttempt(classifyProbeFailure(e, fallbackTimeoutMs = timeoutMs), closedBeforeConnAck = false)
     } finally {
         // Tear down on a non-cancellable context so probe cleanup is reliable
         // even if the caller's coroutine is being cancelled.

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/ConnectFailureClassificationTest.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/ConnectFailureClassificationTest.kt
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.mqtt.packet.ConnAck
+import org.meshtastic.mqtt.packet.MqttProperties
+import org.meshtastic.mqtt.packet.PingResp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+
+/**
+ * `connect()` must distinguish a broker that refused the CONNECT from a network that failed
+ * before the broker ever answered.
+ *
+ * Both used to surface as [MqttException.ConnectionRejected], which made a TCP timeout or a TLS
+ * chain failure indistinguishable from bad credentials — so a consumer with a retry loop either
+ * hammered a broker that would never accept it, or gave up permanently on a transient network
+ * blip. Only a genuine CONNACK carrying an error reason code is a rejection.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectFailureClassificationTest {
+    private val endpoint = MqttEndpoint.Tcp("localhost", 1883)
+
+    private fun config(
+        negotiateVersion: Boolean = false,
+        autoReconnect: Boolean = false,
+        cleanStart: Boolean = true,
+        maxReconnectAttempts: Int = 0,
+    ): MqttConfig =
+        MqttConfig(
+            clientId = "test-client",
+            keepAliveSeconds = 0,
+            cleanStart = cleanStart,
+            negotiateVersion = negotiateVersion,
+            autoReconnect = autoReconnect,
+            maxReconnectAttempts = maxReconnectAttempts,
+            reconnectBaseDelayMs = 100,
+            reconnectMaxDelayMs = 500,
+        )
+
+    // --- Transport failures: retryable, never a rejection ---
+
+    @Test
+    fun tcpConnectRefusedSurfacesAsConnectionFailed() =
+        runTest {
+            val transport = FakeTransport()
+            val refused = RuntimeException("Connection refused")
+            transport.connectError = refused
+            val client = MqttClient(config(), transport, this)
+
+            val error =
+                assertFailsWith<MqttException.ConnectionFailed> {
+                    client.connect(endpoint)
+                }
+            // The original platform exception must survive for diagnostics.
+            assertSame(refused, error.cause)
+
+            client.close()
+        }
+
+    @Test
+    fun tlsHandshakeFailureSurfacesAsConnectionFailed() =
+        runTest {
+            val transport = FakeTransport()
+            transport.connectError =
+                RuntimeException("Trust anchor for certification path not found")
+            val client = MqttClient(config(), transport, this)
+
+            assertFailsWith<MqttException.ConnectionFailed> {
+                client.connect(endpoint)
+            }
+
+            client.close()
+        }
+
+    @Test
+    fun socketClosedWhileAwaitingConnAckSurfacesAsConnectionFailed() =
+        runTest {
+            // CONNECT was written, then the socket died before any CONNACK arrived.
+            val transport = FakeTransport()
+            transport.receiveError = RuntimeException("Not enough data available")
+            val client = MqttClient(config(), transport, this)
+
+            assertFailsWith<MqttException.ConnectionFailed> {
+                client.connect(endpoint)
+            }
+
+            client.close()
+        }
+
+    @Test
+    fun connAckTimeoutSurfacesAsConnectionFailed() =
+        runTest {
+            // Broker accepts the socket and then says nothing at all.
+            val transport = FakeTransport()
+            val client = MqttClient(config(), transport, this)
+
+            val error =
+                assertFailsWith<MqttException.ConnectionFailed> {
+                    client.connect(endpoint)
+                }
+            assertEquals(ReasonCode.UNSPECIFIED_ERROR, error.reasonCode)
+
+            client.close()
+        }
+
+    @Test
+    fun failedTransportIsClassifiedByOriginNotReasonCode() =
+        runTest {
+            // A transport failure has no broker reason code, so it synthesises UNSPECIFIED_ERROR.
+            // That code must not be what decides the exception type.
+            val transport = FakeTransport()
+            transport.connectError = RuntimeException("Network is unreachable")
+            val client = MqttClient(config(), transport, this)
+
+            val error =
+                assertFailsWith<MqttException.ConnectionFailed> {
+                    client.connect(endpoint)
+                }
+            assertEquals(ReasonCode.UNSPECIFIED_ERROR, error.reasonCode)
+
+            client.close()
+        }
+
+    // --- Broker refusals: still rejections ---
+
+    @Test
+    fun connAckErrorReasonCodeSurfacesAsConnectionRejected() =
+        runTest {
+            val transport = FakeTransport()
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.BAD_USER_NAME_OR_PASSWORD))
+            val client = MqttClient(config(), transport, this)
+
+            val error =
+                assertFailsWith<MqttException.ConnectionRejected> {
+                    client.connect(endpoint)
+                }
+            assertEquals(ReasonCode.BAD_USER_NAME_OR_PASSWORD, error.reasonCode)
+
+            client.close()
+        }
+
+    @Test
+    fun brokerRefusalWithProtocolErrorReasonCodeIsStillARejection() =
+        runTest {
+            // PROTOCOL_ERROR is a legitimate CONNACK reason code. Because the broker answered,
+            // this is a refusal — not the library detecting a spec violation.
+            val transport = FakeTransport()
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.PROTOCOL_ERROR))
+            val client = MqttClient(config(), transport, this)
+
+            val error =
+                assertFailsWith<MqttException.ConnectionRejected> {
+                    client.connect(endpoint)
+                }
+            assertEquals(ReasonCode.PROTOCOL_ERROR, error.reasonCode)
+
+            client.close()
+        }
+
+    @Test
+    fun rejectionPreservesServerReference() =
+        runTest {
+            // A non-redirect reason code, so the client reports the refusal instead of chasing
+            // the reference — the point here is that the mapping carries the field through.
+            val transport = FakeTransport()
+            transport.enqueuePacket(
+                ConnAck(
+                    reasonCode = ReasonCode.NOT_AUTHORIZED,
+                    properties = MqttProperties(serverReference = "other.example.com:1883"),
+                ),
+            )
+            val client = MqttClient(config(), transport, this)
+
+            val error =
+                assertFailsWith<MqttException.ConnectionRejected> {
+                    client.connect(endpoint)
+                }
+            assertEquals("other.example.com:1883", error.serverReference)
+
+            client.close()
+        }
+
+    @Test
+    fun unsupportedProtocolVersionRemainsARejectionWhenNegotiationIsOff() =
+        runTest {
+            // Version negotiation failure is a broker verdict, so it stays a rejection.
+            val transport = FakeTransport()
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+            val client = MqttClient(config(negotiateVersion = false), transport, this)
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+
+            client.close()
+        }
+
+    // --- Library-detected spec violations ---
+
+    @Test
+    fun sessionPresentWithCleanStartSurfacesAsProtocolError() =
+        runTest {
+            // §3.2.2.1.1 — the broker answered, but illegally. Not the broker refusing us.
+            val transport = FakeTransport()
+            transport.enqueuePacket(
+                ConnAck(reasonCode = ReasonCode.SUCCESS, sessionPresent = true),
+            )
+            val client = MqttClient(config(cleanStart = true), transport, this)
+
+            assertFailsWith<MqttException.ProtocolError> {
+                client.connect(endpoint)
+            }
+
+            client.close()
+        }
+
+    @Test
+    fun unexpectedPacketDuringHandshakeSurfacesAsProtocolError() =
+        runTest {
+            val transport = FakeTransport()
+            transport.enqueuePacket(PingResp)
+            val client = MqttClient(config(), transport, this)
+
+            assertFailsWith<MqttException.ProtocolError> {
+                client.connect(endpoint)
+            }
+
+            client.close()
+        }
+
+    @Test
+    fun handshakeProtocolViolationReleasesTheSocket() =
+        runTest {
+            // The throw for an unexpected handshake packet originates inside awaitConnAck, whose
+            // rethrow path used to skip transport cleanup and leak the connection.
+            val transport = FakeTransport()
+            transport.enqueuePacket(PingResp)
+            val client = MqttClient(config(), transport, this)
+
+            assertFailsWith<MqttException.ProtocolError> {
+                client.connect(endpoint)
+            }
+            assertFalse(transport.isConnected, "transport must be closed after a failed handshake")
+
+            client.close()
+        }
+
+    // --- Reported connection state matches the thrown exception ---
+
+    @Test
+    fun disconnectedStateCarriesConnectionFailedForTransportFailures() =
+        runTest {
+            val transport = FakeTransport()
+            transport.connectError = RuntimeException("Connection refused")
+            val client = MqttClient(config(), transport, this)
+
+            assertFailsWith<MqttException.ConnectionFailed> {
+                client.connect(endpoint)
+            }
+            val state = client.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            assertIs<MqttException.ConnectionFailed>(state.reason)
+
+            client.close()
+        }
+
+    @Test
+    fun disconnectedStateCarriesConnectionRejectedForBrokerRefusals() =
+        runTest {
+            val transport = FakeTransport()
+            transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.NOT_AUTHORIZED))
+            val client = MqttClient(config(), transport, this)
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+            val state = client.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            assertIs<MqttException.ConnectionRejected>(state.reason)
+
+            client.close()
+        }
+
+    // --- Retry policy: the reason the distinction exists ---
+
+    @Test
+    fun autoReconnectRetriesTransportFailuresInsteadOfGivingUp() =
+        runTest {
+            // A ConnectionRejected ends the reconnect loop after a single attempt. A transport
+            // failure must not: it has to burn through the whole attempt budget and then report
+            // ConnectionFailed as the final reason.
+            val live = FakeTransport()
+            live.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            var transportsCreated = 0
+            val client =
+                MqttClient(config(autoReconnect = true, maxReconnectAttempts = 3), this) {
+                    transportsCreated++
+                    if (transportsCreated == 1) {
+                        live
+                    } else {
+                        FakeTransport().apply { connectError = RuntimeException("Connection refused") }
+                    }
+                }
+
+            client.connect(endpoint)
+            advanceUntilIdle()
+            assertEquals(1, transportsCreated)
+
+            // Drop the established connection to start the reconnect loop.
+            live.receiveError = RuntimeException("Connection reset")
+            live.enqueuePacket(PingResp)
+            advanceUntilIdle()
+            advanceTimeBy(10_000)
+            advanceUntilIdle()
+
+            // 1 initial + 3 reconnect attempts — the loop did not stop at the first failure.
+            assertEquals(4, transportsCreated)
+            val state = client.connectionState.value
+            assertIs<ConnectionState.Disconnected>(state)
+            assertIs<MqttException.ConnectionFailed>(state.reason)
+
+            client.close()
+            advanceUntilIdle()
+        }
+}

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/ConnectFailureClassificationTest.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/ConnectFailureClassificationTest.kt
@@ -17,8 +17,11 @@
 package org.meshtastic.mqtt
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.mqtt.packet.ConnAck
 import org.meshtastic.mqtt.packet.MqttProperties
@@ -29,6 +32,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 /**
  * `connect()` must distinguish a broker that refused the CONNECT from a network that failed
@@ -247,6 +251,27 @@ class ConnectFailureClassificationTest {
             assertFailsWith<MqttException.ProtocolError> {
                 client.connect(endpoint)
             }
+
+            client.close()
+        }
+
+    @Test
+    fun cancellingConnectMidHandshakeReleasesTheSocket() =
+        runTest {
+            // The socket is already open by the time the caller gives up, and the cancellation
+            // branch rethrows without going through the failure paths — so it needs its own
+            // cleanup, on a non-cancellable context.
+            val transport = FakeTransport()
+            val client = MqttClient(config(), transport, this)
+
+            // No CONNACK is ever enqueued, so the handshake parks in awaitConnAck.
+            val job = launch { client.connect(endpoint) }
+            runCurrent()
+            assertTrue(transport.isConnected, "precondition: the transport should be open")
+
+            job.cancelAndJoin()
+
+            assertFalse(transport.isConnected, "transport must be closed when connect() is cancelled")
 
             client.close()
         }

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
@@ -940,7 +940,8 @@ class Mqtt311Test {
                     transport
                 }
 
-            assertFailsWith<MqttException.ConnectionRejected> {
+            // The broker closed without answering, so this is a transport failure — not a refusal.
+            assertFailsWith<MqttException.ConnectionFailed> {
                 client.connect(endpoint)
             }
             assertEquals(1, transportsCreated)
@@ -971,7 +972,7 @@ class Mqtt311Test {
                     transport
                 }
 
-            assertFailsWith<MqttException.ConnectionRejected> {
+            assertFailsWith<MqttException.ConnectionFailed> {
                 client.connect(endpoint)
             }
             assertEquals(1, transportsCreated)
@@ -984,7 +985,7 @@ class Mqtt311Test {
     fun noFallbackWhenConnectWriteItselfFails() =
         runTest {
             // A failure while WRITING the CONNECT packet (broken pipe) is not a
-            // silent close while awaiting CONNACK — no fallback.
+            // silent close while awaiting CONNACK — no fallback, and still a transport failure.
             var transportsCreated = 0
             val transport = FakeTransport(MqttProtocolVersion.V5_0)
             transport.sendError = RuntimeException("Broken pipe")
@@ -1001,7 +1002,7 @@ class Mqtt311Test {
                     transport
                 }
 
-            assertFailsWith<MqttException.ConnectionRejected> {
+            assertFailsWith<MqttException.ConnectionFailed> {
                 client.connect(endpoint)
             }
             assertEquals(1, transportsCreated)

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/Mqtt311Test.kt
@@ -882,4 +882,131 @@ class Mqtt311Test {
 
             client.close()
         }
+
+    @Test
+    fun versionFallbackOnSilentCloseBeforeConnack() =
+        runTest {
+            // Some brokers (e.g. older brokers/gateways behind TLS terminators) close the
+            // connection on an MQTT 5.0 CONNECT without ever answering — no
+            // UNSUPPORTED_PROTOCOL_VERSION CONNACK. The client must still fall back to 3.1.1.
+            val v5Transport = FakeTransport(MqttProtocolVersion.V5_0)
+            val v311Transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            val transports = mutableListOf(v5Transport, v311Transport)
+
+            // V5 attempt: connect succeeds, CONNECT is written, then the broker closes.
+            v5Transport.receiveError = RuntimeException("Not enough data available")
+            // 3.1.1 retry: broker answers a normal CONNACK.
+            v311Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = true,
+                )
+            val client = MqttClient(config, this) { transports.removeAt(0) }
+
+            client.connect(endpoint)
+            advanceUntilIdle()
+
+            assertEquals(ConnectionState.Connected, client.connectionState.value)
+            assertEquals(MqttProtocolVersion.V3_1_1, client.negotiatedProtocolVersion)
+
+            // The V5 CONNECT really was written before the silent close…
+            assertIs<Connect>(v5Transport.decodeSentPackets().first())
+            // …and the retry used protocolLevel 4 (MQTT 3.1.1).
+            val sentConnect = v311Transport.decodeSentPackets().first() as Connect
+            assertEquals(4, sentConnect.protocolLevel)
+
+            client.close()
+        }
+
+    @Test
+    fun noFallbackOnSilentCloseWhenNegotiateVersionDisabled() =
+        runTest {
+            var transportsCreated = 0
+            val transport = FakeTransport(MqttProtocolVersion.V5_0)
+            transport.receiveError = RuntimeException("Not enough data available")
+
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = false,
+                )
+            val client =
+                MqttClient(config, this) {
+                    transportsCreated++
+                    transport
+                }
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+            assertEquals(1, transportsCreated)
+            assertEquals(MqttProtocolVersion.V5_0, client.negotiatedProtocolVersion)
+
+            client.close()
+        }
+
+    @Test
+    fun noFallbackWhenTransportFailsBeforeConnectWritten() =
+        runTest {
+            // A TCP/TLS/DNS failure happens before the CONNECT packet is ever written.
+            // Falling back would mask the real network error and double connect latency
+            // on dead hosts, so exactly one transport must be created.
+            var transportsCreated = 0
+            val transport = FakeTransport(MqttProtocolVersion.V5_0)
+            transport.connectError = RuntimeException("Connection refused")
+
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = true,
+                )
+            val client =
+                MqttClient(config, this) {
+                    transportsCreated++
+                    transport
+                }
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+            assertEquals(1, transportsCreated)
+            assertEquals(MqttProtocolVersion.V5_0, client.negotiatedProtocolVersion)
+
+            client.close()
+        }
+
+    @Test
+    fun noFallbackWhenConnectWriteItselfFails() =
+        runTest {
+            // A failure while WRITING the CONNECT packet (broken pipe) is not a
+            // silent close while awaiting CONNACK — no fallback.
+            var transportsCreated = 0
+            val transport = FakeTransport(MqttProtocolVersion.V5_0)
+            transport.sendError = RuntimeException("Broken pipe")
+
+            val config =
+                MqttConfig(
+                    clientId = "test-client",
+                    keepAliveSeconds = 0,
+                    negotiateVersion = true,
+                )
+            val client =
+                MqttClient(config, this) {
+                    transportsCreated++
+                    transport
+                }
+
+            assertFailsWith<MqttException.ConnectionRejected> {
+                client.connect(endpoint)
+            }
+            assertEquals(1, transportsCreated)
+            assertEquals(MqttProtocolVersion.V5_0, client.negotiatedProtocolVersion)
+
+            client.close()
+        }
 }

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/ProbeApiTest.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/ProbeApiTest.kt
@@ -200,6 +200,85 @@ class ProbeApiTest {
             }
         }
 
+    // --- Version negotiation (5.0 → 3.1.1 fallback) ---
+
+    @Test
+    fun probe_silentCloseAfterV5Connect_fallsBackTo311AndSucceeds() =
+        runTest {
+            // Broker accepts the socket, consumes the MQTT 5.0 CONNECT, then closes
+            // without a CONNACK — the probe must retry with 3.1.1 and succeed.
+            val v5Transport = FakeTransport()
+            v5Transport.receiveError = RuntimeException("Not enough data available")
+            val v311Transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            v311Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            val transports = mutableListOf<MqttTransport>(v5Transport, v311Transport)
+
+            val result =
+                runProbeNegotiating(probeConfig(), { transports.removeAt(0) }, endpoint, timeoutMs = 5_000)
+
+            assertIs<ProbeResult.Success>(result)
+        }
+
+    @Test
+    fun probe_unsupportedProtocolVersionConnack_fallsBackTo311AndSucceeds() =
+        runTest {
+            val v5Transport = FakeTransport()
+            v5Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.UNSUPPORTED_PROTOCOL_VERSION))
+            val v311Transport = FakeTransport(MqttProtocolVersion.V3_1_1)
+            v311Transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+            val transports = mutableListOf<MqttTransport>(v5Transport, v311Transport)
+
+            val result =
+                runProbeNegotiating(probeConfig(), { transports.removeAt(0) }, endpoint, timeoutMs = 5_000)
+
+            assertIs<ProbeResult.Success>(result)
+        }
+
+    @Test
+    fun probe_transportFailureBeforeConnectWritten_doesNotFallBack() =
+        runTest {
+            // TCP-level failure before the CONNECT packet exists: no retry, one transport.
+            var transportsCreated = 0
+            val transport = FakeTransport()
+            transport.connectError = RuntimeException("Connection refused")
+
+            val result =
+                runProbeNegotiating(
+                    probeConfig(),
+                    {
+                        transportsCreated++
+                        transport
+                    },
+                    endpoint,
+                    timeoutMs = 5_000,
+                )
+
+            assertIs<ProbeResult.TcpFailure>(result)
+            assertEquals(1, transportsCreated)
+        }
+
+    @Test
+    fun probe_silentClose_negotiateVersionDisabled_doesNotFallBack() =
+        runTest {
+            var transportsCreated = 0
+            val transport = FakeTransport()
+            transport.receiveError = RuntimeException("Not enough data available")
+
+            val result =
+                runProbeNegotiating(
+                    probeConfig().copy(negotiateVersion = false),
+                    {
+                        transportsCreated++
+                        transport
+                    },
+                    endpoint,
+                    timeoutMs = 5_000,
+                )
+
+            assertIs<ProbeResult.Other>(result)
+            assertEquals(1, transportsCreated)
+        }
+
     // --- Validation ---
 
     @Test

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/ProbeApiTest.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/ProbeApiTest.kt
@@ -279,6 +279,24 @@ class ProbeApiTest {
             assertEquals(1, transportsCreated)
         }
 
+    // --- Transport-factory failures ---
+
+    @Test
+    fun probe_transportFactoryThrows_isReportedAsAProbeResult() =
+        runTest {
+            // A composite factory with no delegate for the endpoint throws synchronously from
+            // create(). probe() promises a ProbeResult for failures, so this must not escape.
+            val result =
+                runProbeNegotiating(
+                    probeConfig(),
+                    { throw IllegalArgumentException("No registered MqttTransportFactory supports endpoint") },
+                    endpoint,
+                    timeoutMs = 5_000,
+                )
+
+            assertIs<ProbeResult.Other>(result)
+        }
+
     // --- Validation ---
 
     @Test


### PR DESCRIPTION
## Description

Two related fixes to the CONNECT/CONNACK path, consolidated because they touch the same code and the second changes what the first reports.

Both address the same downstream symptom: Meshtastic Android users seeing **"MQTT: connection rejected (check credentials)"** — and MQTT permanently stopping — for failures that were nothing to do with credentials. Roughly 26k RUM events across ~2.4k users on the 2.7.14 build, with raw stacks like `ConnectionRejected: Connection failed: Connection timed out / Not enough data available / Chain validation failed`.

**1. Some brokers silently close an MQTT 5.0 CONNECT** instead of answering `UNSUPPORTED_PROTOCOL_VERSION`. The 3.1.1 fallback only fired on the explicit CONNACK, so the client died with a bare `EOFException`. Observed live on `mqtt.defcon.run:4433`; iOS was unaffected because it speaks 3.1.1 natively.

**2. `connect()` reported every failure as `ConnectionRejected`**, so a TCP timeout or a TLS chain failure was indistinguishable from a bad password. Consumers could not write a correct retry policy from the exception type — stopping on `ConnectionRejected` gave up permanently on a transient network blip, and retrying hammered a broker that would never accept the connection. Meshtastic Android had to reach past the type and re-derive the answer from reason codes.

Reason codes cannot carry that distinction on their own: a broker may legitimately refuse a CONNECT with `PROTOCOL_ERROR`, and a transport failure has no broker reason code at all and synthesises `UNSPECIFIED_ERROR`. So the connection layer now records **which side of the handshake failed** and classifies on that.

## Changes

**Silent-close fallback (`aa26c6d`)**

- 5.0 → 3.1.1 negotiation now also triggers when the broker closes the connection without answering, in `connect()` and in `MqttClient.probe`.
- Phase-gated via a new internal `ConnectionClosedBeforeConnAckException`: it fires only *after* CONNECT was written and *before* a CONNACK arrived. DNS, TCP and TLS failures — and CONNACK timeouts, where the broker kept the connection open — do not trigger it, so real network errors aren't masked and dead hosts don't pay doubled connect latency.
- The probe's retry runs inside the remaining `timeoutMs`, preserving its total wall-clock contract. `probe` also gains the explicit `UNSUPPORTED_PROTOCOL_VERSION` fallback the client already had.

**Failure classification (`5b06418`)**

- `MqttConnectionException` carries an internal `ConnectFailure` origin: `BROKER_REFUSAL`, `PROTOCOL_VIOLATION`, `TRANSPORT`. `connect()` maps on it:

  | Origin | Throws |
  |---|---|
  | CONNACK with an error reason code | `ConnectionRejected` (keeps `serverReference`) |
  | Broker answered but violated the spec | `ProtocolError` |
  | DNS / TCP / TLS / EOF / CONNACK timeout | `ConnectionFailed` — **new**, keeps the platform exception as `cause` |

- Version-negotiation failure arrives as a CONNACK, so it stays a rejection.
- `ConnectionClosedBeforeConnAckException` is a `TRANSPORT` failure — the broker never answered — so once the 3.1.1 retry is exhausted it surfaces as `ConnectionFailed`. Its three no-fallback tests previously asserted `ConnectionRejected` for a refused TCP connect, a broken pipe and a silent close; all three now expect `ConnectionFailed`.
- `Probe.classifyProbeFailure` reads the explicit origin instead of inferring "broker refused" from `cause == null`.
- **Fixes a socket leak:** rejections raised while awaiting CONNACK (unexpected packet type, AUTH during a 3.1.1 handshake, invalid Maximum QoS) took a rethrow path that skipped `transport.close()`. Handshake cleanup is centralised in `abandonHandshake()` and now covers every rejection path.

## Migration

Adds one public type, so this is a **minor bump (0.8.0)**; `apiDump` is regenerated and the delta is purely additive.

Callers matching `ConnectionRejected` to stop retrying keep working and get more accurate — only real refusals land there now. Code that relied on `ConnectionRejected` as the catch-all for *any* connect failure should add a `ConnectionFailed` branch, or catch `MqttException`. Auto-reconnect is unchanged: it already classified by reason code and never stopped on a transport failure.

## Testing

- [x] `./gradlew spotlessApply spotlessCheck detektAll allTests apiCheck koverVerify` passes
- [x] New/updated tests cover the changes

New `ConnectFailureClassificationTest` (15 tests) covers both directions: TCP refused, TLS chain failure, socket closed mid-handshake and CONNACK timeout all produce `ConnectionFailed` with the cause preserved; a CONNACK error reason code, a `PROTOCOL_ERROR` CONNACK and an unrenegotiable version all stay `ConnectionRejected` with `serverReference` intact; spec violations produce `ProtocolError`; `connectionState`'s `Disconnected.reason` matches the thrown type; a handshake violation releases the socket; and auto-reconnect burns its whole attempt budget on transport failures instead of stopping at the first one.

Plus the silent-close suite in `Mqtt311Test` and `ProbeApiTest` (fallback on silent close, no fallback when negotiation is off, none before CONNECT is written, none when the write itself fails).

Test execution verified against the JUnit XML rather than the task outcome, to rule out a cached replay: `ConnectFailureClassificationTest` 15, `Mqtt311Test` 52, `ProbeApiTest` 14 — all fresh, 0 failures.

## Related Issues

Relates to the Meshtastic Android "check credentials" reports; the app-side reason-code gate in `MQTTRepositoryImpl` becomes redundant once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer connection error reporting with a dedicated `ConnectionFailed` error for network, TLS, handshake, and timeout failures.
  * Broker refusals and protocol violations are now reported separately.
  * MQTT 5.0 connections can automatically fall back to MQTT 3.1.1 when supported.

* **Bug Fixes**
  * Improved retry behavior for transport failures.
  * Ensured failed connection handshakes consistently release resources.
  * Preserved underlying transport errors to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->