### PR TITLE
docs: changelog for 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-29
+
 ### Added
 
 - `MqttException.ConnectionFailed` — a new subtype for a connect attempt that failed before the


### PR DESCRIPTION
## Description

Cuts the `[Unreleased]` section as `0.8.0` ahead of tagging `v0.8.0`, following the same pattern as #111 for 0.7.0.

Minor rather than patch because #113 added one public type, `MqttException.ConnectionFailed`. The `apiDump` delta on that PR was purely additive.

## Changes

- Insert `## [0.8.0] - 2026-07-29` above the existing entries, leaving `[Unreleased]` empty.

No source, build, or API changes — the release notes on the GitHub release itself are auto-generated, so this file is for readers of the repo rather than an input to the release workflow.

## Testing

- [x] `./gradlew spotlessCheck detektAll allTests apiCheck koverVerify` passed on the same tree via #113
- [x] New/updated tests cover the changes — n/a, documentation only

## Related Issues

Follows #113. Precedes the `v0.8.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 0.8.0, dated July 29, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->