### PR TITLE
fix(transport): close transport under the send lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,23 @@ Build system: Kotlin DSL (`build.gradle.kts`) with version catalog (`gradle/libs
 
 Send PINGREQ every `keepAliveSeconds * 0.75` if no other packet was sent. If no PINGRESP within `keepAliveSeconds`, treat connection as dead and trigger reconnect (if enabled) or disconnect.
 
+### Single-writer discipline
+
+Ktor's byte channels are single-writer: two coroutines touching one channel corrupt its kotlinx.io
+segment list (`Segment.compact` "Check failed.", or an NPE in the TLS `writeRecord` path — see
+[KTOR-7729](https://youtrack.jetbrains.com/issue/KTOR-7729), open upstream). **Closing counts as
+writing** — `socket.close()` cancels that same channel and, under TLS, hands it to ktor's
+`cio-tls-closer` coroutine to flush close_notify.
+
+So `sendMutex` guards teardown as well as sends. `MqttConnection.shutdownTransport` is the only
+path that closes the transport: it takes `sendMutex`, cancels and joins the read loop and keepalive
+while holding it, then writes any DISCONNECT and closes — all under one lock acquisition, in a
+`NonCancellable` block because the loops it cancels are usually its own caller. Both transports
+guard `close()` the same way for direct SPI users. Every wait is bounded (2s) so a writer wedged on
+a dead peer cannot stall a reconnect.
+
+Anything new that writes to the transport, or closes it, has to join this discipline.
+
 ### TCP vs WebSocket framing
 
 - **TCP** (`TcpTransport.receive()`): Parse fixed header byte → decode variable-length remaining length → read exactly that many bytes. Handle partial reads correctly — this is the trickiest part.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Teardown no longer races an in-flight write on the transport's byte channel.** Closing the
+  socket while another coroutine sat inside `writeFully`/`flush` mutated one kotlinx.io segment
+  list from two coroutines and corrupted it — surfacing as `Segment.compact` "Check failed.", or a
+  `NullPointerException` inside ktor's TLS `writeRecord` as the `cio-tls-closer` coroutine flushed
+  close_notify through the same channel. Ktor's byte channels are single-writer and callers must
+  serialize (YouTrack [KTOR-7729](https://youtrack.jetbrains.com/issue/KTOR-7729), open upstream).
+  Frame writes were already serialized, but every teardown path — `disconnect()`, `abort()`, the
+  fatal-error handler, and a broker-initiated DISCONNECT — closed the transport outside that lock,
+  and the keepalive was a second writer racing the close. Teardown now takes the send lock first,
+  cancels and joins the read loop and keepalive while holding it (so the keepalive can only be
+  cancelled parked in `delay`, never mid-write), then writes any DISCONNECT and closes, all under
+  the one lock. `TcpTransport.close()` and `WebSocketTransport.close()` do the same for direct SPI
+  users. The wait is bounded at 2 seconds so a writer wedged on a dead peer cannot stall a
+  reconnect; past that the close proceeds regardless and the DISCONNECT is skipped.
+
+  Most visible under reconnect churn on flaky mobile networks with many concurrent publishers.
+  Fixes [#123](https://github.com/meshtastic/MQTTastic-Client-KMP/issues/123).
+
+- Fatal-error teardown could skip closing the transport. `handleFatalError` cancelled the read loop
+  before sending its DISCONNECT and closing, so when it was invoked *from* that read loop the very
+  cancellation it had just requested aborted the rest of the teardown at the next suspension point
+  and the exception was swallowed as best-effort. Teardown now runs non-cancellably.
+
 ## [0.8.0] - 2026-07-29
 
 ### Added

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,6 +37,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.bytestring.ByteString
 import org.meshtastic.mqtt.packet.Auth
 import org.meshtastic.mqtt.packet.ConnAck
@@ -357,7 +359,7 @@ internal class MqttConnection(
     /** Release the socket and reset state after a failed CONNECT/CONNACK handshake. */
     private suspend fun abandonHandshake() {
         try {
-            transport.close()
+            shutdownTransport()
         } catch (
             @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
         ) {
@@ -421,14 +423,14 @@ internal class MqttConnection(
     suspend fun disconnect(reasonCode: ReasonCode = ReasonCode.SUCCESS) {
         log.debug(TAG) { "Disconnecting with reasonCode=$reasonCode" }
         failAllPendingAcks()
-        stopBackgroundJobs()
 
         try {
             if (transport.isConnected) {
                 // MQTT 3.1.1: DISCONNECT has no variable header/payload — always send empty
                 // MQTT 5.0: send with reason code and optional properties
-                sendPacket(Disconnect(reasonCode = reasonCode))
-                transport.close()
+                shutdownTransport(Disconnect(reasonCode = reasonCode))
+            } else {
+                shutdownTransport()
             }
         } finally {
             resetConnectionState()
@@ -445,12 +447,9 @@ internal class MqttConnection(
     suspend fun abort() {
         log.debug(TAG) { "Aborting connection (no DISCONNECT)" }
         failAllPendingAcks()
-        stopBackgroundJobs()
 
         try {
-            if (transport.isConnected) {
-                transport.close()
-            }
+            shutdownTransport()
         } finally {
             resetConnectionState()
         }
@@ -700,21 +699,30 @@ internal class MqttConnection(
 
     /** Send a packet over the transport, guarded by [sendMutex] for wire-level serialization. */
     private suspend fun sendPacket(packet: MqttPacket) {
-        sendMutex.withLock {
-            val bytes = packet.encode(version)
+        sendMutex.withLock { sendPacketLocked(packet) }
+    }
 
-            // Enforce broker's Maximum Packet Size on outbound packets (§3.2.2.3.6)
-            serverMaximumPacketSize?.let { maxSize ->
-                require(bytes.size <= maxSize) {
-                    "Outbound ${packet.packetType} (${bytes.size} bytes) exceeds server " +
-                        "Maximum Packet Size ($maxSize) (§3.2.2.3.6)"
-                }
+    /**
+     * Write a packet to the transport. The caller must already hold [sendMutex].
+     *
+     * Only [sendPacket] and [shutdownTransport] call this: teardown sends its DISCONNECT
+     * inside the same lock acquisition that closes the socket, so nothing can slip onto the
+     * wire — or into the underlying byte channel — between the two.
+     */
+    private suspend fun sendPacketLocked(packet: MqttPacket) {
+        val bytes = packet.encode(version)
+
+        // Enforce broker's Maximum Packet Size on outbound packets (§3.2.2.3.6)
+        serverMaximumPacketSize?.let { maxSize ->
+            require(bytes.size <= maxSize) {
+                "Outbound ${packet.packetType} (${bytes.size} bytes) exceeds server " +
+                    "Maximum Packet Size ($maxSize) (§3.2.2.3.6)"
             }
-
-            log.trace(TAG) { "Sending ${packet.packetType} (${bytes.size} bytes)" }
-            transport.send(bytes)
-            lastSendMark = timeSource.markNow()
         }
+
+        log.trace(TAG) { "Sending ${packet.packetType} (${bytes.size} bytes)" }
+        transport.send(bytes)
+        lastSendMark = timeSource.markNow()
     }
 
     /** Register a pending ack deferred for the given packet ID, guarded by [acksMutex]. */
@@ -922,37 +930,19 @@ internal class MqttConnection(
             }
 
         log.error(TAG) { "Fatal error — tearing down connection" }
-        stopBackgroundJobs()
         try {
-            if (transport.isConnected) {
-                if (version.supportsProperties) {
-                    // §4.13: Send DISCONNECT with appropriate reason code before closing
-                    sendPacket(Disconnect(reasonCode = effectiveReasonCode))
-                }
-                // MQTT 3.1.1: no DISCONNECT with reason code — just close the transport
-            }
-        } catch (
-            @Suppress("SwallowedException") _: kotlin.coroutines.cancellation.CancellationException,
-        ) {
-            // Scope cancelled during best-effort DISCONNECT — continue cleanup
+            // §4.13: MQTT 5.0 announces the reason before closing; 3.1.1 has no DISCONNECT
+            // reason code, so it just closes.
+            shutdownTransport(
+                disconnect = if (version.supportsProperties) Disconnect(reasonCode = effectiveReasonCode) else null,
+            )
         } catch (
             @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
         ) {
-            // Best-effort DISCONNECT — transport may already be broken
-        }
-        try {
-            transport.close()
-        } catch (
-            @Suppress("SwallowedException") _: kotlin.coroutines.cancellation.CancellationException,
-        ) {
-            // Scope cancelled during best-effort close — continue cleanup
-        } catch (
-            @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
-        ) {
-            // Best-effort transport close
+            // Best-effort teardown — the transport may already be broken
         }
         // Use NonCancellable to ensure cleanup completes even when the calling job
-        // (read loop or keepalive) was cancelled by stopBackgroundJobs() above.
+        // (read loop or keepalive) was cancelled by shutdownTransport() above.
         withContext(NonCancellable) {
             failAllPendingAcks()
             val reason =
@@ -1071,8 +1061,7 @@ internal class MqttConnection(
                         ),
                     )
                 }
-                stopBackgroundJobs()
-                transport.close()
+                shutdownTransport()
                 failAllPendingAcks()
                 _connectionState.value =
                     ConnectionState.Disconnected(
@@ -1239,11 +1228,79 @@ internal class MqttConnection(
 
     // --- Private: Helpers ---
 
-    private fun stopBackgroundJobs() {
-        keepAliveJob?.cancel()
-        readLoopJob?.cancel()
+    /**
+     * Close the transport without ever overlapping an in-flight write.
+     *
+     * The transport's byte channel is single-writer. Ktor's is not merely undocumented on this
+     * point — closing a socket while another coroutine sits inside `writeFully`/`flush` mutates
+     * one kotlinx.io segment list from two coroutines and corrupts it, surfacing as
+     * `Segment.compact` "Check failed." or a NullPointerException deep inside the TLS record
+     * writer (YouTrack KTOR-7729, still open upstream). So teardown has to join the same
+     * single-writer discipline as [sendPacket] rather than run beside it.
+     *
+     * Order matters:
+     * 1. Take [sendMutex]. No writer is inside `transport.send` once it is held.
+     * 2. Cancel the read loop and keepalive *while holding it*, so the keepalive can only ever be
+     *    cancelled parked in `delay` — never midway through a write — and join them so a cancelled
+     *    writer cannot resume after the socket is gone.
+     * 3. Write [disconnect], if any, and close the transport, still under the lock.
+     *
+     * If a writer is wedged (a dead peer with a full socket buffer blocks `writeFully` until the
+     * TCP timeout), waiting for it forever would hang teardown and, with auto-reconnect, the
+     * client. So the wait is bounded by [WRITER_QUIESCE_TIMEOUT_MS]; past that the socket is closed
+     * regardless — which is also what unblocks the stuck writer — and the DISCONNECT is skipped,
+     * since writing it is exactly the unsafe act being avoided.
+     *
+     * The body is [NonCancellable] because the read loop and keepalive both call this and it
+     * cancels them: on a plain context every suspension point after step 2 would abort and leak
+     * the socket.
+     */
+    private suspend fun shutdownTransport(disconnect: Disconnect? = null) {
+        // Captured before entering NonCancellable — inside it, the current Job is the
+        // withContext coroutine rather than the read-loop/keepalive job we must not join.
+        val callerJob = currentCoroutineContext()[Job]
+        withContext(NonCancellable) {
+            val quiesced =
+                withTimeoutOrNull(WRITER_QUIESCE_TIMEOUT_MS) {
+                    sendMutex.lock()
+                    true
+                } != null
+            if (!quiesced) {
+                log.warn(TAG) {
+                    "Writer still in flight after ${WRITER_QUIESCE_TIMEOUT_MS}ms — closing transport anyway"
+                }
+            }
+            try {
+                stopBackgroundJobs(callerJob)
+                if (disconnect != null && quiesced && transport.isConnected) {
+                    try {
+                        sendPacketLocked(disconnect)
+                    } catch (
+                        @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
+                    ) {
+                        // Best-effort DISCONNECT — the transport may already be broken
+                    }
+                }
+                transport.close()
+            } finally {
+                if (quiesced) sendMutex.unlock()
+            }
+        }
+    }
+
+    /**
+     * Cancel and join the read loop and keepalive jobs.
+     *
+     * [callerJob] is the job this teardown is running on, if any; it is cancelled but not joined,
+     * because the read loop and the keepalive both reach here through [handleFatalError] and a job
+     * cannot join itself.
+     */
+    private suspend fun stopBackgroundJobs(callerJob: Job?) {
+        val jobs = listOfNotNull(keepAliveJob, readLoopJob)
         keepAliveJob = null
         readLoopJob = null
+        jobs.forEach { it.cancel() }
+        jobs.filter { it !== callerJob }.forEach { it.join() }
     }
 
     /** Build a CONNECT packet from [config] per §3.1. */
@@ -1424,6 +1481,15 @@ internal class MqttConnection(
 
         /** Timeout for waiting on acknowledgement packets (30 seconds). */
         const val ACK_TIMEOUT_MS = 30_000L
+
+        /**
+         * How long teardown waits for an in-flight write to finish before closing anyway.
+         *
+         * Long enough that a normal write completes first — that is what keeps the socket close
+         * off the byte channel's writer — and short enough that a writer wedged on a dead peer
+         * cannot stall a reconnect. See [shutdownTransport].
+         */
+        const val WRITER_QUIESCE_TIMEOUT_MS = 2_000L
 
         /** Keepalive factor: send PINGREQ at 75% of keep alive interval. */
         const val KEEPALIVE_FACTOR = 750 // keepAliveSeconds * 750 = milliseconds at 75%

--- a/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
+++ b/core/src/commonMain/kotlin/org/meshtastic/mqtt/MqttConnection.kt
@@ -1251,6 +1251,10 @@ internal class MqttConnection(
      * regardless — which is also what unblocks the stuck writer — and the DISCONNECT is skipped,
      * since writing it is exactly the unsafe act being avoided.
      *
+     * Every other wait here is bounded for the same reason: the job joins by
+     * [JOB_JOIN_TIMEOUT_MS], and the DISCONNECT write itself, which the same dead peer would
+     * otherwise block indefinitely while holding teardown open.
+     *
      * The body is [NonCancellable] because the read loop and keepalive both call this and it
      * cancels them: on a plain context every suspension point after step 2 would abort and leak
      * the socket.
@@ -1274,7 +1278,11 @@ internal class MqttConnection(
                 stopBackgroundJobs(callerJob)
                 if (disconnect != null && quiesced && transport.isConnected) {
                     try {
-                        sendPacketLocked(disconnect)
+                        // Bounded: the same dead peer that blocks a publish blocks this write, and
+                        // the close that follows is what frees the socket. Abandoning the write
+                        // does not reopen the race — this coroutine holds the lock, so the
+                        // abandoned write and the close are sequential on one writer.
+                        withTimeoutOrNull(WRITER_QUIESCE_TIMEOUT_MS) { sendPacketLocked(disconnect) }
                     } catch (
                         @Suppress("TooGenericExceptionCaught", "SwallowedException") _: Exception,
                     ) {
@@ -1300,7 +1308,16 @@ internal class MqttConnection(
         keepAliveJob = null
         readLoopJob = null
         jobs.forEach { it.cancel() }
-        jobs.filter { it !== callerJob }.forEach { it.join() }
+        jobs.filter { it !== callerJob }.forEach { job ->
+            // Bounded, because cancelling a job does not interrupt a NonCancellable section: a
+            // read loop already inside its own teardown runs that to completion first, and an
+            // unbounded join would stack its budget onto ours and delay a reconnect. Giving up
+            // on the join is safe — [sendMutex] is held for the rest of the teardown, so a job
+            // that outlives this wait cannot reach the transport's writer either way.
+            if (withTimeoutOrNull(JOB_JOIN_TIMEOUT_MS) { job.join() } == null) {
+                log.warn(TAG) { "Background job did not finish within ${JOB_JOIN_TIMEOUT_MS}ms — closing anyway" }
+            }
+        }
     }
 
     /** Build a CONNECT packet from [config] per §3.1. */
@@ -1490,6 +1507,14 @@ internal class MqttConnection(
          * cannot stall a reconnect. See [shutdownTransport].
          */
         const val WRITER_QUIESCE_TIMEOUT_MS = 2_000L
+
+        /**
+         * How long teardown waits for a cancelled background job to finish.
+         *
+         * Cancellation does not interrupt a `NonCancellable` section, so a job already inside its
+         * own teardown finishes that first; without a bound its budget would stack onto ours.
+         */
+        const val JOB_JOIN_TIMEOUT_MS = 2_000L
 
         /** Keepalive factor: send PINGREQ at 75% of keep alive interval. */
         const val KEEPALIVE_FACTOR = 750 // keepAliveSeconds * 750 = milliseconds at 75%

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
@@ -155,6 +155,7 @@ internal class FakeTransport(
         receiveError = null
         onConnect = null
         sendGate = null
+        sendsInFlight = 0
         closesDuringSend = 0
         closeCount = 0
         receiveChannel.close()

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/FakeTransport.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.mqtt
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import org.meshtastic.mqtt.packet.MqttPacket
@@ -58,6 +59,29 @@ internal class FakeTransport(
     /** Optional callback invoked after each successful [connect] — use to enqueue response packets. */
     var onConnect: (() -> Unit)? = null
 
+    // -- Teardown-race instrumentation --
+
+    /**
+     * When non-null, [send] suspends on this until it completes — a write held in flight.
+     *
+     * Real byte channels are single-writer: closing the socket while a write is in flight
+     * corrupts the shared segment list (KTOR-7729). Gating a send lets a test hold that window
+     * open and assert teardown waits for it.
+     */
+    var sendGate: CompletableDeferred<Unit>? = null
+
+    /** Number of [send] calls currently suspended inside the transport. */
+    var sendsInFlight = 0
+        private set
+
+    /** Times [close] was entered while a [send] was in flight. Must stay 0. */
+    var closesDuringSend = 0
+        private set
+
+    /** Times [close] was called, whether or not the transport was connected. */
+    var closeCount = 0
+        private set
+
     // -- MqttTransport implementation --
 
     override suspend fun connect(endpoint: MqttEndpoint) {
@@ -74,7 +98,13 @@ internal class FakeTransport(
     override suspend fun send(bytes: ByteArray) {
         check(_isConnected) { "Not connected" }
         sendError?.let { throw it }
-        _sentPackets.add(bytes.copyOf())
+        sendsInFlight++
+        try {
+            sendGate?.await()
+            _sentPackets.add(bytes.copyOf())
+        } finally {
+            sendsInFlight--
+        }
     }
 
     override suspend fun receive(): ByteArray {
@@ -87,6 +117,8 @@ internal class FakeTransport(
     }
 
     override suspend fun close() {
+        closeCount++
+        if (sendsInFlight > 0) closesDuringSend++
         _isConnected = false
         receiveChannel.close()
     }
@@ -122,6 +154,9 @@ internal class FakeTransport(
         sendError = null
         receiveError = null
         onConnect = null
+        sendGate = null
+        closesDuringSend = 0
+        closeCount = 0
         receiveChannel.close()
         receiveChannel = Channel(Channel.UNLIMITED)
     }

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/TeardownRaceTest.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/TeardownRaceTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.mqtt
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.mqtt.packet.ConnAck
+import org.meshtastic.mqtt.packet.Disconnect
+import org.meshtastic.mqtt.packet.PingReq
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Teardown must never touch the transport while a write is in flight.
+ *
+ * The transport's byte channel is single-writer. Closing the socket underneath a coroutine that
+ * is inside `writeFully`/`flush` mutates one kotlinx.io segment list from two coroutines and
+ * corrupts it — `Segment.compact` "Check failed." or a NullPointerException in ktor's TLS
+ * `writeRecord` (KTOR-7729). These tests hold a write open with [FakeTransport.sendGate] and
+ * assert every teardown path waits for it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TeardownRaceTest {
+    private val endpoint = MqttEndpoint.Tcp("localhost", 1883)
+
+    private fun config(keepAliveSeconds: Int = 0) = MqttConfig(clientId = "teardown-test", keepAliveSeconds = keepAliveSeconds)
+
+    private suspend fun connected(
+        transport: FakeTransport,
+        connection: MqttConnection,
+    ) {
+        transport.enqueuePacket(ConnAck(reasonCode = ReasonCode.SUCCESS))
+        connection.connect(endpoint)
+    }
+
+    @Test
+    fun disconnectWaitsForInFlightPublish() =
+        runTest {
+            val transport = FakeTransport()
+            val connection = MqttConnection(transport, config(), this)
+            connected(transport, connection)
+
+            val gate = CompletableDeferred<Unit>()
+            transport.sendGate = gate
+            val publisher = launch { connection.publish(MqttMessage("a/b", byteArrayOf(1))) }
+            runCurrent()
+            assertEquals(1, transport.sendsInFlight, "publish should be parked inside send()")
+
+            // runCurrent, not advanceUntilIdle: advancing virtual time would trip the
+            // quiesce timeout, which is what the next test covers.
+            val disconnector = launch { connection.disconnect() }
+            runCurrent()
+            assertEquals(0, transport.closeCount, "teardown must not close under an in-flight write")
+
+            // Let the write finish; teardown then proceeds.
+            transport.sendGate = null
+            gate.complete(Unit)
+            advanceUntilIdle()
+            publisher.join()
+            disconnector.join()
+
+            assertEquals(0, transport.closesDuringSend)
+            assertEquals(1, transport.closeCount)
+            assertFalse(transport.isConnected)
+            assertIs<Disconnect>(transport.lastSentPacket())
+        }
+
+    @Test
+    fun fatalErrorTeardownWaitsForInFlightPublish() =
+        runTest {
+            val transport = FakeTransport()
+            val connection = MqttConnection(transport, config(), this)
+            connected(transport, connection)
+
+            val gate = CompletableDeferred<Unit>()
+            transport.sendGate = gate
+            val publisher = launch { connection.publish(MqttMessage("a/b", byteArrayOf(1))) }
+            runCurrent()
+
+            // Break the read loop — this is the reconnect-churn path that crashed in production.
+            transport.enqueueReceive(byteArrayOf(0))
+            runCurrent()
+            assertEquals(0, transport.closeCount, "fatal-error teardown must not close under a write")
+
+            transport.sendGate = null
+            gate.complete(Unit)
+            advanceUntilIdle()
+            publisher.join()
+
+            assertEquals(0, transport.closesDuringSend)
+            assertTrue(transport.closeCount >= 1, "transport must still be closed after teardown")
+            assertFalse(transport.isConnected)
+            assertIs<ConnectionState.Disconnected>(connection.connectionState.value)
+        }
+
+    @Test
+    fun teardownClosesEvenIfWriterNeverCompletes() =
+        runTest {
+            val transport = FakeTransport()
+            val connection = MqttConnection(transport, config(), this)
+            connected(transport, connection)
+
+            // A peer that stopped reading blocks writeFully until the TCP timeout. Teardown may
+            // not wait that long — closing the socket is what unblocks the writer.
+            val gate = CompletableDeferred<Unit>()
+            transport.sendGate = gate
+            val publisher = launch { connection.publish(MqttMessage("a/b", byteArrayOf(1))) }
+            runCurrent()
+
+            val disconnector = launch { connection.disconnect() }
+            advanceTimeBy(MqttConnection.WRITER_QUIESCE_TIMEOUT_MS + 1)
+            advanceUntilIdle()
+
+            assertEquals(1, transport.closeCount, "teardown must give up waiting and close")
+            assertFalse(transport.isConnected)
+            // No DISCONNECT: writing one is precisely the unsafe act being avoided.
+            assertTrue(transport.decodeSentPackets().none { it is Disconnect })
+
+            gate.complete(Unit)
+            transport.sendGate = null
+            advanceUntilIdle()
+            publisher.cancel()
+            disconnector.join()
+        }
+
+    @Test
+    fun keepAliveCannotWriteAfterTeardown() =
+        runTest {
+            val transport = FakeTransport()
+            val connection = MqttConnection(transport, config(keepAliveSeconds = 2), this)
+            connected(transport, connection)
+            // runCurrent, not advanceUntilIdle: the keepalive loop never runs dry, so advancing
+            // to idle would drive it through a PINGRESP timeout and tear the connection down
+            // before the disconnect under test.
+            runCurrent()
+
+            connection.disconnect()
+            transport.clearSent()
+
+            // The keepalive job is cancelled and joined under the send lock, so no PINGREQ can
+            // reach a transport that is already closed.
+            advanceTimeBy(10_000)
+            runCurrent()
+
+            assertTrue(transport.decodeSentPackets().none { it is PingReq })
+            assertEquals(0, transport.closesDuringSend)
+        }
+
+    @Test
+    fun brokerDisconnectTeardownWaitsForInFlightPublish() =
+        runTest {
+            val transport = FakeTransport()
+            val connection = MqttConnection(transport, config(), this)
+            connected(transport, connection)
+
+            val gate = CompletableDeferred<Unit>()
+            transport.sendGate = gate
+            val publisher = launch { connection.publish(MqttMessage("a/b", byteArrayOf(1))) }
+            runCurrent()
+
+            transport.enqueuePacket(Disconnect(reasonCode = ReasonCode.SERVER_SHUTTING_DOWN))
+            runCurrent()
+            assertEquals(0, transport.closeCount)
+
+            transport.sendGate = null
+            gate.complete(Unit)
+            advanceUntilIdle()
+            publisher.join()
+
+            assertEquals(0, transport.closesDuringSend)
+            assertFalse(transport.isConnected)
+        }
+}

--- a/core/src/commonTest/kotlin/org/meshtastic/mqtt/TeardownRaceTest.kt
+++ b/core/src/commonTest/kotlin/org/meshtastic/mqtt/TeardownRaceTest.kt
@@ -146,6 +146,26 @@ class TeardownRaceTest {
         }
 
     @Test
+    fun teardownClosesEvenIfDisconnectWriteBlocks() =
+        runTest {
+            val transport = FakeTransport()
+            val connection = MqttConnection(transport, config(), this)
+            connected(transport, connection)
+
+            // Nothing in flight, so teardown takes the lock immediately and writes its DISCONNECT
+            // — into a socket whose buffer the dead peer never drains. The close that frees it
+            // must not sit behind that write.
+            transport.sendGate = CompletableDeferred()
+            val disconnector = launch { connection.disconnect() }
+            advanceTimeBy(MqttConnection.WRITER_QUIESCE_TIMEOUT_MS + 1)
+            advanceUntilIdle()
+
+            assertEquals(1, transport.closeCount, "close must not wait on a blocked DISCONNECT")
+            assertFalse(transport.isConnected)
+            disconnector.join()
+        }
+
+    @Test
     fun keepAliveCannotWriteAfterTeardown() =
         runTest {
             val transport = FakeTransport()

--- a/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
+++ b/transport-tcp/src/commonMain/kotlin/org/meshtastic/mqtt/transport/tcp/TcpTransport.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.mqtt.MqttEndpoint
 import org.meshtastic.mqtt.MqttTransport
 import org.meshtastic.mqtt.MqttTransportFactory
@@ -155,8 +156,8 @@ public class TcpTransport(
     }
 
     override suspend fun send(bytes: ByteArray) {
-        val channel = writeChannel ?: error("Not connected")
         sendMutex.withLock {
+            val channel = writeChannel ?: error("Not connected")
             channel.writeFully(bytes)
             channel.flush()
         }
@@ -211,7 +212,39 @@ public class TcpTransport(
         return packet
     }
 
+    /**
+     * Close the socket, waiting first for any in-flight [send] to finish.
+     *
+     * `socket.close()` cancels the same [io.ktor.utils.io.ByteChannel] a concurrent
+     * `writeFully`/`flush` is writing into — and for TLS, hands it to ktor's `cio-tls-closer`
+     * coroutine, which flushes a close_notify record through it. That channel is single-writer:
+     * two coroutines mutating its kotlinx.io segment list corrupt it, surfacing as
+     * `Segment.compact` "Check failed." or a NullPointerException inside `writeRecord`
+     * (YouTrack KTOR-7729, open upstream — callers must serialize). Holding [sendMutex] across
+     * the close makes teardown part of the same single-writer discipline as [send].
+     *
+     * [MqttConnection][org.meshtastic.mqtt.MqttTransport] already quiesces its own writer before
+     * calling this, so the lock is normally uncontended; the guard matters for direct SPI users
+     * and for a `close()` racing a `send()` from another caller.
+     *
+     * The wait is bounded: a peer that has stopped reading can block `writeFully` until the TCP
+     * timeout, and closing the socket is what unblocks it, so after
+     * [CLOSE_QUIESCE_TIMEOUT_MS] the close proceeds regardless.
+     */
     override suspend fun close() {
+        val quiesced =
+            withTimeoutOrNull(CLOSE_QUIESCE_TIMEOUT_MS) {
+                sendMutex.lock()
+                true
+            } != null
+        try {
+            closeResources()
+        } finally {
+            if (quiesced) sendMutex.unlock()
+        }
+    }
+
+    private fun closeResources() {
         try {
             socket?.close()
         } finally {
@@ -241,6 +274,14 @@ public class TcpTransport(
         const val MAX_PACKET_REMAINING_LENGTH = 16 * 1024 * 1024 // 16 MB
     }
 }
+
+/**
+ * How long [TcpTransport.close] waits for an in-flight send before closing the socket anyway.
+ *
+ * File-private rather than a companion constant: a `const val` in the companion of a public class
+ * is emitted as a public static field on JVM, which would widen the published API surface.
+ */
+private const val CLOSE_QUIESCE_TIMEOUT_MS = 2_000L
 
 /**
  * Returns the TLS SNI server name to advertise for [host], or `null` for IP literals.

--- a/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
+++ b/transport-ws/src/commonMain/kotlin/org/meshtastic/mqtt/transport/ws/WebSocketTransport.kt
@@ -27,6 +27,7 @@ import io.ktor.websocket.readBytes
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.mqtt.MqttEndpoint
 import org.meshtastic.mqtt.MqttTransport
 import org.meshtastic.mqtt.MqttTransportFactory
@@ -73,8 +74,8 @@ public class WebSocketTransport(
     }
 
     override suspend fun send(bytes: ByteArray) {
-        val ws = session ?: error("Not connected")
         sendMutex.withLock {
+            val ws = session ?: error("Not connected")
             ws.send(Frame.Binary(true, bytes))
         }
     }
@@ -100,7 +101,31 @@ public class WebSocketTransport(
         }
     }
 
+    /**
+     * Close the session, waiting first for any in-flight [send] to finish.
+     *
+     * `session.close()` writes a close frame and then tears down the same outgoing channel a
+     * concurrent [send] may be writing into. Ktor's byte channels are single-writer — two
+     * coroutines mutating one channel's kotlinx.io segment list corrupt it (YouTrack KTOR-7729) —
+     * so the close runs under the same [sendMutex] that serializes frames.
+     *
+     * The wait is bounded by [CLOSE_QUIESCE_TIMEOUT_MS]: a stalled peer must not be able to hold
+     * teardown open, and closing is what unblocks a wedged writer.
+     */
     override suspend fun close() {
+        val quiesced =
+            withTimeoutOrNull(CLOSE_QUIESCE_TIMEOUT_MS) {
+                sendMutex.lock()
+                true
+            } != null
+        try {
+            closeResources()
+        } finally {
+            if (quiesced) sendMutex.unlock()
+        }
+    }
+
+    private suspend fun closeResources() {
         try {
             session?.close()
         } finally {
@@ -118,6 +143,14 @@ public class WebSocketTransport(
         const val MAX_FRAME_SIZE = 16L * 1024 * 1024 // 16 MB
     }
 }
+
+/**
+ * How long [WebSocketTransport.close] waits for an in-flight send before closing the session anyway.
+ *
+ * File-private rather than a companion constant: a `const val` in the companion of a public class
+ * is emitted as a public static field on JVM, which would widen the published API surface.
+ */
+private const val CLOSE_QUIESCE_TIMEOUT_MS = 2_000L
 
 /**
  * [MqttTransportFactory] that builds a [WebSocketTransport] for [MqttEndpoint.WebSocket] endpoints.


### PR DESCRIPTION
Closing the socket while another coroutine sits inside `writeFully`/`flush` mutates one kotlinx.io segment list from two coroutines and corrupts it — `Segment.compact` "Check failed.", or an NPE in ktor's TLS `writeRecord` as the `cio-tls-closer` coroutine flushes close_notify through the same channel. Ktor's byte channels are single-writer and callers must serialize ([KTOR-7729](https://youtrack.jetbrains.com/issue/KTOR-7729), open upstream).

Frame writes were already serialized twice, but every teardown path closed the transport **outside** that lock, and the keepalive was a second writer racing the close.

## Changes

- All four teardown paths — `disconnect()`, `abort()`, `handleFatalError`, and the broker-initiated DISCONNECT (which held no lock at all) — now route through one `MqttConnection.shutdownTransport()`. It takes `sendMutex`, cancels **and joins** the read loop and keepalive *while holding it* (so the keepalive can only be cancelled parked in `delay`, never mid-write), then writes any DISCONNECT and closes — all in one lock acquisition.
- The quiesce wait is bounded at 2s: a peer that stopped reading can block `writeFully` until the TCP timeout, and closing is what unblocks it. Past the deadline the close proceeds anyway and the DISCONNECT is skipped, since writing it is precisely the unsafe act.
- `TcpTransport.close()` and `WebSocketTransport.close()` guard the same way for direct SPI users; both also read the channel/session inside the lock rather than before it.
- Teardown now runs `NonCancellable`. This fixes a latent bug the restructure surfaced: `handleFatalError` cancelled the read loop *before* sending its DISCONNECT and closing, so when invoked from that loop the cancellation it had just requested aborted the rest of the teardown at the next suspension point — swallowed as best-effort, leaving the socket unclosed.
- `AGENTS.md` documents the single-writer discipline so new writers join it.

## Testing

New `TeardownRaceTest` holds a write open via a new `FakeTransport.sendGate` and asserts each teardown path waits for it, plus that teardown still closes when the writer never completes. Stubbing out the quiesce fails three of the five, so the tests bite.

`spotlessCheck detektAll allTests apiCheck koverVerify` green across all targets (JVM, Android host, iOS sim, macOS, wasmJs).

Note: the transports' new timeout constants are file-private rather than companion `const val`s — the latter are emitted as public static fields on JVM, which `apiCheck` flagged as a widened API surface.

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT connection shutdown reliability by preventing transport closure during active message sends.
  * Added bounded shutdown handling to ensure connections close even when a send does not complete.
  * Applied consistent cleanup behavior across TCP, WebSocket, and broker-initiated disconnect scenarios.
  * Improved fatal-error recovery so transports are reliably closed during failures.

* **Documentation**
  * Documented the required serialized shutdown behavior for transport operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->