### PR TITLE
ci(release): publish from Linux instead of a macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,13 @@ permissions:
 jobs:
   publish:
     name: Publish to Maven Central
-    runs-on: macos-26
+    # Linux publishes every target. Kotlin/Native cross-compiles the Apple klibs
+    # from any host, and this job runs no Apple tests to begin with — its gate is
+    # spotlessCheck/detektAll/jvmTest/apiCheck — so the macOS runner was only ever
+    # compiling klibs. Verified on 2.4.10: a Linux publishToMavenLocal emits the
+    # same 30 artifacts the 0.8.1 release shipped, iOS and macOS klibs included.
+    # (The sample-artifacts matrix below still uses macOS, for the Apple sample.)
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
       ref: ${{ steps.ver.outputs.ref }}
@@ -69,6 +75,14 @@ jobs:
         with:
           cache_read_only: 'false'
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+      - name: Cache Konan (Kotlin/Native toolchain)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Validate before publish
         run: ./gradlew spotlessCheck detektAll jvmTest apiCheck --stacktrace


### PR DESCRIPTION
The `publish` job runs on `macos-26`. It runs **no Apple tests** — its gate is `spotlessCheck detektAll jvmTest apiCheck` — so the macOS runner was only ever compiling klibs, and Kotlin/Native cross-compiles those from any host.

## Verified, not assumed

Linux, Kotlin 2.4.10, no opt-in flag:

| Check | Result |
|---|---|
| `publishToMavenLocal` | **30 artifacts — exactly what the 0.8.1 release shipped** |
| iOS / macOS klibs | present for `core`, `transport-tcp`, `transport-ws` |

A raw directory listing of `org/meshtastic/` first suggested 10 missing artifacts. They are the abandoned `mqtt-client` umbrella module — **last published 0.3.8**, before the split into `core`/`transport-tcp`/`transport-ws`. Comparing against the actual 0.8.1 release set instead: 30 of 30, nothing missing.

## No CI guard needed here

The sibling PRs (meshtastic/kzstd#68, meshtastic/meshtastic-sdk#114) add a step requiring a green macOS check run before publishing, because those release jobs *did* run Apple tests that Linux cannot. This one never did, so there is no coverage to replace.

## Also

- **caches `~/.konan`** — this job never did, and on a cold Linux runner the Kotlin/Native toolchain download is now on the critical path
- the `macos-26` pin was a Renovate bump (#45), not a deliberate choice
- the `sample-artifacts` matrix keeps its `macos-15` runner — it builds the Apple sample and legitimately needs it

The `SC2012` shellcheck info `actionlint` reports on this file is pre-existing on `main` (verified by stashing), untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release build environment to improve cross-platform artifact publishing.
  * Added caching for the Kotlin/Native toolchain to help streamline release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->