### PR TITLE
ci(codeql): re-enable the java-kotlin analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,15 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # java-kotlin is temporarily disabled: CodeQL <= 2.26.1 rejects
-          # Kotlin 2.4.10 ("Kotlin version 2.4.10 is too recent"), so the
-          # traced build fails and no analysis ever runs. Support (ceiling
-          # 2.4.20) is already merged upstream and ships with the next CLI
-          # release, which codeql-action@v4 picks up automatically.
-          # Once a CodeQL CLI newer than 2.26.1 is out, uncomment to
-          # re-enable and verify Analyze (java-kotlin) goes green.
-          # - language: java-kotlin
-          #   build-mode: manual
+          # Re-enabled: the pinned codeql-action v4.37.8 ships CodeQL CLI 2.26.3,
+          # past the 2.26.1 that rejected Kotlin 2.4.10 as "too recent". The
+          # upstream ceiling is 2.4.20, so this stays green until Kotlin 2.4.20+.
+          - language: java-kotlin
+            build-mode: manual
           - language: actions
             build-mode: none
 


### PR DESCRIPTION
The workflow comment said to re-enable once a CodeQL CLI newer than 2.26.1 shipped. That has happened: the already-pinned codeql-action **v4.37.8 ships CLI 2.26.3** (v4.37.2 shipped 2.26.1), and the upstream Kotlin ceiling is 2.4.20 — past our 2.4.10.

The traced build was failing outright before, so no analysis ever ran; this restores real coverage rather than tidying a comment.

The PR's job is to produce the evidence the comment asked for: **Analyze (java-kotlin) has to go green here.** If it doesn't, revert and correct the ceiling note.

Closes #81.

Same change in meshtastic/meshtastic-sdk#115, which was blocked on the identical CLI version.